### PR TITLE
#3 Add reservation-agent V1.0 keys to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,18 @@
-APP_NAME=Laravel
+APP_NAME=reservation-agent
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 
-APP_LOCALE=en
+APP_LOCALE=de
 APP_FALLBACK_LOCALE=en
-APP_FAKER_LOCALE=en_US
+APP_FAKER_LOCALE=de_DE
+
+# All datetimes are stored in UTC. APP_TIMEZONE controls the default
+# server-side conversion. Restaurant-specific zones live on the
+# `restaurants.timezone` column (PRD-001) and are applied per request
+# when computing availability slots (PRD-005).
+APP_TIMEZONE=UTC
 
 APP_MAINTENANCE_DRIVER=file
 # APP_MAINTENANCE_STORE=database
@@ -47,13 +53,18 @@ REDIS_HOST=127.0.0.1
 REDIS_PASSWORD=null
 REDIS_PORT=6379
 
-MAIL_MAILER=log
+# ──────────────────────────────────────────────────────────────────────
+# Outgoing mail (PRD-005, ReservationReplyMail)
+# Used to send approved reservation replies to guests via SMTP.
+# Secret values stay empty in version control.
+# ──────────────────────────────────────────────────────────────────────
+MAIL_MAILER=smtp
 MAIL_SCHEME=null
-MAIL_HOST=127.0.0.1
-MAIL_PORT=2525
-MAIL_USERNAME=null
-MAIL_PASSWORD=null
-MAIL_FROM_ADDRESS="hello@example.com"
+MAIL_HOST=
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_FROM_ADDRESS=
 MAIL_FROM_NAME="${APP_NAME}"
 
 AWS_ACCESS_KEY_ID=
@@ -63,3 +74,20 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# ──────────────────────────────────────────────────────────────────────
+# OpenAI – AI reply assistant (PRD-005)
+# BYOK: each operator brings their own key. Default model documented
+# in the project README. Never log this key.
+# ──────────────────────────────────────────────────────────────────────
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-4o-mini
+
+# ──────────────────────────────────────────────────────────────────────
+# IMAP inbox – email ingestion (PRD-003)
+# Global fallback credentials. Per-restaurant credentials are stored
+# encrypted on the `restaurants` row (CLAUDE.md security section).
+# ──────────────────────────────────────────────────────────────────────
+IMAP_HOST=
+IMAP_USERNAME=
+IMAP_PASSWORD=


### PR DESCRIPTION
## Summary
- Document every V1.0 environment variable in `.env.example`
- Add `OPENAI_API_KEY`, `OPENAI_MODEL`, `IMAP_HOST/USERNAME/PASSWORD`, `MAIL_MAILER/HOST/USERNAME/PASSWORD` with the owning PRD referenced in section comments
- Add `APP_TIMEZONE=UTC` with a note that all datetimes are stored in UTC and per-restaurant zones live on `restaurants.timezone`
- Switch `APP_NAME` to `reservation-agent` and locale defaults to `de` / `de_DE`
- Reset `MAIL_FROM_ADDRESS` to empty so the placeholder `hello@example.com` cannot accidentally leak into a real send
- `.env` stays gitignored (verified); only `.env.example` is committed

## Why
Issue #3 is a P0 documentation prerequisite for PRD-003 (IMAP) and PRD-005 (OpenAI/SMTP). Without a single source of truth for required environment variables, future PRs would silently introduce new config keys, and operators couldn't tell which secrets they need to provide before booting the app.

The PRD references in section comments make it obvious which feature owns which key, so a deployment checklist can be assembled directly from this file.

## Acceptance criteria
- [x] Empty entries for `OPENAI_API_KEY`, `OPENAI_MODEL`, `IMAP_HOST`, `IMAP_USERNAME`, `IMAP_PASSWORD`, `MAIL_MAILER`, `MAIL_HOST`, `MAIL_USERNAME`, `MAIL_PASSWORD`
- [x] Comments reference the owning PRD per key (PRD-003 for IMAP, PRD-005 for OpenAI + outgoing mail)
- [x] `APP_TIMEZONE` documented; DB always stores UTC
- [x] `.env` gitignored; `.env.example` committed

> Note on "empty entries": `OPENAI_MODEL` and `MAIL_MAILER` are intentionally pre-filled with the defaults the project README documents (`gpt-4o-mini`, `smtp`) — leaving them blank would force every operator to set a default that is the same for everyone. All true secrets and per-environment hosts remain empty.

## Test plan
- [x] `php artisan config:clear && php artisan about` boots cleanly with the new file as base
- [x] Each AC key present (verified via grep)
- [x] `git check-ignore .env` confirms `.env` stays gitignored
- [x] `./vendor/bin/pint --test` → pass
- [x] `npm run format:check` → all files use Prettier code style
- [x] `npm run lint` → no errors

Closes #3