### PR TITLE
Add restaurants table, model, and Tonality enum (#4)

### DIFF
--- a/app/Enums/Tonality.php
+++ b/app/Enums/Tonality.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum Tonality: string
+{
+    case Formal = 'formal';
+    case Casual = 'casual';
+    case Family = 'family';
+}

--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\Tonality;
+use Database\Factories\RestaurantFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Restaurant extends Model
+{
+    /** @use HasFactory<RestaurantFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'slug',
+        'timezone',
+        'capacity',
+        'opening_hours',
+        'tonality',
+        'imap_host',
+        'imap_username',
+        'imap_password',
+    ];
+
+    /**
+     * The attributes that should be hidden for serialization.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'imap_password',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'capacity' => 'integer',
+            'opening_hours' => 'array',
+            'tonality' => Tonality::class,
+            'imap_password' => 'encrypted',
+        ];
+    }
+}

--- a/database/factories/RestaurantFactory.php
+++ b/database/factories/RestaurantFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\Tonality;
+use App\Models\Restaurant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Restaurant>
+ */
+class RestaurantFactory extends Factory
+{
+    protected $model = Restaurant::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = fake()->unique()->company();
+
+        return [
+            'name' => $name,
+            'slug' => Str::slug($name).'-'.Str::lower(Str::random(6)),
+            'timezone' => 'Europe/Berlin',
+            'capacity' => fake()->numberBetween(20, 80),
+            'opening_hours' => [
+                'mon' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '22:30']],
+                'tue' => [],
+                'wed' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '22:30']],
+                'thu' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '22:30']],
+                'fri' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '23:00']],
+                'sat' => [['from' => '18:00', 'to' => '23:00']],
+                'sun' => [['from' => '11:30', 'to' => '15:00']],
+            ],
+            'tonality' => fake()->randomElement(Tonality::cases()),
+            'imap_host' => null,
+            'imap_username' => null,
+            'imap_password' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_04_17_120557_create_restaurants_table.php
+++ b/database/migrations/2026_04_17_120557_create_restaurants_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('restaurants', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->string('timezone')->default('Europe/Berlin');
+            $table->unsignedInteger('capacity');
+            $table->json('opening_hours');
+            $table->string('tonality');
+            $table->string('imap_host')->nullable();
+            $table->string('imap_username')->nullable();
+            $table->text('imap_password')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('restaurants');
+    }
+};

--- a/tests/Feature/Models/RestaurantTest.php
+++ b/tests/Feature/Models/RestaurantTest.php
@@ -81,4 +81,27 @@ class RestaurantTest extends TestCase
 
         $this->assertArrayNotHasKey('imap_password', $restaurant->toArray());
     }
+
+    public function test_timezone_defaults_to_europe_berlin_when_not_provided(): void
+    {
+        DB::table('restaurants')->insert([
+            'name' => 'Test Restaurant',
+            'slug' => 'test-restaurant',
+            'capacity' => 20,
+            'opening_hours' => json_encode([]),
+            'tonality' => Tonality::Casual->value,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->assertSame('Europe/Berlin', Restaurant::query()->sole()->timezone);
+    }
+
+    public function test_null_imap_password_is_handled_gracefully(): void
+    {
+        $restaurant = Restaurant::factory()->create(['imap_password' => null]);
+
+        $this->assertNull($restaurant->fresh()->imap_password);
+        $this->assertNull(DB::table('restaurants')->where('id', $restaurant->id)->value('imap_password'));
+    }
 }

--- a/tests/Feature/Models/RestaurantTest.php
+++ b/tests/Feature/Models/RestaurantTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\Tonality;
+use App\Models\Restaurant;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class RestaurantTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_creates_a_valid_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $this->assertTrue($restaurant->exists);
+        $this->assertNotEmpty($restaurant->name);
+        $this->assertNotEmpty($restaurant->slug);
+        $this->assertSame('Europe/Berlin', $restaurant->timezone);
+        $this->assertIsInt($restaurant->capacity);
+        $this->assertInstanceOf(Tonality::class, $restaurant->tonality);
+    }
+
+    public function test_opening_hours_are_cast_to_an_array(): void
+    {
+        $hours = [
+            'mon' => [['from' => '11:30', 'to' => '14:30']],
+            'tue' => [],
+            'wed' => [['from' => '18:00', 'to' => '22:00']],
+            'thu' => [],
+            'fri' => [['from' => '18:00', 'to' => '23:00']],
+            'sat' => [['from' => '11:30', 'to' => '15:00'], ['from' => '18:00', 'to' => '23:00']],
+            'sun' => [],
+        ];
+
+        $restaurant = Restaurant::factory()->create(['opening_hours' => $hours]);
+
+        $this->assertSame($hours, $restaurant->fresh()->opening_hours);
+    }
+
+    public function test_imap_password_is_encrypted_at_rest_and_decrypted_on_read(): void
+    {
+        $secret = 'super-secret-imap-password-123';
+
+        $restaurant = Restaurant::factory()->create(['imap_password' => $secret]);
+
+        $rawValue = DB::table('restaurants')
+            ->where('id', $restaurant->id)
+            ->value('imap_password');
+
+        $this->assertNotSame($secret, $rawValue, 'imap_password must not be stored in cleartext');
+        $this->assertSame($secret, Crypt::decryptString($rawValue));
+        $this->assertSame($secret, $restaurant->fresh()->imap_password);
+    }
+
+    public function test_tonality_is_cast_to_the_enum(): void
+    {
+        $restaurant = Restaurant::factory()->create(['tonality' => Tonality::Formal]);
+
+        $this->assertSame(Tonality::Formal, $restaurant->fresh()->tonality);
+        $this->assertSame('formal', DB::table('restaurants')->where('id', $restaurant->id)->value('tonality'));
+    }
+
+    public function test_slug_must_be_unique(): void
+    {
+        Restaurant::factory()->create(['slug' => 'bella-italia']);
+
+        $this->expectException(QueryException::class);
+
+        Restaurant::factory()->create(['slug' => 'bella-italia']);
+    }
+
+    public function test_imap_password_is_hidden_from_array_serialization(): void
+    {
+        $restaurant = Restaurant::factory()->create(['imap_password' => 'sensitive']);
+
+        $this->assertArrayNotHasKey('imap_password', $restaurant->toArray());
+    }
+}


### PR DESCRIPTION
## Summary
- `restaurants` migration with columns per PRD-001 (`id`, `name`, `slug` unique, `timezone` default `Europe/Berlin`, `capacity`, `opening_hours` JSON, `tonality`, `imap_host`/`imap_username` nullable, `imap_password` text nullable, timestamps) with `down()` implemented
- `Restaurant` Eloquent model with method-based `casts()` (`opening_hours => array`, `imap_password => encrypted`, `tonality => Tonality::class`, `capacity => integer`), `$fillable`, and `$hidden = ['imap_password']` to keep the secret out of array/JSON serializations
- `Tonality` PHP-backed enum (`formal | casual | family`) — first enum in the project, sets the pattern for future `ReservationStatus`, `ReservationSource`, `ReservationReplyStatus`
- `RestaurantFactory` with the PRD-001 example opening-hours schema (multiple blocks per day, empty array = Ruhetag)
- Feature tests covering: factory validity, `opening_hours` array-cast roundtrip, IMAP-password encryption-at-rest + decrypted on read, `tonality` enum-cast roundtrip, slug unique constraint, `imap_password` hidden from `toArray()`

## Why
Restaurants is the tenant-root entity for the whole system. PRD-001 pins this schema intentionally, and migrations are never retroactively changed — so getting shape, casts, and the secret-handling contract right upfront matters. The encrypted cast + `$hidden` together guarantee the IMAP password never leaves the DB in cleartext and never leaks through serialization (API responses, queued payloads, log dumps).

Path A was chosen for `tonality` (backed enum rather than plain string) to match the CLAUDE.md §Enums convention and give every downstream consumer type safety.

## Test plan
- [x] `./vendor/bin/pint --test` — clean
- [x] `php artisan test --filter=RestaurantTest` — 6 tests, 14 assertions, all green
- [x] `php artisan test` (full suite) — 33 tests, 78 assertions, all green (after `npm run build` so the Vite manifest exists; no regressions introduced by this PR)
- [x] `npm run format:check` — clean

Closes #4