### PR TITLE
Extend users table with restaurant_id and role (#5)

### DIFF
--- a/app/Enums/UserRole.php
+++ b/app/Enums/UserRole.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum UserRole: string
+{
+    case Owner = 'owner';
+    case Staff = 'staff';
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,8 +3,10 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use App\Enums\UserRole;
 use Database\Factories\UserFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -22,6 +24,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'restaurant_id',
+        'role',
     ];
 
     /**
@@ -44,6 +48,15 @@ class User extends Authenticatable
         return [
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
+            'role' => UserRole::class,
         ];
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,6 +2,8 @@
 
 namespace Database\Factories;
 
+use App\Enums\UserRole;
+use App\Models\Restaurant;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
@@ -30,6 +32,8 @@ class UserFactory extends Factory
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'restaurant_id' => null,
+            'role' => UserRole::Staff,
         ];
     }
 
@@ -40,6 +44,16 @@ class UserFactory extends Factory
     {
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
+        ]);
+    }
+
+    /**
+     * Scope the user to the given restaurant.
+     */
+    public function forRestaurant(Restaurant $restaurant): static
+    {
+        return $this->state(fn () => [
+            'restaurant_id' => $restaurant->id,
         ]);
     }
 }

--- a/database/migrations/2026_04_17_123537_add_restaurant_id_and_role_to_users_table.php
+++ b/database/migrations/2026_04_17_123537_add_restaurant_id_and_role_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->foreignId('restaurant_id')
+                ->nullable()
+                ->after('id')
+                ->constrained()
+                ->cascadeOnDelete();
+
+            $table->string('role')->default('staff')->after('password');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('restaurant_id');
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/tests/Feature/Models/UserTest.php
+++ b/tests/Feature/Models/UserTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_for_restaurant_factory_state_assigns_the_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertSame($restaurant->id, $user->restaurant_id);
+        $this->assertTrue($user->restaurant->is($restaurant));
+    }
+
+    public function test_restaurant_id_is_nullable_for_platform_admins(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $this->assertNull($user->restaurant_id);
+        $this->assertNull($user->restaurant);
+    }
+
+    public function test_role_is_cast_to_the_user_role_enum(): void
+    {
+        $user = User::factory()->create(['role' => UserRole::Owner]);
+
+        $this->assertSame(UserRole::Owner, $user->fresh()->role);
+        $this->assertSame('owner', DB::table('users')->where('id', $user->id)->value('role'));
+    }
+
+    public function test_role_defaults_to_staff_when_not_provided(): void
+    {
+        DB::table('users')->insert([
+            'name' => 'Default Role User',
+            'email' => 'default-role@example.test',
+            'password' => Hash::make('password'),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->assertSame(UserRole::Staff, User::query()->sole()->role);
+    }
+
+    public function test_users_are_cascade_deleted_when_their_restaurant_is_deleted(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $users = User::factory()->count(3)->forRestaurant($restaurant)->create();
+        $untouchedUser = User::factory()->create(['restaurant_id' => null]);
+
+        $restaurant->delete();
+
+        foreach ($users as $user) {
+            $this->assertDatabaseMissing('users', ['id' => $user->id]);
+        }
+        $this->assertDatabaseHas('users', ['id' => $untouchedUser->id]);
+    }
+
+    public function test_restaurant_relation_returns_null_when_restaurant_id_is_null(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $this->assertNull($user->restaurant()->first());
+    }
+}


### PR DESCRIPTION
## Summary
- Migration adds `restaurant_id` (bigint FK, nullable, **cascade on restaurant delete**) and `role` (string, DB-default `staff`) to `users`; `down()` drops both cleanly via `dropConstrainedForeignId`
- `UserRole` backed enum (`owner | staff`) — follows the `Tonality` pattern from #4
- `User::restaurant()` `BelongsTo<Restaurant>` relation; `role` cast to `UserRole`
- `UserFactory::forRestaurant(Restaurant $r)` state helper + defaults (`restaurant_id = null`, `role = Staff`)
- Feature tests: factory state assignment, enum cast roundtrip, DB default `staff`, cascade delete, nullable admin case, null-relation resolution

## Why
Every authenticated user in V1.0 is tenant-scoped. PRD-001 pins this shape: `restaurant_id` nullable (future platform admins have null), `role` string. The cascade-on-delete behavior was an explicit decision: in a multi-tenant SaaS, deleting a Restaurant means the tenant is offboarded, and preserving orphaned user accounts would silently promote them to platform-admins by flipping `restaurant_id` to null — a real security footgun. Cascade keeps tenant lifecycle atomic.

Mass-assignment safety: `restaurant_id` and `role` are in `$fillable` so factories and future admin flows can set them, but the existing `RegisteredUserController` uses explicit field mapping (`'name' => $request->name`, etc.) — there is no attack surface via registration today. Future controllers must use FormRequests with a whitelist per CLAUDE.md convention.

## Test plan
- [x] `./vendor/bin/pint --test` — clean
- [x] `php artisan test --filter=UserTest` — 6 tests, 12 assertions, green
- [x] `php artisan test` (full suite) — 41 tests, 93 assertions, green (no regressions in existing auth/dashboard tests after adding the new columns)
- [x] `php artisan migrate:fresh` locally succeeds with both migrations

Closes #5