### PR TITLE
Add Reservation enums with transition rules (#9)

### DIFF
--- a/app/Enums/ReservationReplyStatus.php
+++ b/app/Enums/ReservationReplyStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Enums;
+
+enum ReservationReplyStatus: string
+{
+    case Draft = 'draft';
+    case Approved = 'approved';
+    case Sent = 'sent';
+    case Failed = 'failed';
+}

--- a/app/Enums/ReservationSource.php
+++ b/app/Enums/ReservationSource.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum ReservationSource: string
+{
+    case WebForm = 'web_form';
+    case Email = 'email';
+}

--- a/app/Enums/ReservationStatus.php
+++ b/app/Enums/ReservationStatus.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Enums;
+
+enum ReservationStatus: string
+{
+    case New = 'new';
+    case InReview = 'in_review';
+    case Replied = 'replied';
+    case Confirmed = 'confirmed';
+    case Declined = 'declined';
+    case Cancelled = 'cancelled';
+
+    /**
+     * @return list<self>
+     */
+    public function allowedNextStates(): array
+    {
+        return match ($this) {
+            self::New => [self::InReview, self::Declined],
+            self::InReview => [self::Replied, self::Declined],
+            self::Replied => [self::Confirmed, self::Cancelled],
+            self::Confirmed => [self::Cancelled],
+            self::Declined, self::Cancelled => [],
+        };
+    }
+
+    public function canTransitionTo(self $target): bool
+    {
+        return in_array($target, $this->allowedNextStates(), true);
+    }
+}

--- a/tests/Unit/Enums/ReservationStatusTest.php
+++ b/tests/Unit/Enums/ReservationStatusTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\ReservationStatus;
+use Tests\TestCase;
+
+class ReservationStatusTest extends TestCase
+{
+    /**
+     * The full transition matrix from PRD-001. True = allowed, false = forbidden.
+     * Every pair not listed below is implicitly forbidden by the default false.
+     *
+     * @return array<string, array{0: ReservationStatus, 1: ReservationStatus, 2: bool}>
+     */
+    public static function transitionMatrix(): array
+    {
+        $allowed = [
+            [ReservationStatus::New, ReservationStatus::InReview],
+            [ReservationStatus::New, ReservationStatus::Declined],
+            [ReservationStatus::InReview, ReservationStatus::Replied],
+            [ReservationStatus::InReview, ReservationStatus::Declined],
+            [ReservationStatus::Replied, ReservationStatus::Confirmed],
+            [ReservationStatus::Replied, ReservationStatus::Cancelled],
+            [ReservationStatus::Confirmed, ReservationStatus::Cancelled],
+        ];
+
+        $rows = [];
+        foreach (ReservationStatus::cases() as $from) {
+            foreach (ReservationStatus::cases() as $to) {
+                $isAllowed = false;
+                foreach ($allowed as [$a, $b]) {
+                    if ($from === $a && $to === $b) {
+                        $isAllowed = true;
+                        break;
+                    }
+                }
+                $rows["{$from->value} → {$to->value}"] = [$from, $to, $isAllowed];
+            }
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @dataProvider transitionMatrix
+     */
+    public function test_can_transition_to_matches_the_prd_matrix(ReservationStatus $from, ReservationStatus $to, bool $expected): void
+    {
+        $this->assertSame($expected, $from->canTransitionTo($to));
+    }
+
+    public function test_prd_disallowed_examples_are_forbidden(): void
+    {
+        $this->assertFalse(ReservationStatus::Confirmed->canTransitionTo(ReservationStatus::New));
+    }
+
+    public function test_self_transitions_are_forbidden(): void
+    {
+        foreach (ReservationStatus::cases() as $status) {
+            $this->assertFalse(
+                $status->canTransitionTo($status),
+                "{$status->value} → {$status->value} must be forbidden (self-transition)"
+            );
+        }
+    }
+
+    public function test_declined_and_cancelled_are_terminal(): void
+    {
+        $this->assertSame([], ReservationStatus::Declined->allowedNextStates());
+        $this->assertSame([], ReservationStatus::Cancelled->allowedNextStates());
+
+        foreach (ReservationStatus::cases() as $target) {
+            $this->assertFalse(ReservationStatus::Declined->canTransitionTo($target));
+            $this->assertFalse(ReservationStatus::Cancelled->canTransitionTo($target));
+        }
+    }
+
+    public function test_allowed_next_states_for_new_are_in_review_and_declined(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [ReservationStatus::InReview, ReservationStatus::Declined],
+            ReservationStatus::New->allowedNextStates()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `App\Enums\ReservationStatus` (`new | in_review | replied | confirmed | declined | cancelled`) with:
  - `allowedNextStates(): list<self>` encoding the PRD-001 transition matrix
  - `canTransitionTo(self $target): bool` derived from the matrix via `in_array`
  - `declined` and `cancelled` are terminal (no outgoing transitions)
- `App\Enums\ReservationSource` (`web_form | email`)
- `App\Enums\ReservationReplyStatus` (`draft | approved | sent | failed`)
- Unit tests (`tests/Unit/Enums/ReservationStatusTest.php`) exhaustively covering the 36-pair transition matrix via `@dataProvider` (7 allowed, 29 forbidden), plus self-transition rejection, terminal-state emptiness, and the PRD-001 `confirmed → new` must-fail example

## Why
Path 2 of the sequencing discussion: building the enums before `reservation_requests` (#6) and `reservation_replies` (#7) means those models can wire the casts in directly — no rework. Status transitions are the single source of truth for the bulk-update endpoint (PRD-004) and the approval endpoint (PRD-005); encoding them on the enum (not scattered across services) keeps the contract discoverable and testable in one place.

Implementation choice: `allowedNextStates()` + `in_array()` rather than a monolithic `match` on `[$this, $target]` pairs, because the list form is reusable — the PRD-004 dashboard will need to render only the valid next-status options as a dropdown, and that code can now call `$reservation->status->allowedNextStates()` directly.

## Scope note
The AC line "All three enums wired into `$casts` of the corresponding models" cannot literally be satisfied in this PR because `ReservationRequest` and `ReservationReply` models don't exist yet. They are created in #6 and #7; this PR makes the enums ready for use there, and those issues' ACs will pick up the wiring naturally.

## Test plan
- [x] `./vendor/bin/pint --test` — clean
- [x] `php artisan test --filter=ReservationStatusTest` — 40 tests (36 matrix + 4 behavior), 58 assertions, green
- [x] `php artisan test` (full suite) — 81 tests, 151 assertions, green; no regressions

Closes #9