### PR TITLE
Add reservation_requests scaffold (#6)

### DIFF
--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use Database\Factories\ReservationRequestFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
+
+class ReservationRequest extends Model
+{
+    /** @use HasFactory<ReservationRequestFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'restaurant_id',
+        'source',
+        'status',
+        'guest_name',
+        'guest_email',
+        'guest_phone',
+        'party_size',
+        'desired_at',
+        'message',
+        'raw_payload',
+        'needs_manual_review',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'source' => ReservationSource::class,
+            'status' => ReservationStatus::class,
+            'party_size' => 'integer',
+            'desired_at' => 'datetime',
+            'raw_payload' => 'encrypted:array',
+            'needs_manual_review' => 'boolean',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
+    }
+
+    /**
+     * @return HasMany<ReservationReply, $this>
+     */
+    public function replies(): HasMany
+    {
+        return $this->hasMany(ReservationReply::class);
+    }
+
+    /**
+     * @return HasOne<ReservationReply, $this>
+     */
+    public function latestReply(): HasOne
+    {
+        return $this->hasOne(ReservationReply::class)->latestOfMany();
+    }
+}

--- a/database/factories/ReservationRequestFactory.php
+++ b/database/factories/ReservationRequestFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ReservationRequest>
+ */
+class ReservationRequestFactory extends Factory
+{
+    protected $model = ReservationRequest::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'restaurant_id' => Restaurant::factory(),
+            'source' => ReservationSource::WebForm,
+            'status' => ReservationStatus::New,
+            'guest_name' => fake()->name(),
+            'guest_email' => fake()->safeEmail(),
+            'guest_phone' => fake()->optional()->e164PhoneNumber(),
+            'party_size' => fake()->numberBetween(2, 8),
+            'desired_at' => fake()->dateTimeBetween('+1 day', '+14 days'),
+            'message' => fake()->optional()->sentence(),
+            'raw_payload' => null,
+            'needs_manual_review' => false,
+        ];
+    }
+
+    public function inReview(): static
+    {
+        return $this->state(fn () => [
+            'status' => ReservationStatus::InReview,
+        ]);
+    }
+
+    public function confirmed(): static
+    {
+        return $this->state(fn () => [
+            'status' => ReservationStatus::Confirmed,
+        ]);
+    }
+
+    public function forRestaurant(Restaurant $restaurant): static
+    {
+        return $this->state(fn () => [
+            'restaurant_id' => $restaurant->id,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_17_125725_create_reservation_requests_table.php
+++ b/database/migrations/2026_04_17_125725_create_reservation_requests_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reservation_requests', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('source');
+            $table->string('status');
+            $table->string('guest_name');
+            $table->string('guest_email')->nullable();
+            $table->string('guest_phone')->nullable();
+            $table->unsignedInteger('party_size');
+            $table->dateTime('desired_at')->nullable();
+            $table->text('message')->nullable();
+            $table->text('raw_payload')->nullable();
+            $table->boolean('needs_manual_review')->default(false);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reservation_requests');
+    }
+};

--- a/tests/Feature/Models/ReservationRequestTest.php
+++ b/tests/Feature/Models/ReservationRequestTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ReservationRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_creates_a_valid_reservation_request_with_default_status_new(): void
+    {
+        $request = ReservationRequest::factory()->create();
+
+        $this->assertTrue($request->exists);
+        $this->assertSame(ReservationStatus::New, $request->status);
+        $this->assertSame(ReservationSource::WebForm, $request->source);
+        $this->assertNotEmpty($request->guest_name);
+        $this->assertIsInt($request->party_size);
+        $this->assertFalse($request->needs_manual_review);
+    }
+
+    public function test_in_review_state_sets_status_to_in_review(): void
+    {
+        $request = ReservationRequest::factory()->inReview()->create();
+
+        $this->assertSame(ReservationStatus::InReview, $request->status);
+    }
+
+    public function test_confirmed_state_sets_status_to_confirmed(): void
+    {
+        $request = ReservationRequest::factory()->confirmed()->create();
+
+        $this->assertSame(ReservationStatus::Confirmed, $request->status);
+    }
+
+    public function test_for_restaurant_state_attaches_to_provided_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertSame($restaurant->id, $request->restaurant_id);
+    }
+
+    public function test_source_and_status_are_persisted_as_string_values_and_cast_back_to_enums(): void
+    {
+        $request = ReservationRequest::factory()->create([
+            'source' => ReservationSource::Email,
+            'status' => ReservationStatus::Replied,
+        ]);
+
+        $row = DB::table('reservation_requests')->where('id', $request->id)->first();
+
+        $this->assertSame('email', $row->source);
+        $this->assertSame('replied', $row->status);
+        $this->assertSame(ReservationSource::Email, $request->fresh()->source);
+        $this->assertSame(ReservationStatus::Replied, $request->fresh()->status);
+    }
+
+    public function test_desired_at_is_cast_to_a_carbon_instance(): void
+    {
+        $request = ReservationRequest::factory()->create([
+            'desired_at' => '2026-05-01 19:30:00',
+        ]);
+
+        $this->assertInstanceOf(Carbon::class, $request->desired_at);
+        $this->assertSame('2026-05-01 19:30:00', $request->desired_at->format('Y-m-d H:i:s'));
+    }
+
+    public function test_desired_at_may_be_null_when_not_parsable(): void
+    {
+        $request = ReservationRequest::factory()->create(['desired_at' => null]);
+
+        $this->assertNull($request->fresh()->desired_at);
+    }
+
+    public function test_raw_payload_is_encrypted_at_rest_and_decrypted_on_read(): void
+    {
+        $payload = [
+            'form' => 'web',
+            'fields' => ['name' => 'Erika Mustermann', 'party_size' => 4],
+        ];
+
+        $request = ReservationRequest::factory()->create(['raw_payload' => $payload]);
+
+        $rawValue = DB::table('reservation_requests')->where('id', $request->id)->value('raw_payload');
+
+        $this->assertNotNull($rawValue);
+        $this->assertNotSame(json_encode($payload), $rawValue, 'raw_payload must not be stored as plain JSON');
+        $this->assertSame($payload, json_decode(Crypt::decryptString($rawValue), true));
+        $this->assertSame($payload, $request->fresh()->raw_payload);
+    }
+
+    public function test_needs_manual_review_defaults_to_false_when_omitted(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        DB::table('reservation_requests')->insert([
+            'restaurant_id' => $restaurant->id,
+            'source' => ReservationSource::WebForm->value,
+            'status' => ReservationStatus::New->value,
+            'guest_name' => 'Test Guest',
+            'party_size' => 2,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $request = ReservationRequest::query()->sole();
+
+        $this->assertFalse($request->needs_manual_review);
+    }
+
+    public function test_reservation_requests_are_cascade_deleted_with_their_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $otherRestaurant = Restaurant::factory()->create();
+
+        ReservationRequest::factory()->forRestaurant($restaurant)->count(3)->create();
+        ReservationRequest::factory()->forRestaurant($otherRestaurant)->create();
+
+        $this->assertSame(4, ReservationRequest::query()->count());
+
+        $restaurant->delete();
+
+        $this->assertSame(1, ReservationRequest::query()->count());
+        $this->assertSame(
+            $otherRestaurant->id,
+            ReservationRequest::query()->sole()->restaurant_id
+        );
+    }
+
+    public function test_restaurant_id_is_required(): void
+    {
+        $this->expectException(QueryException::class);
+
+        DB::table('reservation_requests')->insert([
+            'source' => ReservationSource::WebForm->value,
+            'status' => ReservationStatus::New->value,
+            'guest_name' => 'Test Guest',
+            'party_size' => 2,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    public function test_belongs_to_restaurant_relation_returns_owning_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create(['name' => 'Bella Italia']);
+
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertSame($restaurant->id, $request->restaurant->id);
+        $this->assertSame('Bella Italia', $request->restaurant->name);
+    }
+}


### PR DESCRIPTION
## Summary
- New migration `2026_04_17_125725_create_reservation_requests_table.php`: id, `restaurant_id` FK (cascade on delete), `source`, `status`, `guest_name`, nullable `guest_email`/`guest_phone`, `party_size` (unsignedInt), nullable `desired_at` (datetime, UTC), nullable `message`, nullable `raw_payload`, `needs_manual_review` (bool, default false), timestamps.
- `App\Models\ReservationRequest` with method-based `casts()` for `source` → `ReservationSource`, `status` → `ReservationStatus`, `desired_at` → `datetime`, `raw_payload` → `encrypted:array`, `needs_manual_review` → `boolean`, `party_size` → `integer`.
- Relations: `restaurant()` (belongsTo), `replies()` (hasMany ReservationReply), `latestReply()` (hasOne ReservationReply → `latestOfMany`).
- `ReservationRequestFactory` with default state (`status=new`, `source=web_form`), plus `inReview()`, `confirmed()` and `forRestaurant($restaurant)` helpers.
- 12 feature tests covering factory states, enum cast roundtrip, `desired_at` Carbon cast incl. null, raw-payload encryption-at-rest (`Crypt::decryptString`), DB default for `needs_manual_review`, cascade delete from restaurant, `restaurant_id` NOT NULL enforcement, and `belongsTo` navigation.

## Why
Foundation for every reservation source. A uniform record shape lets the dashboard (PRD-004), email ingestion (PRD-003), and AI reply flow (PRD-005) all read the same table.

## Deviations / notes
- **`raw_payload` column is `text`, not `json` as the PRD table literally states.** `encrypted:array` writes ciphertext, which is not a valid JSON value — a `json` column would reject it in MySQL/Postgres. Encryption at rest is the stronger requirement here (raw email bodies + form payloads contain guest PII), so the column type was downgraded to `text` to make that cast work. Functionality from the cast side is unchanged: reads/writes go through `array` in PHP.
- No `$hidden` fields on this model. Guest PII (name/email/phone) is protected at the serialization boundary via API Resources (per `CLAUDE.md` — "Validierung / Serialisierung gehören in FormRequests / API Resources, nicht ins Model").
- `replies()` / `latestReply()` reference `App\Models\ReservationReply`, which does not exist yet. The class name is a compile-time string and is only resolved when the relation is actually queried — none of the tests in this PR do that. Runtime behaviour of those two relations lands with #7 (`reservation_replies` migration + model), which will add the matching feature tests.
- `RestaurantScope` global scope is explicitly **out of scope** here — tracked as a separate foundation issue.

## Test plan
- [x] `./vendor/bin/pint --test` — pass
- [x] `php artisan test` — 93 tests, 178 assertions, 0 failures (deprecation warnings are a pre-existing `PDO::MYSQL_ATTR_SSL_CA` PHP 8.5 notice from `config/database.php`, not introduced here)
- [x] `php artisan migrate:fresh --env=testing` — all six migrations apply cleanly
- [x] `php artisan migrate:rollback --step=1 --env=testing && php artisan migrate --env=testing` — `down()` reverses and re-applies the new migration cleanly

Refs #6