### PR TITLE
Add reservation_replies scaffold (#7)

### DIFF
--- a/app/Models/ReservationReply.php
+++ b/app/Models/ReservationReply.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ReservationReplyStatus;
+use Database\Factories\ReservationReplyFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ReservationReply extends Model
+{
+    /** @use HasFactory<ReservationReplyFactory> */
+    use HasFactory;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'reservation_request_id',
+        'status',
+        'body',
+        'ai_prompt_snapshot',
+        'approved_by',
+        'approved_at',
+        'sent_at',
+        'error_message',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'status' => ReservationReplyStatus::class,
+            'ai_prompt_snapshot' => 'array',
+            'approved_at' => 'datetime',
+            'sent_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<ReservationRequest, $this>
+     */
+    public function reservationRequest(): BelongsTo
+    {
+        return $this->belongsTo(ReservationRequest::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function approver(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'approved_by');
+    }
+}

--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -73,6 +73,6 @@ class ReservationRequest extends Model
      */
     public function latestReply(): HasOne
     {
-        return $this->hasOne(ReservationReply::class)->latestOfMany();
+        return $this->hasOne(ReservationReply::class)->latestOfMany('created_at');
     }
 }

--- a/database/factories/ReservationReplyFactory.php
+++ b/database/factories/ReservationReplyFactory.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ReservationReplyStatus;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ReservationReply>
+ */
+class ReservationReplyFactory extends Factory
+{
+    protected $model = ReservationReply::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'reservation_request_id' => ReservationRequest::factory(),
+            'status' => ReservationReplyStatus::Draft,
+            'body' => fake()->paragraph(),
+            'ai_prompt_snapshot' => null,
+            'approved_by' => null,
+            'approved_at' => null,
+            'sent_at' => null,
+            'error_message' => null,
+        ];
+    }
+
+    public function draft(): static
+    {
+        return $this->state(fn () => [
+            'status' => ReservationReplyStatus::Draft,
+            'approved_by' => null,
+            'approved_at' => null,
+            'sent_at' => null,
+            'error_message' => null,
+        ]);
+    }
+
+    public function approved(): static
+    {
+        return $this->state(fn () => [
+            'status' => ReservationReplyStatus::Approved,
+            'approved_by' => User::factory(),
+            'approved_at' => now(),
+            'sent_at' => null,
+            'error_message' => null,
+        ]);
+    }
+
+    public function sent(): static
+    {
+        return $this->state(fn () => [
+            'status' => ReservationReplyStatus::Sent,
+            'approved_by' => User::factory(),
+            'approved_at' => now()->subMinutes(2),
+            'sent_at' => now(),
+            'error_message' => null,
+        ]);
+    }
+
+    public function failed(): static
+    {
+        return $this->state(fn () => [
+            'status' => ReservationReplyStatus::Failed,
+            'approved_by' => User::factory(),
+            'approved_at' => now()->subMinutes(5),
+            'sent_at' => null,
+            'error_message' => 'SMTP connection timed out after 30s',
+        ]);
+    }
+
+    public function forReservationRequest(ReservationRequest $request): static
+    {
+        return $this->state(fn () => [
+            'reservation_request_id' => $request->id,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_17_230007_create_reservation_replies_table.php
+++ b/database/migrations/2026_04_17_230007_create_reservation_replies_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reservation_replies', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reservation_request_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('status');
+            $table->text('body');
+            $table->json('ai_prompt_snapshot')->nullable();
+            $table->foreignId('approved_by')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->dateTime('approved_at')->nullable();
+            $table->dateTime('sent_at')->nullable();
+            $table->text('error_message')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reservation_replies');
+    }
+};

--- a/tests/Feature/Models/ReservationReplyTest.php
+++ b/tests/Feature/Models/ReservationReplyTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\ReservationReplyStatus;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class ReservationReplyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_default_creates_a_draft_reply(): void
+    {
+        $reply = ReservationReply::factory()->create();
+
+        $this->assertTrue($reply->exists);
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+        $this->assertNotEmpty($reply->body);
+        $this->assertNull($reply->approved_by);
+        $this->assertNull($reply->approved_at);
+        $this->assertNull($reply->sent_at);
+        $this->assertNull($reply->error_message);
+    }
+
+    public function test_draft_state_resets_approval_fields(): void
+    {
+        $reply = ReservationReply::factory()->draft()->create();
+
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+        $this->assertNull($reply->approved_by);
+        $this->assertNull($reply->approved_at);
+        $this->assertNull($reply->sent_at);
+    }
+
+    public function test_approved_state_sets_approver_and_approved_at(): void
+    {
+        $reply = ReservationReply::factory()->approved()->create();
+
+        $this->assertSame(ReservationReplyStatus::Approved, $reply->status);
+        $this->assertNotNull($reply->approved_by);
+        $this->assertInstanceOf(Carbon::class, $reply->approved_at);
+        $this->assertNull($reply->sent_at);
+        $this->assertNull($reply->error_message);
+    }
+
+    public function test_sent_state_sets_sent_at_in_addition_to_approval_fields(): void
+    {
+        $reply = ReservationReply::factory()->sent()->create();
+
+        $this->assertSame(ReservationReplyStatus::Sent, $reply->status);
+        $this->assertNotNull($reply->approved_by);
+        $this->assertInstanceOf(Carbon::class, $reply->approved_at);
+        $this->assertInstanceOf(Carbon::class, $reply->sent_at);
+        $this->assertNull($reply->error_message);
+    }
+
+    public function test_failed_state_records_error_message_and_keeps_sent_at_null(): void
+    {
+        $reply = ReservationReply::factory()->failed()->create();
+
+        $this->assertSame(ReservationReplyStatus::Failed, $reply->status);
+        $this->assertNotNull($reply->approved_by);
+        $this->assertInstanceOf(Carbon::class, $reply->approved_at);
+        $this->assertNull($reply->sent_at);
+        $this->assertNotEmpty($reply->error_message);
+    }
+
+    public function test_for_reservation_request_state_attaches_to_provided_request(): void
+    {
+        $request = ReservationRequest::factory()->create();
+
+        $reply = ReservationReply::factory()->forReservationRequest($request)->create();
+
+        $this->assertSame($request->id, $reply->reservation_request_id);
+    }
+
+    public function test_status_is_persisted_as_string_value_and_cast_back_to_enum(): void
+    {
+        $reply = ReservationReply::factory()->approved()->create();
+
+        $rawStatus = DB::table('reservation_replies')->where('id', $reply->id)->value('status');
+
+        $this->assertSame('approved', $rawStatus);
+        $this->assertSame(ReservationReplyStatus::Approved, $reply->fresh()->status);
+    }
+
+    public function test_ai_prompt_snapshot_is_cast_to_an_array(): void
+    {
+        $snapshot = [
+            'restaurant' => ['name' => 'Bella Italia', 'tonality' => 'formal'],
+            'request' => ['party_size' => 4, 'desired_at' => '2026-05-01T19:30:00Z'],
+            'availability' => ['slots' => ['19:00', '19:30', '20:00']],
+        ];
+
+        $reply = ReservationReply::factory()->create(['ai_prompt_snapshot' => $snapshot]);
+
+        $this->assertSame($snapshot, $reply->fresh()->ai_prompt_snapshot);
+    }
+
+    public function test_ai_prompt_snapshot_may_be_null(): void
+    {
+        $reply = ReservationReply::factory()->create(['ai_prompt_snapshot' => null]);
+
+        $this->assertNull($reply->fresh()->ai_prompt_snapshot);
+    }
+
+    public function test_approved_at_and_sent_at_round_trip_as_carbon(): void
+    {
+        $reply = ReservationReply::factory()->create([
+            'approved_at' => '2026-05-01 19:30:00',
+            'sent_at' => '2026-05-01 19:31:00',
+        ]);
+
+        $fresh = $reply->fresh();
+
+        $this->assertInstanceOf(Carbon::class, $fresh->approved_at);
+        $this->assertInstanceOf(Carbon::class, $fresh->sent_at);
+        $this->assertSame('2026-05-01 19:30:00', $fresh->approved_at->format('Y-m-d H:i:s'));
+        $this->assertSame('2026-05-01 19:31:00', $fresh->sent_at->format('Y-m-d H:i:s'));
+    }
+
+    public function test_belongs_to_reservation_request_relation_returns_parent(): void
+    {
+        $request = ReservationRequest::factory()->create(['guest_name' => 'Mara Schmidt']);
+
+        $reply = ReservationReply::factory()->forReservationRequest($request)->create();
+
+        $this->assertSame($request->id, $reply->reservationRequest->id);
+        $this->assertSame('Mara Schmidt', $reply->reservationRequest->guest_name);
+    }
+
+    public function test_approver_relation_returns_the_approving_user(): void
+    {
+        $approver = User::factory()->create(['name' => 'Tom Werner']);
+
+        $reply = ReservationReply::factory()->approved()->create([
+            'approved_by' => $approver->id,
+        ]);
+
+        $this->assertSame($approver->id, $reply->approver->id);
+        $this->assertSame('Tom Werner', $reply->approver->name);
+    }
+
+    public function test_approver_relation_is_null_when_approved_by_is_null(): void
+    {
+        $reply = ReservationReply::factory()->draft()->create();
+
+        $this->assertNull($reply->approver);
+    }
+
+    public function test_replies_cascade_delete_when_their_reservation_request_is_deleted(): void
+    {
+        $request = ReservationRequest::factory()->create();
+        $otherRequest = ReservationRequest::factory()->create();
+
+        ReservationReply::factory()->forReservationRequest($request)->count(2)->create();
+        ReservationReply::factory()->forReservationRequest($otherRequest)->create();
+
+        $this->assertSame(3, ReservationReply::query()->count());
+
+        $request->delete();
+
+        $this->assertSame(1, ReservationReply::query()->count());
+        $this->assertSame(
+            $otherRequest->id,
+            ReservationReply::query()->sole()->reservation_request_id
+        );
+    }
+
+    public function test_approved_by_is_nulled_when_approving_user_is_deleted(): void
+    {
+        $approver = User::factory()->create();
+        $reply = ReservationReply::factory()->sent()->create([
+            'approved_by' => $approver->id,
+        ]);
+
+        $this->assertSame($approver->id, $reply->fresh()->approved_by);
+
+        $approver->delete();
+
+        $fresh = $reply->fresh();
+        $this->assertNotNull($fresh, 'Reply must survive approver deletion');
+        $this->assertNull($fresh->approved_by, 'approved_by must be nulled on user delete');
+        $this->assertNotNull($fresh->approved_at, 'approved_at audit timestamp must remain');
+        $this->assertNotNull($fresh->sent_at, 'sent_at audit timestamp must remain');
+    }
+}

--- a/tests/Feature/Models/ReservationRequestTest.php
+++ b/tests/Feature/Models/ReservationRequestTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Models;
 
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
+use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use Illuminate\Database\QueryException;
@@ -161,5 +162,38 @@ class ReservationRequestTest extends TestCase
 
         $this->assertSame($restaurant->id, $request->restaurant->id);
         $this->assertSame('Bella Italia', $request->restaurant->name);
+    }
+
+    public function test_replies_relation_returns_all_attached_replies(): void
+    {
+        $request = ReservationRequest::factory()->create();
+        $otherRequest = ReservationRequest::factory()->create();
+
+        ReservationReply::factory()->forReservationRequest($request)->count(3)->create();
+        ReservationReply::factory()->forReservationRequest($otherRequest)->create();
+
+        $this->assertCount(3, $request->replies);
+        $this->assertCount(1, $otherRequest->replies);
+    }
+
+    public function test_latest_reply_returns_the_most_recently_created_reply(): void
+    {
+        $request = ReservationRequest::factory()->create();
+
+        ReservationReply::factory()->forReservationRequest($request)->create([
+            'body' => 'First draft',
+            'created_at' => now()->subHours(2),
+        ]);
+        $newest = ReservationReply::factory()->forReservationRequest($request)->create([
+            'body' => 'Latest revision',
+            'created_at' => now(),
+        ]);
+        ReservationReply::factory()->forReservationRequest($request)->create([
+            'body' => 'Middle draft',
+            'created_at' => now()->subHour(),
+        ]);
+
+        $this->assertSame($newest->id, $request->latestReply->id);
+        $this->assertSame('Latest revision', $request->latestReply->body);
     }
 }


### PR DESCRIPTION
## Summary
- Migration `2026_04_17_230007_create_reservation_replies_table.php`: `reservation_request_id` FK (**cascadeOnDelete** — deleting a request wipes its drafts/replies), `status`, `body` (text), `ai_prompt_snapshot` (json nullable), `approved_by` FK users (**nullable + nullOnDelete**, so audit trail survives user deletion), `approved_at`, `sent_at`, `error_message`, timestamps.
- `App\Models\ReservationReply` with method-based `casts()` — `status` → `ReservationReplyStatus`, `ai_prompt_snapshot` → `array`, `approved_at` / `sent_at` → `datetime`. Relations: `reservationRequest()` (belongsTo), `approver()` (belongsTo `User` via `approved_by`).
- `ReservationReplyFactory` with `draft()` (default), `approved()`, `sent()`, `failed()` states plus `forReservationRequest()` helper. Each state sets the approval / send / error fields consistently with its status.
- 15 feature tests for `ReservationReply` covering every state, enum cast roundtrip, `ai_prompt_snapshot` array cast (incl. null), `approved_at` / `sent_at` as Carbon, both `belongsTo` navigations incl. the null-approver case, cascade delete from parent `ReservationRequest`, and the nullOnDelete behaviour when the approving user is removed (audit timestamps remain).
- **Backfills the two deferred relation tests from #6** (`replies()` hasMany and `latestReply()` hasOne+latestOfMany) now that `ReservationReply` exists.

## Why
Every AI-generated or manually authored reply needs a persisted record so the dashboard can show the draft, capture the approver for audit, and record send status + error detail. Keeping it as a separate table (1:n from `reservation_requests`) lets us keep an immutable history of every drafted/edited/sent version per request — important once PRD-005 starts regenerating replies.

## Design decisions (confirmed with owner before build)
- **`ai_prompt_snapshot` is a real `json` column with `array` cast** (option 1A), not encrypted like `raw_payload`. Rationale: the snapshot is the Context-JSON we *deliberately* ship to OpenAI — treat it as already sanitized and keep it searchable. If anything leaks into it, the right fix is the sanitize layer, not encryption at rest.
- **`approved_by` uses `nullOnDelete` (2A):** when a user is deleted, the reply they approved keeps its `approved_at` / `sent_at` / `body` — only the `approved_by` pointer goes null. Cascading would destroy reservation history; restricting would block operational user cleanup. nullOnDelete is the audit-friendly default.

## Bug caught & fixed during this PR
- `latestReply()` originally used Laravel's default `latestOfMany()` which sorts by primary key. The new `test_latest_reply_returns_the_most_recently_created_reply` test inserts three replies out of chronological order — it caught that "largest PK" ≠ "most recent" when rows are inserted with backdated `created_at`. Changed to `latestOfMany('created_at')`.

## Test plan
- [x] `./vendor/bin/pint --test` — pass
- [x] `php artisan test` — 110 tests, 230 assertions, 0 failures (+ 17 over #99; deprecations are the pre-existing PHP 8.5 PDO notice)
- [x] `php artisan migrate:fresh --env=testing` — applies all 7 migrations cleanly
- [x] `php artisan migrate:rollback --step=1 --env=testing && php artisan migrate --env=testing` — new migration reverses and re-applies cleanly

Refs #7