### PR TITLE
Add failed_email_imports quarantine table (#8)

### DIFF
--- a/app/Models/FailedEmailImport.php
+++ b/app/Models/FailedEmailImport.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\FailedEmailImportFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class FailedEmailImport extends Model
+{
+    /** @use HasFactory<FailedEmailImportFactory> */
+    use HasFactory;
+
+    const UPDATED_AT = null;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'restaurant_id',
+        'message_id',
+        'raw_headers',
+        'raw_body',
+        'error',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
+    }
+}

--- a/database/factories/FailedEmailImportFactory.php
+++ b/database/factories/FailedEmailImportFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FailedEmailImport;
+use App\Models\Restaurant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<FailedEmailImport>
+ */
+class FailedEmailImportFactory extends Factory
+{
+    protected $model = FailedEmailImport::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $messageId = '<'.Str::uuid()->toString().'@mail.example.com>';
+        $from = fake()->safeEmail();
+        $subject = 'Reservierung '.fake()->date();
+
+        $rawHeaders = implode("\n", [
+            "From: {$from}",
+            'To: reservierung@restaurant.example',
+            "Subject: {$subject}",
+            'Date: '.now()->toRfc2822String(),
+            "Message-ID: {$messageId}",
+            'Content-Type: text/plain; charset=UTF-8',
+        ]);
+
+        return [
+            'restaurant_id' => Restaurant::factory(),
+            'message_id' => $messageId,
+            'raw_headers' => $rawHeaders,
+            'raw_body' => fake()->paragraph(3),
+            'error' => 'Unable to parse desired_at: ambiguous date phrase "nächsten Freitag".',
+        ];
+    }
+
+    public function forRestaurant(Restaurant $restaurant): static
+    {
+        return $this->state(fn () => [
+            'restaurant_id' => $restaurant->id,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_17_231041_create_failed_email_imports_table.php
+++ b/database/migrations/2026_04_17_231041_create_failed_email_imports_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('failed_email_imports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('message_id');
+            $table->text('raw_headers');
+            $table->text('raw_body');
+            $table->text('error');
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_email_imports');
+    }
+};

--- a/tests/Feature/Models/FailedEmailImportTest.php
+++ b/tests/Feature/Models/FailedEmailImportTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\FailedEmailImport;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class FailedEmailImportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_creates_a_valid_failed_email_import(): void
+    {
+        $failure = FailedEmailImport::factory()->create();
+
+        $this->assertTrue($failure->exists);
+        $this->assertNotEmpty($failure->message_id);
+        $this->assertNotEmpty($failure->raw_headers);
+        $this->assertNotEmpty($failure->raw_body);
+        $this->assertNotEmpty($failure->error);
+    }
+
+    public function test_for_restaurant_state_attaches_to_provided_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $failure = FailedEmailImport::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertSame($restaurant->id, $failure->restaurant_id);
+    }
+
+    public function test_belongs_to_restaurant_returns_owning_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create(['name' => 'Trattoria Milano']);
+
+        $failure = FailedEmailImport::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertSame($restaurant->id, $failure->restaurant->id);
+        $this->assertSame('Trattoria Milano', $failure->restaurant->name);
+    }
+
+    public function test_failed_imports_cascade_delete_when_their_restaurant_is_deleted(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $other = Restaurant::factory()->create();
+
+        FailedEmailImport::factory()->forRestaurant($restaurant)->count(3)->create();
+        FailedEmailImport::factory()->forRestaurant($other)->create();
+
+        $this->assertSame(4, FailedEmailImport::query()->count());
+
+        $restaurant->delete();
+
+        $this->assertSame(1, FailedEmailImport::query()->count());
+        $this->assertSame($other->id, FailedEmailImport::query()->sole()->restaurant_id);
+    }
+
+    public function test_created_at_is_populated_as_a_carbon_instance(): void
+    {
+        $failure = FailedEmailImport::factory()->create();
+
+        $this->assertInstanceOf(Carbon::class, $failure->created_at);
+        $this->assertNotNull($failure->fresh()->created_at);
+    }
+
+    public function test_table_has_no_updated_at_column(): void
+    {
+        $this->assertFalse(
+            Schema::hasColumn('failed_email_imports', 'updated_at'),
+            'failed_email_imports is append-only and must not have an updated_at column'
+        );
+    }
+
+    public function test_saving_an_existing_record_does_not_attempt_to_write_updated_at(): void
+    {
+        $failure = FailedEmailImport::factory()->create();
+
+        $failure->error = 'Updated error message';
+        $failure->save();
+
+        $this->assertSame('Updated error message', $failure->fresh()->error);
+    }
+
+    public function test_large_raw_body_is_persisted_intact(): void
+    {
+        $body = str_repeat("Dear staff,\nI would like to reserve a table.\n", 200);
+
+        $failure = FailedEmailImport::factory()->create(['raw_body' => $body]);
+
+        $this->assertSame($body, $failure->fresh()->raw_body);
+    }
+
+    public function test_message_id_is_not_unique_so_retries_may_create_repeat_entries(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $messageId = '<duplicate@mail.example.com>';
+
+        FailedEmailImport::factory()->forRestaurant($restaurant)->create(['message_id' => $messageId]);
+        FailedEmailImport::factory()->forRestaurant($restaurant)->create(['message_id' => $messageId]);
+
+        $this->assertSame(2, FailedEmailImport::query()->where('message_id', $messageId)->count());
+    }
+}


### PR DESCRIPTION
## Summary
- Migration `2026_04_17_231041_create_failed_email_imports_table.php`: `restaurant_id` FK (cascadeOnDelete, symmetric with `reservation_requests` and `reservation_replies`), `message_id`, `raw_headers`, `raw_body`, `error`, and a single `created_at` column (`useCurrent()` default, **no `updated_at`** — quarantine entries are immutable).
- `App\Models\FailedEmailImport` with `const UPDATED_AT = null;` so Eloquent auto-populates `created_at` but never tries to write the missing column. `belongsTo(Restaurant)` relation plus a `created_at` → `datetime` cast.
- `FailedEmailImportFactory` produces realistic fixtures: RFC-style `Message-ID`, multi-line headers (`From` / `To` / `Subject` / `Date` / `Message-ID` / `Content-Type`), paragraph body, and a representative parser-error string (ambiguous German date phrase). `forRestaurant()` helper matches the pattern used by the other factories.
- 9 feature tests covering: factory creation, `forRestaurant()` helper, `belongsTo` navigation, cascade delete from restaurant, `created_at` auto-populated as Carbon, **no `updated_at` column** exists, saving a modified existing record does not attempt to write `updated_at`, large (≈8 kB) bodies survive a roundtrip, and `message_id` is non-unique (two entries with the same ID in the same restaurant coexist).

## Why
When PRD-003's `FetchReservationEmailsJob` can't parse a mail (ambiguous date, unsupported format, corrupt MIME), the mail must not be silently dropped or retried into a loop. A quarantine table keeps the raw source + the parser's error, so staff can inspect and the job can move on instead of blocking the queue.

## Design decisions
- **Only `created_at`** (PRD-001 says so, and the semantic matches: a quarantine entry is a log line, not a mutable record). Implemented via `timestamp('created_at')->useCurrent()` in the migration and `const UPDATED_AT = null;` on the model — Laravel 12's supported way to disable one timestamp while keeping auto-population of the other.
- **`message_id` is not unique.** PRD-001 shows no unique key; PRD-003's idempotency story (don't re-import the same message) lives in the *success* path (`reservation_requests`). Letting the quarantine record duplicates keeps retry history instead of silently swallowing repeated failures. If retention becomes a problem, the separate retention-policy doc flagged in the issue's technical notes can add a unique constraint or a pruning job — for now this is explicit and tested.
- **`cascadeOnDelete`** on `restaurant_id`: deleting a restaurant wipes its failed-import quarantine alongside its reservations and replies. Keeping orphaned quarantine rows would leak guest data and serve no purpose.

## Test plan
- [x] `./vendor/bin/pint --test` — pass
- [x] `php artisan test` — 119 tests, 247 assertions, 0 failures (+ 9 over #100)
- [x] `php artisan migrate:fresh --env=testing` — all 8 migrations apply cleanly
- [x] `php artisan migrate:rollback --step=1 --env=testing && php artisan migrate --env=testing` — new migration reverses and re-applies cleanly

Refs #8