### PR TITLE
Add RestaurantScope global Eloquent scope (#10)

### DIFF
--- a/app/Models/FailedEmailImport.php
+++ b/app/Models/FailedEmailImport.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Scopes\RestaurantScope;
 use Database\Factories\FailedEmailImportFactory;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[ScopedBy(RestaurantScope::class)]
 class FailedEmailImport extends Model
 {
     /** @use HasFactory<FailedEmailImportFactory> */

--- a/app/Models/ReservationReply.php
+++ b/app/Models/ReservationReply.php
@@ -3,11 +3,14 @@
 namespace App\Models;
 
 use App\Enums\ReservationReplyStatus;
+use App\Models\Scopes\RestaurantScope;
 use Database\Factories\ReservationReplyFactory;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+#[ScopedBy(RestaurantScope::class)]
 class ReservationReply extends Model
 {
     /** @use HasFactory<ReservationReplyFactory> */

--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -4,13 +4,16 @@ namespace App\Models;
 
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
+use App\Models\Scopes\RestaurantScope;
 use Database\Factories\ReservationRequestFactory;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
+#[ScopedBy(RestaurantScope::class)]
 class ReservationRequest extends Model
 {
     /** @use HasFactory<ReservationRequestFactory> */

--- a/app/Models/Scopes/RestaurantScope.php
+++ b/app/Models/Scopes/RestaurantScope.php
@@ -21,7 +21,7 @@ final class RestaurantScope implements Scope
         $restaurantId = Auth::user()?->restaurant_id;
 
         if ($restaurantId === null) {
-            $builder->whereRaw('1 = 0');
+            $builder->whereIn($model->qualifyColumn($model->getKeyName()), []);
 
             return;
         }

--- a/app/Models/Scopes/RestaurantScope.php
+++ b/app/Models/Scopes/RestaurantScope.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Scopes;
+
+use App\Models\ReservationReply;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+use Illuminate\Support\Facades\Auth;
+
+final class RestaurantScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        if (! Auth::hasUser()) {
+            return;
+        }
+
+        $restaurantId = Auth::user()?->restaurant_id;
+
+        if ($restaurantId === null) {
+            $builder->whereRaw('1 = 0');
+
+            return;
+        }
+
+        if ($model instanceof ReservationReply) {
+            $builder->whereHas(
+                'reservationRequest',
+                fn (Builder $query) => $query->where('restaurant_id', $restaurantId)
+            );
+
+            return;
+        }
+
+        $builder->where($model->qualifyColumn('restaurant_id'), $restaurantId);
+    }
+}

--- a/tests/Feature/Models/Scopes/RestaurantScopeTest.php
+++ b/tests/Feature/Models/Scopes/RestaurantScopeTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Tests\Feature\Models\Scopes;
+
+use App\Models\FailedEmailImport;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\Scopes\RestaurantScope;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RestaurantScopeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_sees_only_reservation_requests_of_own_restaurant(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $userA = User::factory()->forRestaurant($restaurantA)->create();
+
+        $ownRequest = ReservationRequest::factory()->forRestaurant($restaurantA)->create();
+        $foreignRequest = ReservationRequest::factory()->forRestaurant($restaurantB)->create();
+
+        $this->actingAs($userA);
+
+        $ids = ReservationRequest::query()->pluck('id')->all();
+
+        $this->assertContains($ownRequest->id, $ids);
+        $this->assertNotContains($foreignRequest->id, $ids);
+    }
+
+    public function test_authenticated_user_cannot_find_foreign_reservation_request_by_primary_key(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $userA = User::factory()->forRestaurant($restaurantA)->create();
+
+        $foreignRequest = ReservationRequest::factory()->forRestaurant($restaurantB)->create();
+
+        $this->actingAs($userA);
+
+        $this->assertNull(ReservationRequest::query()->find($foreignRequest->id));
+    }
+
+    public function test_authenticated_user_sees_only_failed_email_imports_of_own_restaurant(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $userA = User::factory()->forRestaurant($restaurantA)->create();
+
+        $ownImport = FailedEmailImport::factory()->forRestaurant($restaurantA)->create();
+        $foreignImport = FailedEmailImport::factory()->forRestaurant($restaurantB)->create();
+
+        $this->actingAs($userA);
+
+        $ids = FailedEmailImport::query()->pluck('id')->all();
+
+        $this->assertContains($ownImport->id, $ids);
+        $this->assertNotContains($foreignImport->id, $ids);
+    }
+
+    public function test_authenticated_user_sees_only_reservation_replies_belonging_to_own_restaurant(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $userA = User::factory()->forRestaurant($restaurantA)->create();
+
+        $ownRequest = ReservationRequest::factory()->forRestaurant($restaurantA)->create();
+        $foreignRequest = ReservationRequest::factory()->forRestaurant($restaurantB)->create();
+
+        $ownReply = ReservationReply::factory()->forReservationRequest($ownRequest)->create();
+        $foreignReply = ReservationReply::factory()->forReservationRequest($foreignRequest)->create();
+
+        $this->actingAs($userA);
+
+        $ids = ReservationReply::query()->pluck('id')->all();
+
+        $this->assertContains($ownReply->id, $ids);
+        $this->assertNotContains($foreignReply->id, $ids);
+    }
+
+    public function test_unauthenticated_context_bypasses_the_scope_on_all_tenant_models(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+
+        ReservationRequest::factory()->forRestaurant($restaurantA)->create();
+        $requestB = ReservationRequest::factory()->forRestaurant($restaurantB)->create();
+        FailedEmailImport::factory()->forRestaurant($restaurantA)->create();
+        FailedEmailImport::factory()->forRestaurant($restaurantB)->create();
+        ReservationReply::factory()->forReservationRequest($requestB)->create();
+
+        $this->assertGuest();
+
+        $this->assertSame(2, ReservationRequest::query()->count());
+        $this->assertSame(2, FailedEmailImport::query()->count());
+        $this->assertSame(1, ReservationReply::query()->count());
+    }
+
+    public function test_without_global_scope_returns_all_records_for_internal_use(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $userA = User::factory()->forRestaurant($restaurantA)->create();
+
+        ReservationRequest::factory()->forRestaurant($restaurantA)->create();
+        ReservationRequest::factory()->forRestaurant($restaurantB)->create();
+
+        $this->actingAs($userA);
+
+        $this->assertSame(1, ReservationRequest::query()->count());
+        $this->assertSame(
+            2,
+            ReservationRequest::query()->withoutGlobalScope(RestaurantScope::class)->count()
+        );
+    }
+
+    public function test_authenticated_user_without_restaurant_id_sees_no_records_fail_safe(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $orphanUser = User::factory()->create(['restaurant_id' => null]);
+
+        ReservationRequest::factory()->forRestaurant($restaurantA)->create();
+        ReservationRequest::factory()->forRestaurant($restaurantB)->create();
+
+        $this->actingAs($orphanUser);
+
+        $this->assertSame(0, ReservationRequest::query()->count());
+        $this->assertSame(0, FailedEmailImport::query()->count());
+    }
+
+    public function test_scope_filters_cross_tenant_even_when_counting_with_joins(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $userA = User::factory()->forRestaurant($restaurantA)->create();
+
+        ReservationRequest::factory()->forRestaurant($restaurantA)->count(3)->create();
+        ReservationRequest::factory()->forRestaurant($restaurantB)->count(5)->create();
+
+        $this->actingAs($userA);
+
+        $this->assertSame(3, ReservationRequest::query()->count());
+    }
+}


### PR DESCRIPTION
## Summary
- New `App\Models\Scopes\RestaurantScope` applies `where restaurant_id = <auth user's restaurant_id>` when a user is authenticated.
- Attached via `#[ScopedBy]` attribute to `ReservationRequest`, `ReservationReply` and `FailedEmailImport`.
- `ReservationReply` has no direct `restaurant_id` column — filtered relationally via `whereHas('reservationRequest', …)` so the schema stays normalized.
- Unauthenticated context (queue workers, console commands, public routes) bypasses the scope — CLAUDE.md requirement for queues and the public reservation endpoint.
- Fail-safe: an authenticated user with `restaurant_id = null` returns zero rows (`1 = 0`) instead of leaking cross-tenant data.
- `withoutGlobalScope(RestaurantScope::class)` remains available for internal admin/platform queries.

## Why
Acceptance criterion from PRD-001 / Issue #10: owner A must never see or load records of restaurant B, even through a direct Eloquent query. Enforcing this centrally in a global scope replaces ad-hoc `where('restaurant_id', auth()->user()->restaurant_id)` calls in controllers — which CLAUDE.md explicitly forbids ("Tenant-Scope gehört in Policies und globale Eloquent Scopes").

## Test plan
- `php artisan test --filter=RestaurantScopeTest` — 8 new tests covering:
  - per-model tenant isolation (requests, replies, failed imports)
  - direct primary-key lookup across tenants returns null
  - unauthenticated bypass across all three models
  - `withoutGlobalScope` escape hatch
  - orphan user (no `restaurant_id`) sees no records
  - scope survives aggregations (`count()`)
- `php artisan test` — full suite green (127 tests, 263 assertions).
- `./vendor/bin/pint --test` — pass.
- `npm run lint && npm run format:check` — clean.

Closes #10