### PR TITLE
Add tenant authorization policies (#11)

### DIFF
--- a/app/Policies/ReservationRequestPolicy.php
+++ b/app/Policies/ReservationRequestPolicy.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\ReservationRequest;
+use App\Models\User;
+
+final class ReservationRequestPolicy
+{
+    public function view(User $user, ReservationRequest $request): bool
+    {
+        return $user->restaurant_id === $request->restaurant_id;
+    }
+
+    public function update(User $user, ReservationRequest $request): bool
+    {
+        return $user->restaurant_id === $request->restaurant_id;
+    }
+
+    public function delete(User $user, ReservationRequest $request): bool
+    {
+        return $user->restaurant_id === $request->restaurant_id;
+    }
+
+    public function bulkUpdate(User $user): bool
+    {
+        return $user->restaurant_id !== null;
+    }
+}

--- a/app/Policies/RestaurantPolicy.php
+++ b/app/Policies/RestaurantPolicy.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\User;
+
+final class RestaurantPolicy
+{
+    public function view(User $user, Restaurant $restaurant): bool
+    {
+        return $user->restaurant_id === $restaurant->id;
+    }
+
+    public function update(User $user, Restaurant $restaurant): bool
+    {
+        return $user->restaurant_id === $restaurant->id;
+    }
+
+    public function manage(User $user, Restaurant $restaurant): bool
+    {
+        return $user->restaurant_id === $restaurant->id
+            && $user->role === UserRole::Owner;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers;
+
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Policies\ReservationRequestPolicy;
+use App\Policies\RestaurantPolicy;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\ServiceProvider;
+
+final class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * @var array<class-string, class-string>
+     */
+    public static array $policies = [
+        Restaurant::class => RestaurantPolicy::class,
+        ReservationRequest::class => ReservationRequestPolicy::class,
+    ];
+
+    public function boot(): void
+    {
+        foreach (self::$policies as $model => $policy) {
+            Gate::policy($model, $policy);
+        }
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Providers\AppServiceProvider;
+use App\Providers\AuthServiceProvider;
 
 return [
     AppServiceProvider::class,
+    AuthServiceProvider::class,
 ];

--- a/tests/Feature/Policies/ReservationRequestPolicyTest.php
+++ b/tests/Feature/Policies/ReservationRequestPolicyTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature\Policies;
+
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Policies\ReservationRequestPolicy;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+class ReservationRequestPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_policy_is_registered_in_auth_service_provider(): void
+    {
+        $this->assertSame(
+            ReservationRequestPolicy::class,
+            AuthServiceProvider::$policies[ReservationRequest::class] ?? null
+        );
+
+        $this->assertInstanceOf(
+            ReservationRequestPolicy::class,
+            Gate::getPolicyFor(ReservationRequest::class)
+        );
+    }
+
+    public function test_member_of_restaurant_may_view_own_request(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertTrue($user->can('view', $request));
+    }
+
+    public function test_foreign_user_may_not_view_request(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+        $foreignRequest = ReservationRequest::factory()->forRestaurant($foreign)->create();
+
+        $this->assertFalse($user->can('view', $foreignRequest));
+    }
+
+    public function test_member_of_restaurant_may_update_own_request(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertTrue($user->can('update', $request));
+    }
+
+    public function test_foreign_user_may_not_update_request(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+        $foreignRequest = ReservationRequest::factory()->forRestaurant($foreign)->create();
+
+        $this->assertFalse($user->can('update', $foreignRequest));
+    }
+
+    public function test_member_of_restaurant_may_delete_own_request(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertTrue($user->can('delete', $request));
+    }
+
+    public function test_foreign_user_may_not_delete_request(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+        $foreignRequest = ReservationRequest::factory()->forRestaurant($foreign)->create();
+
+        $this->assertFalse($user->can('delete', $foreignRequest));
+    }
+
+    public function test_user_with_restaurant_may_bulk_update(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertTrue($user->can('bulkUpdate', ReservationRequest::class));
+    }
+
+    public function test_orphan_user_without_restaurant_may_not_bulk_update(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $this->assertFalse($user->can('bulkUpdate', ReservationRequest::class));
+    }
+
+    public function test_authorize_throws_authorization_exception_for_foreign_request_access(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+        $foreignRequest = ReservationRequest::factory()->forRestaurant($foreign)->create();
+
+        $this->expectException(AuthorizationException::class);
+
+        Gate::forUser($user)->authorize('view', $foreignRequest);
+    }
+}

--- a/tests/Feature/Policies/RestaurantPolicyTest.php
+++ b/tests/Feature/Policies/RestaurantPolicyTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\Policies;
+
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Policies\RestaurantPolicy;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+class RestaurantPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_policy_is_registered_in_auth_service_provider(): void
+    {
+        $this->assertSame(
+            RestaurantPolicy::class,
+            AuthServiceProvider::$policies[Restaurant::class] ?? null
+        );
+
+        $this->assertInstanceOf(
+            RestaurantPolicy::class,
+            Gate::getPolicyFor(Restaurant::class)
+        );
+    }
+
+    public function test_member_of_restaurant_may_view_it(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertTrue($user->can('view', $restaurant));
+    }
+
+    public function test_foreign_user_may_not_view_restaurant(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+
+        $this->assertFalse($user->can('view', $foreign));
+    }
+
+    public function test_member_of_restaurant_may_update_it(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->assertTrue($user->can('update', $restaurant));
+    }
+
+    public function test_foreign_user_may_not_update_restaurant(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+
+        $this->assertFalse($user->can('update', $foreign));
+    }
+
+    public function test_owner_of_restaurant_may_manage_it(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()
+            ->forRestaurant($restaurant)
+            ->create(['role' => UserRole::Owner]);
+
+        $this->assertTrue($owner->can('manage', $restaurant));
+    }
+
+    public function test_staff_member_may_not_manage_own_restaurant(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $staff = User::factory()
+            ->forRestaurant($restaurant)
+            ->create(['role' => UserRole::Staff]);
+
+        $this->assertFalse($staff->can('manage', $restaurant));
+    }
+
+    public function test_owner_of_other_restaurant_may_not_manage_foreign_restaurant(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $foreignOwner = User::factory()
+            ->forRestaurant($home)
+            ->create(['role' => UserRole::Owner]);
+
+        $this->assertFalse($foreignOwner->can('manage', $foreign));
+    }
+
+    public function test_authorize_throws_authorization_exception_for_foreign_access(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+
+        $this->expectException(AuthorizationException::class);
+
+        Gate::forUser($user)->authorize('view', $foreign);
+    }
+}


### PR DESCRIPTION
## Summary
- `App\Policies\RestaurantPolicy` with `view`, `update`, `manage` — `manage` requires `UserRole::Owner` **and** same-restaurant membership.
- `App\Policies\ReservationRequestPolicy` with `view`, `update`, `delete`, `bulkUpdate`. `bulkUpdate` is class-level and only allows users who belong to a restaurant; per-item tenancy is then enforced via `update` inside the bulk handler.
- `App\Providers\AuthServiceProvider` with a public static `\$policies` array and `Gate::policy()` registration in `boot()`. Registered in `bootstrap/providers.php`.
- 19 new feature tests covering same-tenant allowed, cross-tenant denied, staff/owner distinction for `manage`, policy registration, and `AuthorizationException` (→ 403) on foreign access.

## Why
Global scope (PR #102) filters queries. It does NOT cover cases where the scope is bypassed — `withoutGlobalScope`, console, queue, public routes — nor write-side concerns like \"may this user actually *manage* this restaurant?\". Policies are the explicit per-action guard; the scope is defense-in-depth. CLAUDE.md: *\"niemals \`where('restaurant_id', auth()->user()->restaurant_id)\` im Controller\"* — this is how we avoid that.

## Test plan
- `php artisan test --filter=Policies` — 19 tests green.
- `php artisan test` — full suite 146 tests / 284 assertions.
- `./vendor/bin/pint --test` — pass.
- `npm run lint && npm run format:check` — clean.

Closes #11