### PR TITLE
Seed demo tenant for local development (#12)

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,22 +2,100 @@
 
 namespace Database\Seeders;
 
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Enums\Tonality;
+use App\Enums\UserRole;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
 use App\Models\User;
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
 
 class DatabaseSeeder extends Seeder
 {
     /**
-     * Seed the application's database.
+     * Seed a deterministic demo tenant for local development.
+     *
+     * Idempotent: re-running the seeder reuses the existing restaurant, owner
+     * and reservations (matched by slug / email / guest_email + desired_at).
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $restaurant = Restaurant::firstOrCreate(
+            ['slug' => 'demo-restaurant'],
+            [
+                'name' => 'Demo Restaurant',
+                'timezone' => 'Europe/Berlin',
+                'capacity' => 40,
+                'opening_hours' => [
+                    'mon' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '22:30']],
+                    'tue' => [],
+                    'wed' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '22:30']],
+                    'thu' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '22:30']],
+                    'fri' => [['from' => '11:30', 'to' => '14:30'], ['from' => '18:00', 'to' => '23:00']],
+                    'sat' => [['from' => '18:00', 'to' => '23:00']],
+                    'sun' => [['from' => '11:30', 'to' => '15:00']],
+                ],
+                'tonality' => Tonality::Casual,
+            ]
+        );
 
-        User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
-        ]);
+        User::firstOrCreate(
+            ['email' => 'owner@demo.test'],
+            [
+                'name' => 'Demo Owner',
+                'password' => Hash::make('password'),
+                'email_verified_at' => now(),
+                'restaurant_id' => $restaurant->id,
+                'role' => UserRole::Owner,
+            ]
+        );
+
+        $demoRequests = [
+            [
+                'status' => ReservationStatus::New,
+                'guest_name' => 'Anna Becker',
+                'guest_email' => 'anna.becker@demo.test',
+                'party_size' => 2,
+                'desired_at' => now()->addDays(1)->setTime(19, 0),
+                'message' => 'Gern am Fenster, falls möglich.',
+            ],
+            [
+                'status' => ReservationStatus::InReview,
+                'guest_name' => 'Familie Huber',
+                'guest_email' => 'familie.huber@demo.test',
+                'party_size' => 5,
+                'desired_at' => now()->addDays(3)->setTime(18, 30),
+                'message' => 'Kinderstuhl benötigt.',
+            ],
+            [
+                'status' => ReservationStatus::Confirmed,
+                'guest_name' => 'Klaus Schmidt',
+                'guest_email' => 'klaus.schmidt@demo.test',
+                'party_size' => 4,
+                'desired_at' => now()->addDays(7)->setTime(20, 0),
+                'message' => null,
+            ],
+        ];
+
+        foreach ($demoRequests as $data) {
+            $exists = ReservationRequest::query()
+                ->withoutGlobalScopes()
+                ->where('restaurant_id', $restaurant->id)
+                ->where('guest_email', $data['guest_email'])
+                ->exists();
+
+            if ($exists) {
+                continue;
+            }
+
+            ReservationRequest::factory()
+                ->forRestaurant($restaurant)
+                ->create([
+                    ...$data,
+                    'source' => ReservationSource::WebForm,
+                ]);
+        }
     }
 }

--- a/tests/Feature/Seeders/DatabaseSeederTest.php
+++ b/tests/Feature/Seeders/DatabaseSeederTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Enums\ReservationStatus;
+use App\Enums\UserRole;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class DatabaseSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_seeder_creates_a_demo_restaurant_with_opening_hours(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+
+        $restaurant = Restaurant::query()->where('slug', 'demo-restaurant')->sole();
+
+        $this->assertSame('Demo Restaurant', $restaurant->name);
+        $this->assertSame('Europe/Berlin', $restaurant->timezone);
+        $this->assertIsArray($restaurant->opening_hours);
+        $this->assertArrayHasKey('mon', $restaurant->opening_hours);
+        $this->assertSame([], $restaurant->opening_hours['tue'], 'Tuesday should be a rest day');
+    }
+
+    public function test_seeder_creates_owner_user_with_known_password(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+
+        $owner = User::query()->where('email', 'owner@demo.test')->sole();
+        $restaurant = Restaurant::query()->where('slug', 'demo-restaurant')->sole();
+
+        $this->assertSame($restaurant->id, $owner->restaurant_id);
+        $this->assertSame(UserRole::Owner, $owner->role);
+        $this->assertTrue(Hash::check('password', $owner->password));
+        $this->assertNotNull($owner->email_verified_at);
+    }
+
+    public function test_seeder_creates_three_reservations_in_different_statuses(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+
+        $restaurant = Restaurant::query()->where('slug', 'demo-restaurant')->sole();
+
+        $requests = ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->where('restaurant_id', $restaurant->id)
+            ->get();
+
+        $this->assertCount(3, $requests);
+        $this->assertEqualsCanonicalizing(
+            [
+                ReservationStatus::New->value,
+                ReservationStatus::InReview->value,
+                ReservationStatus::Confirmed->value,
+            ],
+            $requests->pluck('status')->map(fn (ReservationStatus $s) => $s->value)->all()
+        );
+    }
+
+    public function test_seeder_is_idempotent_on_reruns(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+        $this->seed(DatabaseSeeder::class);
+
+        $this->assertSame(1, Restaurant::query()->where('slug', 'demo-restaurant')->count());
+        $this->assertSame(1, User::query()->where('email', 'owner@demo.test')->count());
+
+        $restaurant = Restaurant::query()->where('slug', 'demo-restaurant')->sole();
+
+        $this->assertSame(
+            3,
+            ReservationRequest::query()
+                ->withoutGlobalScopes()
+                ->where('restaurant_id', $restaurant->id)
+                ->count()
+        );
+    }
+
+    public function test_seeder_does_not_leak_between_restaurants_via_guest_email_match(): void
+    {
+        $other = Restaurant::factory()->create(['slug' => 'other']);
+        ReservationRequest::factory()
+            ->forRestaurant($other)
+            ->create(['guest_email' => 'anna.becker@demo.test']);
+
+        $this->seed(DatabaseSeeder::class);
+
+        $demo = Restaurant::query()->where('slug', 'demo-restaurant')->sole();
+
+        $this->assertSame(
+            3,
+            ReservationRequest::query()
+                ->withoutGlobalScopes()
+                ->where('restaurant_id', $demo->id)
+                ->count()
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `DatabaseSeeder` now provisions a deterministic demo tenant:
  - Restaurant: **Demo Restaurant** (slug \`demo-restaurant\`, Europe/Berlin, Tue as rest day, capacity 40).
  - Owner user: **owner@demo.test** / password \`password\`, role Owner, email pre-verified — can log in after seeding with no extra steps.
  - 3 reservation requests covering statuses **new**, **in_review**, **confirmed** with realistic guest data and future \`desired_at\`.
- All factories already satisfied the criterion: \`RestaurantFactory\` has realistic opening hours, \`UserFactory::forRestaurant(…)\` exists, \`ReservationRequestFactory\` has \`inReview()\` and \`confirmed()\` states (\`new\` is the default status — no \`new()\` method because \`Illuminate\Database\Eloquent\Factories\Factory::new()\` is static and can't be overridden).

## Why
Without deterministic seed data, every new developer had to manually create a restaurant, a user, and sample reservations before they could exercise the dashboard. Running \`php artisan migrate:fresh --seed\` now yields a ready-to-use tenant in one command.

## Idempotency
\`firstOrCreate\` on \`slug\`/\`email\` plus a per-restaurant \`guest_email\` \`exists()\` check on reservations means \`db:seed\` can run repeatedly (with or without \`migrate:fresh\`) without duplicating rows. The exists-check uses \`withoutGlobalScopes()\` so the new \`RestaurantScope\` can't mask an existing row if seeding ever runs in an authenticated context.

## Test plan
- \`php artisan test --filter=DatabaseSeederTest\` — 5 tests: restaurant shape, owner credentials, three statuses present, idempotency over 3 reruns, no leakage across tenants via matching guest_email.
- \`php artisan migrate:fresh --seed\` — ran locally, completes cleanly.
- \`php artisan test\` — full suite green (151 tests, 299 assertions).
- \`./vendor/bin/pint --test\` — pass.
- \`npm run lint && npm run format:check\` — clean.

Closes #12