### PR TITLE
Dashboard shell page with restaurant greeting (#13)

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Middleware;
 
+use App\Models\Restaurant;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Http\Request;
 use Inertia\Middleware;
@@ -38,13 +39,24 @@ class HandleInertiaRequests extends Middleware
     {
         [$message, $author] = str(Inspiring::quotes()->random())->explode('-');
 
+        $user = $request->user();
+        $restaurant = $user?->restaurant;
+
         return array_merge(parent::share($request), [
             ...parent::share($request),
             'name' => config('app.name'),
             'quote' => ['message' => trim($message), 'author' => trim($author)],
             'auth' => [
-                'user' => $request->user(),
+                'user' => $user,
             ],
+            'restaurant' => $restaurant instanceof Restaurant
+                ? [
+                    'id' => $restaurant->id,
+                    'name' => $restaurant->name,
+                    'timezone' => $restaurant->timezone,
+                    'tonality' => $restaurant->tonality,
+                ]
+                : null,
         ]);
     }
 }

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -1,31 +1,22 @@
 <script setup lang="ts">
-import NavFooter from '@/components/NavFooter.vue';
 import NavMain from '@/components/NavMain.vue';
 import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
-import { BookOpen, Folder, LayoutGrid } from 'lucide-vue-next';
+import { CalendarClock, Settings } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
 const mainNavItems: NavItem[] = [
     {
-        title: 'Dashboard',
+        title: 'Reservierungen',
         href: '/dashboard',
-        icon: LayoutGrid,
-    },
-];
-
-const footerNavItems: NavItem[] = [
-    {
-        title: 'Github Repo',
-        href: 'https://github.com/laravel/vue-starter-kit',
-        icon: Folder,
+        icon: CalendarClock,
     },
     {
-        title: 'Documentation',
-        href: 'https://laravel.com/docs/starter-kits',
-        icon: BookOpen,
+        title: 'Einstellungen',
+        href: '/settings/profile',
+        icon: Settings,
     },
 ];
 </script>
@@ -49,7 +40,6 @@ const footerNavItems: NavItem[] = [
         </SidebarContent>
 
         <SidebarFooter>
-            <NavFooter :items="footerNavItems" />
             <NavUser />
         </SidebarFooter>
     </Sidebar>

--- a/resources/js/components/NavMain.vue
+++ b/resources/js/components/NavMain.vue
@@ -6,7 +6,7 @@ import type { Component } from 'vue';
 
 interface NavItem {
     title: string;
-    url: string;
+    href: string;
     icon: Component;
 }
 
@@ -22,8 +22,8 @@ const page = usePage<SharedData>();
         <SidebarGroupLabel>Platform</SidebarGroupLabel>
         <SidebarMenu>
             <SidebarMenuItem v-for="item in items" :key="item.title">
-                <SidebarMenuButton as-child :is-active="item.url === page.url">
-                    <Link :href="item.url">
+                <SidebarMenuButton as-child :is-active="item.href === page.url">
+                    <Link :href="item.href">
                         <component :is="item.icon" />
                         <span>{{ item.title }}</span>
                     </Link>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import AppLayout from '@/layouts/AppLayout.vue';
-import { type BreadcrumbItem } from '@/types';
-import { Head } from '@inertiajs/vue3';
-import PlaceholderPattern from '../components/PlaceholderPattern.vue';
+import { type BreadcrumbItem, type SharedData } from '@/types';
+import { Head, usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
 
 const breadcrumbs: BreadcrumbItem[] = [
     {
@@ -11,30 +11,29 @@ const breadcrumbs: BreadcrumbItem[] = [
     },
 ];
 
-defineProps<{
-    name?: string;
-}>();
+const page = usePage<SharedData>();
+const restaurantName = computed(() => page.props.restaurant?.name ?? '');
 </script>
 
 <template>
     <Head title="Dashboard" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="flex h-full flex-1 flex-col gap-4 rounded-xl p-4">
-            <div class="grid auto-rows-min gap-4 md:grid-cols-3">
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-                <div class="relative aspect-video overflow-hidden rounded-xl border border-sidebar-border/70 dark:border-sidebar-border">
-                    <PlaceholderPattern />
-                </div>
-            </div>
-            <div class="relative min-h-[100vh] flex-1 rounded-xl border border-sidebar-border/70 dark:border-sidebar-border md:min-h-min">
-                <PlaceholderPattern />
-            </div>
+        <div class="flex h-full flex-1 flex-col gap-6 p-6">
+            <header data-testid="restaurant-header">
+                <h1 class="text-2xl font-semibold tracking-tight">
+                    {{ restaurantName }}
+                </h1>
+                <p class="text-sm text-muted-foreground">Willkommen im Reservierungs-Dashboard.</p>
+            </header>
+
+            <section
+                data-testid="reservations-empty-state"
+                class="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-sidebar-border/70 p-12 text-center dark:border-sidebar-border"
+            >
+                <p class="text-lg font-medium">Noch keine Reservierungen</p>
+                <p class="mt-1 text-sm text-muted-foreground">Sobald eine Anfrage eingeht, erscheint sie hier.</p>
+            </section>
         </div>
     </AppLayout>
 </template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -20,6 +20,7 @@ export interface SharedData {
     name: string;
     quote: { message: string; author: string };
     auth: Auth;
+    restaurant: Restaurant | null;
     ziggy: {
         location: string;
         url: string;
@@ -29,12 +30,23 @@ export interface SharedData {
     };
 }
 
+export interface Restaurant {
+    id: number;
+    name: string;
+    timezone: string;
+    tonality: 'formal' | 'casual' | 'family';
+}
+
+export type UserRole = 'owner' | 'staff';
+
 export interface User {
     id: number;
     name: string;
     email: string;
     avatar?: string;
     email_verified_at: string | null;
+    restaurant_id: number | null;
+    role: UserRole;
     created_at: string;
     updated_at: string;
 }

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -2,26 +2,82 @@
 
 namespace Tests\Feature;
 
+use App\Models\Restaurant;
 use App\Models\User;
+use Database\Seeders\DatabaseSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
 class DashboardTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_guests_are_redirected_to_the_login_page()
+    public function test_guests_are_redirected_to_the_login_page(): void
     {
         $response = $this->get('/dashboard');
+
         $response->assertRedirect('/login');
     }
 
-    public function test_authenticated_users_can_visit_the_dashboard()
+    public function test_authenticated_user_lands_on_dashboard_page(): void
     {
         $user = User::factory()->create();
+
         $this->actingAs($user);
 
-        $response = $this->get('/dashboard');
-        $response->assertStatus(200);
+        $this->get('/dashboard')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Dashboard'));
+    }
+
+    public function test_dashboard_receives_restaurant_name_via_shared_props(): void
+    {
+        $restaurant = Restaurant::factory()->create(['name' => 'Trattoria Testa']);
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($user);
+
+        $this->get('/dashboard')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->where('restaurant.id', $restaurant->id)
+                ->where('restaurant.name', 'Trattoria Testa')
+                ->where('restaurant.timezone', $restaurant->timezone)
+                ->etc()
+            );
+    }
+
+    public function test_user_without_restaurant_receives_null_restaurant_prop(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $this->actingAs($user);
+
+        $this->get('/dashboard')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->where('restaurant', null)
+            );
+    }
+
+    public function test_seeded_demo_owner_can_login_and_reach_dashboard_with_restaurant_name(): void
+    {
+        $this->seed(DatabaseSeeder::class);
+
+        $this->post('/login', [
+            'email' => 'owner@demo.test',
+            'password' => 'password',
+        ])->assertRedirect('/dashboard');
+
+        $this->get('/dashboard')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->where('restaurant.name', 'Demo Restaurant')
+                ->etc()
+            );
     }
 }


### PR DESCRIPTION
## Summary
- \`HandleInertiaRequests::share()\` now exposes a \`restaurant\` prop (\`id\`, \`name\`, \`timezone\`, \`tonality\`) loaded from the authenticated user's restaurant. Null when the user has no restaurant or is a guest.
- \`resources/js/pages/Dashboard.vue\` replaces the starter-kit placeholder grid. It now renders the restaurant name in a page header and a \"Noch keine Reservierungen\" empty state. Real listing comes in PRD-004.
- \`AppSidebar\` nav items reduced to what V1.0 actually offers: **Reservierungen** → \`/dashboard\`, **Einstellungen** → \`/settings/profile\`. Logout stays in the NavUser dropdown (sidebar footer) — it already posts to the named \`logout\` route.
- TypeScript: new \`Restaurant\` interface, \`SharedData.restaurant\`, \`User.restaurant_id\` / \`User.role\`.

## Drive-by fix
\`NavMain\` declared a locally shadowed \`NavItem\` interface using \`url\`, but \`AppSidebar\` passes items with \`href\` (matching the shared \`NavItem\` type). The template bound \`:href=\"item.url\"\` — all sidebar links were rendering an empty href. Renaming to \`href\` fixes the real navigation. Directly in scope of this issue because I rewrote the sidebar items.

## Why
Authenticated users need a landing page that reflects their tenant. Sharing the restaurant as an Inertia shared prop means every future page (including settings and forthcoming reservation detail pages) can show the restaurant context without duplicating load logic in controllers.

## Test plan
- \`php artisan test --filter=DashboardTest\` — 5 tests:
  - guest redirected to /login
  - authenticated user reaches Dashboard component
  - restaurant prop is populated with id/name/timezone when user belongs to a restaurant
  - restaurant prop is null for user without a restaurant
  - seeded demo owner can log in with \`owner@demo.test\` / \`password\` and reach the dashboard with restaurant name \"Demo Restaurant\"
- \`php artisan test\` — full suite green (154 tests / 350 assertions)
- \`./vendor/bin/pint --test\`, \`npm run lint\`, \`npm run format:check\`, \`npm run build\` — all clean

Closes #13