### PR TITLE
Reservation show controller with tenant-aware 403 (#107)

### DIFF
--- a/app/Http/Controllers/ReservationRequestController.php
+++ b/app/Http/Controllers/ReservationRequestController.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\ReservationRequest;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class ReservationRequestController extends Controller
+{
+    public function show(int $reservation): Response
+    {
+        $reservationRequest = ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->findOrFail($reservation);
+
+        Gate::authorize('view', $reservationRequest);
+
+        return Inertia::render('Reservations/Show', [
+            'reservation' => [
+                'id' => $reservationRequest->id,
+                'guest_name' => $reservationRequest->guest_name,
+                'guest_email' => $reservationRequest->guest_email,
+                'party_size' => $reservationRequest->party_size,
+                'desired_at' => $reservationRequest->desired_at?->toIso8601String(),
+                'status' => $reservationRequest->status->value,
+                'source' => $reservationRequest->source->value,
+                'message' => $reservationRequest->message,
+            ],
+        ]);
+    }
+}

--- a/resources/js/pages/Reservations/Show.vue
+++ b/resources/js/pages/Reservations/Show.vue
@@ -1,0 +1,62 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Head } from '@inertiajs/vue3';
+
+interface ReservationProp {
+    id: number;
+    guest_name: string;
+    guest_email: string;
+    party_size: number;
+    desired_at: string | null;
+    status: string;
+    source: string;
+    message: string | null;
+}
+
+defineProps<{
+    reservation: ReservationProp;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Dashboard', href: '/dashboard' },
+    { title: 'Reservierung', href: '#' },
+];
+</script>
+
+<template>
+    <Head :title="`Reservierung #${reservation.id}`" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="flex h-full flex-1 flex-col gap-6 p-6" data-testid="reservation-detail">
+            <header>
+                <h1 class="text-2xl font-semibold tracking-tight">Reservierung #{{ reservation.id }}</h1>
+                <p class="text-sm text-muted-foreground">{{ reservation.guest_name }} · {{ reservation.party_size }} Personen</p>
+            </header>
+
+            <dl class="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div>
+                    <dt class="text-sm text-muted-foreground">Status</dt>
+                    <dd class="font-medium">{{ reservation.status }}</dd>
+                </div>
+                <div>
+                    <dt class="text-sm text-muted-foreground">Quelle</dt>
+                    <dd class="font-medium">{{ reservation.source }}</dd>
+                </div>
+                <div>
+                    <dt class="text-sm text-muted-foreground">E-Mail</dt>
+                    <dd class="font-medium">{{ reservation.guest_email }}</dd>
+                </div>
+                <div>
+                    <dt class="text-sm text-muted-foreground">Wunschzeit</dt>
+                    <dd class="font-medium">{{ reservation.desired_at ?? '—' }}</dd>
+                </div>
+            </dl>
+
+            <section v-if="reservation.message">
+                <h2 class="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Nachricht</h2>
+                <p class="whitespace-pre-line text-sm">{{ reservation.message }}</p>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -3,6 +3,12 @@ declare module 'ziggy-js' {
   interface RouteList {
     "home": [],
     "dashboard": [],
+    "reservations.show": [
+        {
+            "name": "reservation",
+            "required": true
+        }
+    ],
     "profile.edit": [],
     "profile.update": [],
     "profile.destroy": [],

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\ReservationRequestController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -10,6 +11,11 @@ Route::get('/', function () {
 Route::get('dashboard', function () {
     return Inertia::render('Dashboard');
 })->middleware(['auth', 'verified'])->name('dashboard');
+
+Route::get('reservations/{reservation}', [ReservationRequestController::class, 'show'])
+    ->whereNumber('reservation')
+    ->middleware(['auth', 'verified'])
+    ->name('reservations.show');
 
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';

--- a/tests/Feature/ReservationRequestShowTest.php
+++ b/tests/Feature/ReservationRequestShowTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class ReservationRequestShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_guests_are_redirected_to_the_login_page(): void
+    {
+        $reservation = ReservationRequest::factory()
+            ->forRestaurant(Restaurant::factory()->create())
+            ->create();
+
+        $this->get("/reservations/{$reservation->id}")
+            ->assertRedirect('/login');
+    }
+
+    public function test_member_of_restaurant_sees_own_reservation(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $reservation = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['guest_name' => 'Alice Example']);
+
+        $this->actingAs($user);
+
+        $this->get("/reservations/{$reservation->id}")
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Reservations/Show')
+                ->where('reservation.id', $reservation->id)
+                ->where('reservation.guest_name', 'Alice Example')
+                ->where('reservation.status', $reservation->status->value)
+                ->where('reservation.source', $reservation->source->value)
+                ->etc()
+            );
+    }
+
+    public function test_foreign_tenant_reservation_returns_403_not_404(): void
+    {
+        [$restaurantA, $restaurantB] = Restaurant::factory()->count(2)->create();
+        $userA = User::factory()->forRestaurant($restaurantA)->create();
+        $foreignReservation = ReservationRequest::factory()
+            ->forRestaurant($restaurantB)
+            ->create();
+
+        $this->actingAs($userA);
+
+        $this->get("/reservations/{$foreignReservation->id}")
+            ->assertForbidden();
+    }
+
+    public function test_unknown_id_returns_404(): void
+    {
+        $user = User::factory()->forRestaurant(Restaurant::factory()->create())->create();
+
+        $this->actingAs($user);
+
+        $this->get('/reservations/999999')
+            ->assertNotFound();
+    }
+
+    public function test_user_without_restaurant_cannot_view_any_reservation(): void
+    {
+        $reservation = ReservationRequest::factory()
+            ->forRestaurant(Restaurant::factory()->create())
+            ->create();
+        $orphan = User::factory()->create(['restaurant_id' => null]);
+
+        $this->actingAs($orphan);
+
+        $this->get("/reservations/{$reservation->id}")
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- New `GET /reservations/{reservation}` route backed by `ReservationRequestController@show`, wired into `web` + `auth` + `verified` middleware with a numeric id constraint.
- Controller deliberately bypasses `RestaurantScope` via `withoutGlobalScopes()` and then hands the row to `Gate::authorize('view', …)` — so foreign-tenant access returns **403 via policy**, not 404 via scope. `ReservationRequestPolicy::view` becomes the load-bearing authorisation gate.
- Minimal `Reservations/Show` Inertia page (guest, party size, status, source, desired_at, message) as a placeholder until PRD-004 finalises the detail view.
- Regenerated `ziggy.d.ts` picks up the new route name for typed `route('reservations.show', …)` calls.

## Why
Closes the last open AC from Epic #1 (exit criterion 5): "Direct GET of a foreign `reservation_requests/{id}` → 403". Splits out from #18 (Teil B). The 403-via-explicit-bypass posture was chosen over 404-via-scope so the policy is exercised rather than masked — matches the Epic wording and makes the multi-tenant boundary observable in tests.

## Test plan
Feature test `ReservationRequestShowTest` covers five cases:
- [x] Unauthenticated → redirect to `/login`
- [x] Own-tenant request → 200 + Inertia `Reservations/Show` with the reservation payload
- [x] Foreign-tenant request → **403**, verifying the scope bypass path
- [x] Unknown id → 404
- [x] Orphan user (`restaurant_id = null`) → 403

Ran locally:
- [x] `php artisan test --filter=ReservationRequestShowTest` → 5 tests, 23 assertions, all pass
- [x] `php artisan test` → 164 green, 387 assertions
- [x] `./vendor/bin/pint --test` → pass
- [x] `npm run lint:check` / `npm run format:check` / `npm run build` → pass
- [x] `php artisan ziggy:generate --types-only resources/js/ziggy.d.ts` regenerated; ziggy-drift CI should stay green.

Closes #107