### PR TITLE
Register public reservation routes (#20)

### DIFF
--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\Restaurant;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class PublicReservationController extends Controller
+{
+    public function create(Restaurant $restaurant): Response
+    {
+        return Inertia::render('Public/ReservationForm', [
+            'restaurant' => [
+                'name' => $restaurant->name,
+                'slug' => $restaurant->slug,
+            ],
+        ]);
+    }
+
+    public function store(Restaurant $restaurant): RedirectResponse
+    {
+        return redirect()->route('public.reservations.thanks', $restaurant);
+    }
+
+    public function thanks(Restaurant $restaurant): Response
+    {
+        return Inertia::render('Public/Thanks', [
+            'restaurant' => [
+                'name' => $restaurant->name,
+            ],
+        ]);
+    }
+}

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -9,6 +9,27 @@ declare module 'ziggy-js' {
             "required": true
         }
     ],
+    "public.reservations.create": [
+        {
+            "name": "restaurant",
+            "required": true,
+            "binding": "slug"
+        }
+    ],
+    "public.reservations.store": [
+        {
+            "name": "restaurant",
+            "required": true,
+            "binding": "slug"
+        }
+    ],
+    "public.reservations.thanks": [
+        {
+            "name": "restaurant",
+            "required": true,
+            "binding": "slug"
+        }
+    ],
     "profile.edit": [],
     "profile.update": [],
     "profile.destroy": [],

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\ReservationRequestController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -16,6 +17,16 @@ Route::get('reservations/{reservation}', [ReservationRequestController::class, '
     ->whereNumber('reservation')
     ->middleware(['auth', 'verified'])
     ->name('reservations.show');
+
+Route::get('r/{restaurant:slug}/reservations', [PublicReservationController::class, 'create'])
+    ->name('public.reservations.create');
+
+Route::post('r/{restaurant:slug}/reservations', [PublicReservationController::class, 'store'])
+    ->middleware('throttle:10,1')
+    ->name('public.reservations.store');
+
+Route::get('r/{restaurant:slug}/reservations/thanks', [PublicReservationController::class, 'thanks'])
+    ->name('public.reservations.thanks');
 
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';

--- a/tests/Feature/PublicReservationRoutesTest.php
+++ b/tests/Feature/PublicReservationRoutesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class PublicReservationRoutesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_route_renders_form_for_known_slug(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'name' => 'Demo Restaurant',
+            'slug' => 'demo',
+        ]);
+
+        $this->get(route('public.reservations.create', $restaurant))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Public/ReservationForm', false)
+                ->where('restaurant.name', 'Demo Restaurant')
+                ->where('restaurant.slug', 'demo')
+            );
+    }
+
+    public function test_create_route_returns_404_for_unknown_slug(): void
+    {
+        $this->get('/r/unknown-slug/reservations')->assertNotFound();
+    }
+
+    public function test_store_route_redirects_to_thanks_for_known_slug(): void
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+
+        $this->post(route('public.reservations.store', $restaurant))
+            ->assertRedirect(route('public.reservations.thanks', $restaurant));
+    }
+
+    public function test_store_route_returns_404_for_unknown_slug(): void
+    {
+        $this->post('/r/unknown-slug/reservations')->assertNotFound();
+    }
+
+    public function test_thanks_route_renders_for_known_slug(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'name' => 'Demo Restaurant',
+            'slug' => 'demo',
+        ]);
+
+        $this->get(route('public.reservations.thanks', $restaurant))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Public/Thanks', false)
+                ->where('restaurant.name', 'Demo Restaurant')
+            );
+    }
+
+    public function test_thanks_route_returns_404_for_unknown_slug(): void
+    {
+        $this->get('/r/unknown-slug/reservations/thanks')->assertNotFound();
+    }
+
+    public function test_store_route_throttles_at_eleventh_request_per_minute(): void
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+        $url = route('public.reservations.store', $restaurant);
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->post($url)->assertRedirect();
+        }
+
+        $this->post($url)->assertStatus(429);
+    }
+}


### PR DESCRIPTION
## Summary
- Register `GET/POST /r/{restaurant:slug}/reservations` and `GET .../thanks` with `public.reservations.{create,store,thanks}` route names
- Apply `throttle:10,1` middleware on the POST route
- Add `PublicReservationController` stub returning the placeholder Inertia pages so the routes resolve; full request handling lands with #21/#22
- Regenerate `resources/js/ziggy.d.ts` for the three new routes

## Why
Epic #19 (PRD-002) needs the route layer in place before the FormRequest (#21) and full controller (#22) can wire onto it. Following CLAUDE.md, this stays as flat `Route::` calls to match the existing `routes/web.php` style instead of introducing a prefix group.

## Test plan
- [x] `php artisan test` — 171 tests / 429 assertions (was 164 before; +7 new in `PublicReservationRoutesTest`)
- [x] `./vendor/bin/pint --test` — clean
- [x] `npm run lint:check` and `npm run format:check` — clean
- [x] `php artisan ziggy:generate resources/js/ziggy.{js,d.ts}` re-run; only `resources/js/ziggy.d.ts` committed (matches #109 precedent)

Closes #20