### PR TITLE
Add StoreReservationRequest FormRequest (#21)

### DIFF
--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\StoreReservationRequest;
 use App\Models\Restaurant;
 use Illuminate\Http\RedirectResponse;
 use Inertia\Inertia;
@@ -21,7 +22,7 @@ final class PublicReservationController extends Controller
         ]);
     }
 
-    public function store(Restaurant $restaurant): RedirectResponse
+    public function store(StoreReservationRequest $request, Restaurant $restaurant): RedirectResponse
     {
         return redirect()->route('public.reservations.thanks', $restaurant);
     }

--- a/app/Http/Requests/StoreReservationRequest.php
+++ b/app/Http/Requests/StoreReservationRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreReservationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'guest_name' => ['required', 'string', 'max:120'],
+            'guest_email' => ['required', 'email:rfc,dns', 'max:190'],
+            'guest_phone' => ['nullable', 'string', 'max:40'],
+            'party_size' => ['required', 'integer', 'min:1', 'max:20'],
+            'desired_at' => ['required', 'date', 'after:now'],
+            'message' => ['nullable', 'string', 'max:2000'],
+            'website' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'guest_name.required' => 'Bitte geben Sie Ihren Namen an.',
+            'guest_name.string' => 'Der Name muss aus Text bestehen.',
+            'guest_name.max' => 'Der Name darf höchstens 120 Zeichen lang sein.',
+
+            'guest_email.required' => 'Bitte geben Sie eine E-Mail-Adresse an.',
+            'guest_email.email' => 'Bitte geben Sie eine gültige E-Mail-Adresse an.',
+            'guest_email.max' => 'Die E-Mail-Adresse darf höchstens 190 Zeichen lang sein.',
+
+            'guest_phone.string' => 'Die Telefonnummer muss aus Text bestehen.',
+            'guest_phone.max' => 'Die Telefonnummer darf höchstens 40 Zeichen lang sein.',
+
+            'party_size.required' => 'Bitte geben Sie die Personenzahl an.',
+            'party_size.integer' => 'Die Personenzahl muss eine ganze Zahl sein.',
+            'party_size.min' => 'Die Reservierung muss für mindestens 1 Person sein.',
+            'party_size.max' => 'Pro Anfrage sind höchstens 20 Personen möglich.',
+
+            'desired_at.required' => 'Bitte geben Sie das gewünschte Datum samt Uhrzeit an.',
+            'desired_at.date' => 'Datum und Uhrzeit sind ungültig.',
+            'desired_at.after' => 'Der Wunschtermin muss in der Zukunft liegen.',
+
+            'message.string' => 'Die Nachricht muss aus Text bestehen.',
+            'message.max' => 'Die Nachricht darf höchstens 2000 Zeichen lang sein.',
+        ];
+    }
+}

--- a/tests/Feature/PublicReservationRoutesTest.php
+++ b/tests/Feature/PublicReservationRoutesTest.php
@@ -32,14 +32,6 @@ class PublicReservationRoutesTest extends TestCase
         $this->get('/r/unknown-slug/reservations')->assertNotFound();
     }
 
-    public function test_store_route_redirects_to_thanks_for_known_slug(): void
-    {
-        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
-
-        $this->post(route('public.reservations.store', $restaurant))
-            ->assertRedirect(route('public.reservations.thanks', $restaurant));
-    }
-
     public function test_store_route_returns_404_for_unknown_slug(): void
     {
         $this->post('/r/unknown-slug/reservations')->assertNotFound();

--- a/tests/Feature/StoreReservationRequestTest.php
+++ b/tests/Feature/StoreReservationRequestTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class StoreReservationRequestTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'guest_name' => 'Alice Example',
+            'guest_email' => 'alice@gmail.com',
+            'guest_phone' => '+49 30 1234567',
+            'party_size' => 4,
+            'desired_at' => Carbon::now()->addDays(3)->format('Y-m-d H:i'),
+            'message' => 'Fensterplatz wäre toll.',
+        ], $overrides);
+    }
+
+    public function test_valid_payload_redirects_to_thanks(): void
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+
+        $this->post(route('public.reservations.store', $restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $restaurant));
+    }
+
+    public function test_filled_honeypot_still_validates_so_the_bot_sees_no_difference(): void
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+
+        $this->post(
+            route('public.reservations.store', $restaurant),
+            $this->validPayload(['website' => 'http://spam.example'])
+        )
+            ->assertRedirect(route('public.reservations.thanks', $restaurant))
+            ->assertSessionHasNoErrors();
+    }
+
+    public function test_optional_fields_may_be_omitted(): void
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+
+        $payload = $this->validPayload();
+        unset($payload['guest_phone'], $payload['message']);
+
+        $this->post(route('public.reservations.store', $restaurant), $payload)
+            ->assertRedirect(route('public.reservations.thanks', $restaurant));
+    }
+
+    public function test_guest_name_is_required(): void
+    {
+        $this->postValid(['guest_name' => null])
+            ->assertSessionHasErrors(['guest_name' => 'Bitte geben Sie Ihren Namen an.']);
+    }
+
+    public function test_guest_name_is_capped_at_120_characters(): void
+    {
+        $this->postValid(['guest_name' => str_repeat('a', 121)])
+            ->assertSessionHasErrors(['guest_name' => 'Der Name darf höchstens 120 Zeichen lang sein.']);
+    }
+
+    public function test_guest_email_is_required(): void
+    {
+        $this->postValid(['guest_email' => null])
+            ->assertSessionHasErrors(['guest_email' => 'Bitte geben Sie eine E-Mail-Adresse an.']);
+    }
+
+    public function test_guest_email_must_be_valid(): void
+    {
+        $this->postValid(['guest_email' => 'not-an-email'])
+            ->assertSessionHasErrors(['guest_email' => 'Bitte geben Sie eine gültige E-Mail-Adresse an.']);
+    }
+
+    public function test_guest_phone_is_optional_but_capped_at_40_characters(): void
+    {
+        $this->postValid(['guest_phone' => str_repeat('1', 41)])
+            ->assertSessionHasErrors(['guest_phone' => 'Die Telefonnummer darf höchstens 40 Zeichen lang sein.']);
+    }
+
+    public function test_party_size_is_required(): void
+    {
+        $this->postValid(['party_size' => null])
+            ->assertSessionHasErrors(['party_size' => 'Bitte geben Sie die Personenzahl an.']);
+    }
+
+    public function test_party_size_must_be_at_least_one(): void
+    {
+        $this->postValid(['party_size' => 0])
+            ->assertSessionHasErrors(['party_size' => 'Die Reservierung muss für mindestens 1 Person sein.']);
+    }
+
+    public function test_party_size_above_20_is_rejected(): void
+    {
+        $this->postValid(['party_size' => 21])
+            ->assertSessionHasErrors(['party_size' => 'Pro Anfrage sind höchstens 20 Personen möglich.']);
+    }
+
+    public function test_party_size_must_be_an_integer(): void
+    {
+        $this->postValid(['party_size' => 'four'])
+            ->assertSessionHasErrors(['party_size' => 'Die Personenzahl muss eine ganze Zahl sein.']);
+    }
+
+    public function test_desired_at_is_required(): void
+    {
+        $this->postValid(['desired_at' => null])
+            ->assertSessionHasErrors(['desired_at' => 'Bitte geben Sie das gewünschte Datum samt Uhrzeit an.']);
+    }
+
+    public function test_desired_at_in_the_past_is_rejected(): void
+    {
+        $this->postValid(['desired_at' => Carbon::now()->subHour()->format('Y-m-d H:i')])
+            ->assertSessionHasErrors(['desired_at' => 'Der Wunschtermin muss in der Zukunft liegen.']);
+    }
+
+    public function test_message_is_capped_at_2000_characters(): void
+    {
+        $this->postValid(['message' => str_repeat('a', 2001)])
+            ->assertSessionHasErrors(['message' => 'Die Nachricht darf höchstens 2000 Zeichen lang sein.']);
+    }
+
+    private function postValid(array $overrides)
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+
+        return $this->from(route('public.reservations.create', $restaurant))
+            ->post(route('public.reservations.store', $restaurant), $this->validPayload($overrides));
+    }
+}


### PR DESCRIPTION
## Summary
- Add `StoreReservationRequest` with the full validation rule set from PRD-002 (`guest_name`, `guest_email` incl. `rfc,dns`, `guest_phone`, `party_size` 1..20, `desired_at` after:now, `message`, `website` honeypot)
- Per-field German error messages via `messages()`
- Wire the FormRequest into `PublicReservationController@store` so feature tests exercise the real validation pipeline; honeypot persistence, UTC conversion, and event dispatch still land with #22

## Why
Epic #19 (PRD-002) needs the validation contract locked before the controller does anything more than redirect. Validation lives in the FormRequest per CLAUDE.md ("Validierung NIE in Controllern").

### One spec ambiguity worth flagging
The issue lists the honeypot rule as `['nullable', 'size:0']` but simultaneously says "validates OK even when filled". `size:0` returns 422 on a filled field, which would let a bot diff success vs rejection and defeat the honeypot. The prose wins: rules are permissive (`nullable, string, max:255`) and the controller will branch on the honeypot in #22.

## Test plan
- [x] `php artisan test` — 185 tests / 458 assertions (was 171; +15 new in `StoreReservationRequestTest`, -1 moved out of `PublicReservationRoutesTest`)
- [x] `./vendor/bin/pint --test` — clean
- [x] `npm run lint:check` + `npm run format:check` — clean
- [x] New test `test_filled_honeypot_still_validates_so_the_bot_sees_no_difference` locks in the anti-detection behaviour

Closes #21