### PR TITLE
Add ReservationRequestReceived event (#23)

### DIFF
--- a/app/Events/ReservationRequestReceived.php
+++ b/app/Events/ReservationRequestReceived.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\ReservationRequest;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final class ReservationRequestReceived
+{
+    use Dispatchable;
+
+    public function __construct(public readonly ReservationRequest $request) {}
+}

--- a/tests/Unit/Events/ReservationRequestReceivedTest.php
+++ b/tests/Unit/Events/ReservationRequestReceivedTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit\Events;
+
+use App\Events\ReservationRequestReceived;
+use App\Models\ReservationRequest;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class ReservationRequestReceivedTest extends TestCase
+{
+    public function test_event_carries_the_reservation_request(): void
+    {
+        $reservation = new ReservationRequest(['guest_name' => 'Alice Example']);
+
+        $event = new ReservationRequestReceived($reservation);
+
+        $this->assertSame($reservation, $event->request);
+    }
+
+    public function test_event_is_dispatchable(): void
+    {
+        Event::fake();
+        $reservation = new ReservationRequest(['guest_name' => 'Alice Example']);
+
+        ReservationRequestReceived::dispatch($reservation);
+
+        Event::assertDispatched(
+            ReservationRequestReceived::class,
+            fn (ReservationRequestReceived $event) => $event->request === $reservation
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Add `App\Events\ReservationRequestReceived` with `public readonly ReservationRequest $request` and `use Dispatchable`
- Add DB-free unit test in `tests/Unit/Events/ReservationRequestReceivedTest.php` verifying the payload is carried and the event is dispatchable

## Why
Epic #19 (PRD-002) needs the event type to exist before #22 can wire its dispatch in `PublicReservationController@store`. The listener lives with PRD-005; this PR only lands the event class so downstream issues can depend on the type.

### Scope note
Issue #23's AC mentions "Dispatched from `PublicReservationController@store`" — that wiring is #22's scope (it also owns the honeypot branch, UTC conversion, and `ReservationRequest` persistence). Splitting it this way keeps #22 focused on the controller without inventing the event ad hoc.

## Test plan
- [x] `php artisan test` — 187 tests / 460 assertions (was 185; +2 new in `ReservationRequestReceivedTest`)
- [x] `./vendor/bin/pint --test` — clean

Closes #23