### PR TITLE
Add Public/Thanks Vue confirmation page (#25)

### DIFF
--- a/resources/js/pages/Public/Thanks.vue
+++ b/resources/js/pages/Public/Thanks.vue
@@ -1,0 +1,20 @@
+<script setup lang="ts">
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { Head } from '@inertiajs/vue3';
+
+defineProps<{
+    restaurant: {
+        name: string;
+    };
+}>();
+</script>
+
+<template>
+    <PublicLayout :heading="`Vielen Dank für Ihre Anfrage bei ${restaurant.name}`" description="Wir melden uns so schnell wie möglich bei Ihnen.">
+        <Head :title="`Reservierung bestätigt – ${restaurant.name}`" />
+
+        <p class="text-sm text-muted-foreground">
+            Ihre Reservierungsanfrage ist bei uns eingegangen. Sobald das Team Ihre Wunschzeit geprüft hat, erhalten Sie eine Rückmeldung per E-Mail.
+        </p>
+    </PublicLayout>
+</template>

--- a/tests/Feature/PublicReservationRoutesTest.php
+++ b/tests/Feature/PublicReservationRoutesTest.php
@@ -47,7 +47,7 @@ class PublicReservationRoutesTest extends TestCase
         $this->get(route('public.reservations.thanks', $restaurant))
             ->assertOk()
             ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('Public/Thanks', false)
+                ->component('Public/Thanks')
                 ->where('restaurant.name', 'Demo Restaurant')
             );
     }

--- a/tests/Feature/PublicReservationStoreTest.php
+++ b/tests/Feature/PublicReservationStoreTest.php
@@ -140,7 +140,7 @@ class PublicReservationStoreTest extends TestCase
         $this->get(route('public.reservations.thanks', $restaurant))
             ->assertOk()
             ->assertInertia(fn (AssertableInertia $page) => $page
-                ->component('Public/Thanks', false)
+                ->component('Public/Thanks')
                 ->where('restaurant.name', 'Osteria Luna')
             );
     }


### PR DESCRIPTION
## Summary
- Add `resources/js/pages/Public/Thanks.vue` reusing `PublicLayout` — heading with restaurant name, short German acknowledgement copy, no guest PII, no analytics.
- Drop the `false` existence-skip on the two `Public/Thanks` assertions in `PublicReservationRoutesTest` + `PublicReservationStoreTest`; Inertia now asserts the Vue file exists.

## Why
PRD-002 requires a confirmation landing after a successful store (and also after a triggered honeypot, which silently redirects here). With the page file in place, the feature suite can finally assert the full redirect target end-to-end without the escape hatch.

## Test plan
- `php artisan test --filter='PublicReservation'` — 13 passing, 91 assertions
- `./vendor/bin/pint --test` — pass
- `npm run lint:check` — pass
- `npm run format:check` — pass
- `npm run build` — bundle produced

Closes #25