### PR TITLE
Render throttle as Inertia-friendly response on public store (#26)

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -4,7 +4,9 @@ use App\Http\Middleware\HandleInertiaRequests;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Exceptions\ThrottleRequestsException;
 use Illuminate\Http\Middleware\AddLinkHeadersForPreloadedAssets;
+use Illuminate\Http\Request;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -19,5 +21,15 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        $exceptions->render(function (ThrottleRequestsException $e, Request $request) {
+            if ($request->header('X-Inertia')) {
+                return back()
+                    ->withInput()
+                    ->withErrors([
+                        'throttle' => 'Zu viele Anfragen. Bitte versuchen Sie es in einer Minute erneut.',
+                    ]);
+            }
+
+            return null;
+        });
     })->create();

--- a/resources/js/pages/Public/ReservationForm.vue
+++ b/resources/js/pages/Public/ReservationForm.vue
@@ -58,6 +58,14 @@ const submit = () => {
         <Head :title="`Reservierung – ${restaurant.name}`" />
 
         <form @submit.prevent="submit" class="flex flex-col gap-6">
+            <div
+                v-if="form.errors.throttle"
+                role="alert"
+                class="rounded-md border border-destructive/50 bg-destructive/10 p-3 text-sm text-destructive"
+            >
+                {{ form.errors.throttle }}
+            </div>
+
             <div class="grid gap-2">
                 <Label for="guest_name">Name</Label>
                 <Input id="guest_name" type="text" required autocomplete="name" autofocus v-model="form.guest_name" placeholder="Vor- und Nachname" />

--- a/tests/Feature/PublicReservationRoutesTest.php
+++ b/tests/Feature/PublicReservationRoutesTest.php
@@ -68,4 +68,19 @@ class PublicReservationRoutesTest extends TestCase
 
         $this->post($url)->assertStatus(429);
     }
+
+    public function test_throttled_inertia_request_redirects_back_with_throttle_error(): void
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+        $url = route('public.reservations.store', $restaurant);
+
+        for ($i = 0; $i < 10; $i++) {
+            $this->post($url)->assertRedirect();
+        }
+
+        $this->withHeaders(['X-Inertia' => 'true'])
+            ->post($url)
+            ->assertRedirect()
+            ->assertSessionHasErrors('throttle');
+    }
 }


### PR DESCRIPTION
## Summary
- Register a `ThrottleRequestsException` render callback in `bootstrap/app.php`. When the request carries `X-Inertia`, return `back()->withInput()->withErrors(['throttle' => ...])` so Inertia follows the redirect and re-renders the form with a flash error. Non-Inertia callers fall through to Laravel's default plain 429 HTML response.
- Surface the flash error inline on `Public/ReservationForm.vue` via a `role="alert"` banner bound to `form.errors.throttle`, so a throttled real user sees an actionable message above the form instead of Inertia's default error modal.
- Add a feature test asserting that an Inertia-flagged 11th POST redirects back with a session `throttle` error. The existing non-Inertia 429 test still passes unchanged.

## Why
PRD-002 already pinned the defense layer — `throttle:10,1` on the public POST route plus the silent honeypot. The remaining gap in #26 was the UX: a raw 429 on an Inertia submission triggers Inertia's XHR error modal with the Laravel HTML error page, which is hostile to a real user who just happens to retry too fast. Redirecting back with a form-level error keeps them in context.

Honeypot + throttle remain the entire bot defense for V1.0; CAPTCHA stays out until #29 is decided (see PRD section "Offene Entscheidungen").

## Test plan
- `php artisan test` — 195 passing, 524 assertions (new `test_throttled_inertia_request_redirects_back_with_throttle_error`)
- `./vendor/bin/pint --test` — pass
- `npm run lint:check` — pass
- `npm run format:check` — pass
- `npm run build` — pass

Closes #26