### PR TITLE
Centralise 20-guest cap as ReservationRequest constant (#30)

### DIFF
--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -25,6 +25,7 @@ final class PublicReservationController extends Controller
                 'slug' => $restaurant->slug,
                 'tonality' => $restaurant->tonality->value,
             ],
+            'maxPartySize' => ReservationRequest::MAX_PARTY_SIZE,
         ]);
     }
 

--- a/app/Http/Requests/StoreReservationRequest.php
+++ b/app/Http/Requests/StoreReservationRequest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Requests;
 
+use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Support\Timezone;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -52,7 +53,7 @@ class StoreReservationRequest extends FormRequest
             'guest_name' => ['required', 'string', 'max:120'],
             'guest_email' => ['required', 'email:rfc,dns', 'max:190'],
             'guest_phone' => ['nullable', 'string', 'max:40'],
-            'party_size' => ['required', 'integer', 'min:1', 'max:20'],
+            'party_size' => ['required', 'integer', 'min:1', 'max:'.ReservationRequest::MAX_PARTY_SIZE],
             'desired_at' => ['required', 'date', 'after:now'],
             'message' => ['nullable', 'string', 'max:2000'],
             'website' => ['nullable', 'string', 'max:255'],
@@ -79,7 +80,7 @@ class StoreReservationRequest extends FormRequest
             'party_size.required' => 'Bitte geben Sie die Personenzahl an.',
             'party_size.integer' => 'Die Personenzahl muss eine ganze Zahl sein.',
             'party_size.min' => 'Die Reservierung muss für mindestens 1 Person sein.',
-            'party_size.max' => 'Pro Anfrage sind höchstens 20 Personen möglich.',
+            'party_size.max' => 'Pro Anfrage sind höchstens '.ReservationRequest::MAX_PARTY_SIZE.' Personen möglich.',
 
             'desired_at.required' => 'Bitte geben Sie das gewünschte Datum samt Uhrzeit an.',
             'desired_at.date' => 'Datum und Uhrzeit sind ungültig.',

--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -19,6 +19,8 @@ class ReservationRequest extends Model
     /** @use HasFactory<ReservationRequestFactory> */
     use HasFactory;
 
+    public const int MAX_PARTY_SIZE = 20;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/docs/PRD-002-web-reservation-form.md
+++ b/docs/PRD-002-web-reservation-form.md
@@ -144,4 +144,4 @@ return [
 
 - **CAPTCHA Ja/Nein?** – Entschieden: kein CAPTCHA in V1.0, Honeypot + Rate-Limit reichen für den Pilot. Trigger-Kriterien und bevorzugter Anbieter (Cloudflare Turnstile) in [`decisions/captcha-v1.md`](decisions/captcha-v1.md).
 - **Default-Öffnungszeiten-Check im Formular** – V1.0 validiert **nicht**, ob das Restaurant zum gewünschten Zeitpunkt überhaupt geöffnet ist. Diese Prüfung macht der KI-Assistent (PRD-005) und liefert dann z. B. einen Alternativ-Vorschlag. Begründung: wir wollen auch Anfragen außerhalb der Öffnungszeiten annehmen (Eventanfragen, geschlossene Gesellschaften).
-- **Max-Personenzahl pro Restaurant individuell?** – In V1.0 hart auf 20 gecappt. Individuelle Limits kommen erst, wenn ein Pilot es braucht.
+- **Max-Personenzahl pro Restaurant individuell?** – Entschieden: in V1.0 hart auf 20 gecappt, zentralisiert als `ReservationRequest::MAX_PARTY_SIZE`. Trigger für Per-Restaurant-Override und Implementierungs-Skizze in [`decisions/party-size-cap.md`](decisions/party-size-cap.md).

--- a/docs/decisions/party-size-cap.md
+++ b/docs/decisions/party-size-cap.md
@@ -1,0 +1,58 @@
+# Entscheidung: Harter Cap von 20 Personen pro Anfrage in V1.0
+
+**Status:** angenommen
+**Datum:** 2026-04-18
+**Bezug:** PRD-002 (Öffentliches Reservierungsformular), Issue #30
+
+## Kontext
+
+`ReservationRequest` erlaubt ein `party_size` zwischen 1 und 20. Die Zahl 20 taucht an drei Stellen auf, die sauber im Gleichschritt bleiben müssen:
+
+- `StoreReservationRequest::rules()` (`max:...`)
+- Die deutschsprachige Fehlermeldung `party_size.max`
+- Der `<select>` im öffentlichen `Public/ReservationForm.vue`
+
+Später wird die gleiche Grenze vom KI-Kontext-Builder (PRD-005) gelesen, wenn er dem Gastronom Alternativen vorschlägt.
+
+PRD-002 stellte zwei Fragen:
+
+1. Sollen einzelne Restaurants den Cap überschreiben können?
+2. Wo zentralisieren wir die 20, solange es keinen Override gibt?
+
+## Entscheidung
+
+**V1.0 bleibt hart bei 20.** Kein Per-Restaurant-Override, keine neue Spalte, keine Config. Die Grenze ist eine Klassenkonstante auf dem Domänen-Modell: `App\Models\ReservationRequest::MAX_PARTY_SIZE = 20`.
+
+Alle Stellen lesen aus dieser Konstante:
+
+- `StoreReservationRequest` referenziert sie in Rule + Message
+- `PublicReservationController::create()` gibt sie als Inertia-Prop `maxPartySize` ans Frontend weiter
+- Die Vue-Form bezieht die Dropdown-Range aus `props.maxPartySize` – kein gespiegelter Literalwert mehr
+
+## Begründung
+
+- Im Pilot-Panel gibt es aktuell kein Restaurant mit einem belastbaren Bedarf > 20. Eine Spalte einzuführen, die niemand nutzt, ist vorauseilende Abstraktion und bläht das Datenmodell + Migrations-Historie unnötig auf.
+- Anfragen > 20 Personen sind in der Regel Eventanfragen mit Spezialregeln (Menü, Raumbuchung, Anzahlung). Die Web-Form ist dafür nicht der richtige Kanal – solche Gäste sollen weiterhin direkt per E-Mail / Telefon buchen, nicht im Self-Service-Formular.
+- Die Konstante auf dem Modell statt in `config/reservations.php` hält das Wissen bei der Domäne. Der KI-Kontext-Builder (PRD-005) liest sie ebenfalls vom Modell – keine Indirektion über Config-Keys.
+
+## Trigger für Umstellung auf Per-Restaurant-Override
+
+Umschalten auf einen optionalen `restaurants.max_party_size` Override, sobald **einer** dieser Punkte eintritt. Dokumentation + Folge-Issue dann Pflicht.
+
+1. **Konkreter Pilot-Bedarf:** Ein Bestandskunde (aktive Nutzung > 4 Wochen) meldet nachvollziehbar, dass regelmäßig Anfragen für 21–50 Personen über das Formular kommen sollen. "Nice to have" reicht nicht – es muss ein Umsatzthema oder wiederholt abgewiesene Gäste geben.
+2. **Abweichende Event-Schwelle:** Ein Pilot hat ein Event-Konzept (Weihnachtsfeiern, Catering), für das die Web-Form bewusst als Einstieg dienen soll. Dann wird ein separater Flow nötig, nicht nur ein höherer Cap.
+
+## Implementierung bei Nachrüstung (Skizze)
+
+- Migration: nullable `restaurants.max_party_size` (unsigned tinyInt, default NULL)
+- Model: `Restaurant::effectiveMaxPartySize(): int` – `?? ReservationRequest::MAX_PARTY_SIZE`
+- `StoreReservationRequest` liest `$this->route('restaurant')->effectiveMaxPartySize()` statt der Konstante
+- Controller gibt `maxPartySize` aus `effectiveMaxPartySize()` weiter
+- Kontext-Builder PRD-005 analog
+
+Die Konstante auf dem Modell bleibt dabei Default-Wert und Ankerpunkt.
+
+## Nicht in diesem Dokument
+
+- Event-Buchungs-Flow (eigenes PRD, nicht Teil von V1.0)
+- Config-basierte Override-Variante (verworfen – Config würde die Domain-Grenze vom Modell trennen)

--- a/resources/js/pages/Public/ReservationForm.vue
+++ b/resources/js/pages/Public/ReservationForm.vue
@@ -15,6 +15,7 @@ const props = defineProps<{
         slug: string;
         tonality: Tonality;
     };
+    maxPartySize: number;
 }>();
 
 const greetings: Record<Tonality, string> = {
@@ -36,7 +37,7 @@ const form = useForm({
     website: '',
 });
 
-const partySizes = Array.from({ length: 20 }, (_, i) => i + 1);
+const partySizes = computed(() => Array.from({ length: props.maxPartySize }, (_, i) => i + 1));
 
 const submit = () => {
     form.transform((data) => ({


### PR DESCRIPTION
## Summary
- Add `public const int MAX_PARTY_SIZE = 20;` on `App\Models\ReservationRequest`.
- `StoreReservationRequest` now reads the constant in both the `max:` rule and the German error message — no mirrored literal.
- `PublicReservationController::create()` passes the constant to the Inertia page as `maxPartySize`; `Public/ReservationForm.vue` builds the party-size `<select>` range from `props.maxPartySize` (computed) instead of the hardcoded `20` literal.
- Add `docs/decisions/party-size-cap.md` recording the V1.0 decision (hard 20, no per-restaurant override), the concrete triggers for nachrüsten, and a sketch of the `restaurants.max_party_size` override path when needed.
- Link the decision doc from the PRD-002 "Risiken & offene Fragen" entry.

## Why
The cap sat in three places (rule, message, Vue dropdown) with no structural link — a change in any one was a latent drift bug, and PRD-005 will soon need the same number for the AI context builder. Moving it onto the domain model centralises it before the second reader arrives. Deciding *not* to add a per-restaurant override up front keeps the data model clean and avoids speculative generality; the decision doc defines the trigger that flips it.

## Test plan
- `php artisan test` — 197 passing, 502 assertions (same coverage, unchanged behaviour)
- `./vendor/bin/pint --test` — pass
- `npm run lint:check` — pass
- `npm run format:check` — pass
- `npm run build` — pass

Closes #30