### PR TITLE
Install webklex/laravel-imap (#32)

### DIFF
--- a/bootstrap/cache/packages.php
+++ b/bootstrap/cache/packages.php
@@ -55,4 +55,15 @@
       0 => 'Tighten\\Ziggy\\ZiggyServiceProvider',
     ),
   ),
+  'webklex/laravel-imap' => 
+  array (
+    'aliases' => 
+    array (
+      'Client' => 'Webklex\\IMAP\\Facades\\Client',
+    ),
+    'providers' => 
+    array (
+      0 => 'Webklex\\IMAP\\Providers\\LaravelServiceProvider',
+    ),
+  ),
 );

--- a/bootstrap/cache/services.php
+++ b/bootstrap/cache/services.php
@@ -32,7 +32,9 @@
     28 => 'NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider',
     29 => 'Termwind\\Laravel\\TermwindServiceProvider',
     30 => 'Tighten\\Ziggy\\ZiggyServiceProvider',
-    31 => 'App\\Providers\\AppServiceProvider',
+    31 => 'Webklex\\IMAP\\Providers\\LaravelServiceProvider',
+    32 => 'App\\Providers\\AppServiceProvider',
+    33 => 'App\\Providers\\AuthServiceProvider',
   ),
   'eager' => 
   array (
@@ -52,7 +54,9 @@
     13 => 'NunoMaduro\\Collision\\Adapters\\Laravel\\CollisionServiceProvider',
     14 => 'Termwind\\Laravel\\TermwindServiceProvider',
     15 => 'Tighten\\Ziggy\\ZiggyServiceProvider',
-    16 => 'App\\Providers\\AppServiceProvider',
+    16 => 'Webklex\\IMAP\\Providers\\LaravelServiceProvider',
+    17 => 'App\\Providers\\AppServiceProvider',
+    18 => 'App\\Providers\\AuthServiceProvider',
   ),
   'deferred' => 
   array (

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
-        "tightenco/ziggy": "^2.4"
+        "tightenco/ziggy": "^2.4",
+        "webklex/laravel-imap": "^6.2"
     },
     "require-dev": {
         "fakerphp/faker": "^1.23",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "238758776cef75e40b61f11e6f2e00e2",
+    "content-hash": "166ee1413d31bc2d04a0264a3c4616bf",
     "packages": [
         {
             "name": "brick/math",
@@ -6142,6 +6142,164 @@
                 }
             ],
             "time": "2024-11-21T01:49:47+00:00"
+        },
+        {
+            "name": "webklex/laravel-imap",
+            "version": "6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Webklex/laravel-imap.git",
+                "reference": "57609df58c2f4ef625e4d90a47d8615cfb15f925"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Webklex/laravel-imap/zipball/57609df58c2f4ef625e4d90a47d8615cfb15f925",
+                "reference": "57609df58c2f4ef625e4d90a47d8615cfb15f925",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": ">=6.0.0",
+                "php": "^8.0.2",
+                "webklex/php-imap": "^6.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Client": "Webklex\\IMAP\\Facades\\Client"
+                    },
+                    "providers": [
+                        "Webklex\\IMAP\\Providers\\LaravelServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webklex\\IMAP\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Malte Goldenbaum",
+                    "email": "github@webklex.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Laravel IMAP client",
+            "homepage": "https://github.com/webklex/laravel-imap",
+            "keywords": [
+                "idle",
+                "imap",
+                "laravel",
+                "laravel-imap",
+                "mail",
+                "oauth",
+                "pop3",
+                "webklex"
+            ],
+            "support": {
+                "issues": "https://github.com/Webklex/laravel-imap/issues",
+                "source": "https://github.com/Webklex/laravel-imap/tree/6.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/webklex",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://ko-fi.com/webklex",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2025-04-25T06:06:46+00:00"
+        },
+        {
+            "name": "webklex/php-imap",
+            "version": "6.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Webklex/php-imap.git",
+                "reference": "6b8ef85d621bbbaf52741b00cca8e9237e2b2e05"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Webklex/php-imap/zipball/6b8ef85d621bbbaf52741b00cca8e9237e2b2e05",
+                "reference": "6b8ef85d621bbbaf52741b00cca8e9237e2b2e05",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "ext-iconv": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-openssl": "*",
+                "ext-zip": "*",
+                "illuminate/pagination": ">=5.0.0",
+                "nesbot/carbon": "^2.62.1|^3.2.4",
+                "php": "^8.0.2",
+                "symfony/http-foundation": ">=2.8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "suggest": {
+                "symfony/mime": "Recomended for better extension support",
+                "symfony/var-dumper": "Usefull tool for debugging"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webklex\\PHPIMAP\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Malte Goldenbaum",
+                    "email": "github@webklex.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "PHP IMAP client",
+            "homepage": "https://github.com/webklex/php-imap",
+            "keywords": [
+                "imap",
+                "mail",
+                "php-imap",
+                "pop3",
+                "webklex"
+            ],
+            "support": {
+                "issues": "https://github.com/Webklex/php-imap/issues",
+                "source": "https://github.com/Webklex/php-imap/tree/6.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.buymeacoffee.com/webklex",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://ko-fi.com/webklex",
+                    "type": "ko_fi"
+                }
+            ],
+            "time": "2025-04-25T06:02:37+00:00"
         }
     ],
     "packages-dev": [

--- a/config/imap.php
+++ b/config/imap.php
@@ -1,0 +1,264 @@
+<?php
+
+use Webklex\IMAP\Events\FlagDeletedEvent;
+use Webklex\IMAP\Events\FlagNewEvent;
+use Webklex\IMAP\Events\FolderDeletedEvent;
+use Webklex\IMAP\Events\FolderMovedEvent;
+use Webklex\IMAP\Events\FolderNewEvent;
+use Webklex\IMAP\Events\MessageCopiedEvent;
+use Webklex\IMAP\Events\MessageDeletedEvent;
+use Webklex\IMAP\Events\MessageMovedEvent;
+use Webklex\IMAP\Events\MessageNewEvent;
+use Webklex\IMAP\Events\MessageRestoredEvent;
+use Webklex\PHPIMAP\Decoder\AttachmentDecoder;
+use Webklex\PHPIMAP\Decoder\HeaderDecoder;
+use Webklex\PHPIMAP\Decoder\MessageDecoder;
+use Webklex\PHPIMAP\IMAP;
+use Webklex\PHPIMAP\Support\Masks\AttachmentMask;
+use Webklex\PHPIMAP\Support\Masks\MessageMask;
+
+/*
+* File:     imap.php
+* Category: config
+* Author:   M. Goldenbaum
+* Created:  24.09.16 22:36
+* Updated:  -
+*
+* Description:
+*  -
+*/
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | IMAP default account
+    |--------------------------------------------------------------------------
+    |
+    | The default account identifier. It will be used as default for any missing account parameters.
+    | If however the default account is missing a parameter the package default will be used.
+    | Set to 'false' [boolean] to disable this functionality.
+    |
+    */
+    'default' => env('IMAP_DEFAULT_ACCOUNT', 'default'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default date format
+    |--------------------------------------------------------------------------
+    |
+    | The default date format is used to convert any given Carbon::class object into a valid date string.
+    | These are currently known working formats: "d-M-Y", "d-M-y", "d M y"
+    |
+    */
+    'date_format' => 'd-M-Y',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available IMAP accounts
+    |--------------------------------------------------------------------------
+    |
+    | Please list all IMAP accounts which you are planning to use within the
+    | array below.
+    |
+    */
+    'accounts' => [
+
+        'default' => [// account identifier
+            'host' => env('IMAP_HOST', 'localhost'),
+            'port' => env('IMAP_PORT', 993),
+            'protocol' => env('IMAP_PROTOCOL', 'imap'), // might also use imap, [pop3 or nntp (untested)]
+            'encryption' => env('IMAP_ENCRYPTION', 'ssl'), // Supported: false, 'ssl', 'tls', 'notls', 'starttls'
+            'validate_cert' => env('IMAP_VALIDATE_CERT', true),
+            'username' => env('IMAP_USERNAME', 'root@example.com'),
+            'password' => env('IMAP_PASSWORD', ''),
+            'authentication' => env('IMAP_AUTHENTICATION', null),
+            'proxy' => [
+                'socket' => null,
+                'request_fulluri' => false,
+                'username' => null,
+                'password' => null,
+            ],
+            'timeout' => 30,
+            'extensions' => [],
+        ],
+
+        /*
+        'gmail' => [ // account identifier
+            'host' => 'imap.gmail.com',
+            'port' => 993,
+            'encryption' => 'ssl',
+            'validate_cert' => true,
+            'username' => 'example@gmail.com',
+            'password' => 'PASSWORD',
+            'authentication' => 'oauth',
+        ],
+
+        'another' => [ // account identifier
+            'host' => '',
+            'port' => 993,
+            'encryption' => false,
+            'validate_cert' => true,
+            'username' => '',
+            'password' => '',
+            'authentication' => null,
+        ]
+        */
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available IMAP options
+    |--------------------------------------------------------------------------
+    |
+    | Available php imap config parameters are listed below
+    |   -Delimiter (optional):
+    |       This option is only used when calling $oClient->
+    |       You can use any supported char such as ".", "/", (...)
+    |   -Fetch option:
+    |       IMAP::FT_UID  - Message marked as read by fetching the body message
+    |       IMAP::FT_PEEK - Fetch the message without setting the "seen" flag
+    |   -Fetch sequence id:
+    |       IMAP::ST_UID  - Fetch message components using the message uid
+    |       IMAP::ST_MSGN - Fetch message components using the message number
+    |   -Body download option
+    |       Default TRUE
+    |   -Flag download option
+    |       Default TRUE
+    |   -Soft fail
+    |       Default FALSE - Set to TRUE if you want to ignore certain exception while fetching bulk messages
+    |   -RFC822
+    |       Default TRUE - Set to FALSE to prevent the usage of \imap_rfc822_parse_headers().
+    |                      See https://github.com/Webklex/php-imap/issues/115 for more information.
+    |   -Debug enable to trace communication traffic
+    |   -UID cache enable the UID cache
+    |   -Fallback date is used if the given message date could not be parsed
+    |   -Boundary regex used to detect message boundaries. If you are having problems with empty messages, missing
+    |       attachments or anything like this. Be advised that it likes to break which causes new problems..
+    |   -Message key identifier option
+    |       You can choose between the following:
+    |       'id'     - Use the MessageID as array key (default, might cause hickups with yahoo mail)
+    |       'number' - Use the message number as array key (isn't always unique and can cause some interesting behavior)
+    |       'list'   - Use the message list number as array key (incrementing integer (does not always start at 0 or 1)
+    |       'uid'    - Use the message uid as array key (isn't always unique and can cause some interesting behavior)
+    |   -Fetch order
+    |       'asc'  - Order all messages ascending (probably results in oldest first)
+    |       'desc' - Order all messages descending (probably results in newest first)
+    |   -Disposition types potentially considered an attachment
+    |       Default ['attachment', 'inline']
+    |   -Common folders
+    |       Default folder locations and paths assumed if none is provided
+    |   -Open IMAP options:
+    |       DISABLE_AUTHENTICATOR - Disable authentication properties.
+    |                               Use 'GSSAPI' if you encounter the following
+    |                               error: "Kerberos error: No credentials cache
+    |                               file found (try running kinit) (...)"
+    |                               or ['GSSAPI','PLAIN'] if you are using outlook mail
+    |
+    */
+    'options' => [
+        'delimiter' => '/',
+        'fetch' => IMAP::FT_PEEK,
+        'sequence' => IMAP::ST_UID,
+        'fetch_body' => true,
+        'fetch_flags' => true,
+        'soft_fail' => false,
+        'rfc822' => true,
+        'debug' => false,
+        'uid_cache' => true,
+        // 'fallback_date' => "01.01.1970 00:00:00",
+        'boundary' => '/boundary=(.*?(?=;)|(.*))/i',
+        'message_key' => 'list',
+        'fetch_order' => 'asc',
+        'dispositions' => ['attachment', 'inline'],
+        'common_folders' => [
+            'root' => 'INBOX',
+            'junk' => 'INBOX/Junk',
+            'draft' => 'INBOX/Drafts',
+            'sent' => 'INBOX/Sent',
+            'trash' => 'INBOX/Trash',
+        ],
+        'open' => [
+            // 'DISABLE_AUTHENTICATOR' => 'GSSAPI'
+        ],
+    ],
+
+    /**
+     * |--------------------------------------------------------------------------
+     * | Available decoding options
+     * |--------------------------------------------------------------------------
+     * |
+     * | Available php imap config parameters are listed below
+     * |   -options: Decoder options (currently only the message subject and attachment name decoder can be set)
+     * |       'utf-8' - Uses imap_utf8($string) to decode a string
+     * |       'mimeheader' - Uses mb_decode_mimeheader($string) to decode a string
+     * |   -decoder: Decoder to be used. Can be replaced by custom decoders if needed.
+     * |       'header' - HeaderDecoder
+     * |       'message' - MessageDecoder
+     * |       'attachment' - AttachmentDecoder
+     */
+    'decoding' => [
+        'options' => [
+            'header' => 'utf-8', // mimeheader
+            'message' => 'utf-8', // mimeheader
+            'attachment' => 'utf-8', // mimeheader
+        ],
+        'decoder' => [
+            'header' => HeaderDecoder::class,
+            'message' => MessageDecoder::class,
+            'attachment' => AttachmentDecoder::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available flags
+    |--------------------------------------------------------------------------
+    |
+    | List all available / supported flags. Set to null to accept all given flags.
+     */
+    'flags' => ['recent', 'flagged', 'answered', 'deleted', 'seen', 'draft'],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available events
+    |--------------------------------------------------------------------------
+    |
+    */
+    'events' => [
+        'message' => [
+            'new' => MessageNewEvent::class,
+            'moved' => MessageMovedEvent::class,
+            'copied' => MessageCopiedEvent::class,
+            'deleted' => MessageDeletedEvent::class,
+            'restored' => MessageRestoredEvent::class,
+        ],
+        'folder' => [
+            'new' => FolderNewEvent::class,
+            'moved' => FolderMovedEvent::class,
+            'deleted' => FolderDeletedEvent::class,
+        ],
+        'flag' => [
+            'new' => FlagNewEvent::class,
+            'deleted' => FlagDeletedEvent::class,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Available masking options
+    |--------------------------------------------------------------------------
+    |
+    | By using your own custom masks you can implement your own methods for
+    | a better and faster access and less code to write.
+    |
+    | Checkout the two examples custom_attachment_mask and custom_message_mask
+    | for a quick start.
+    |
+    | The provided masks below are used as the default masks.
+    */
+    'masks' => [
+        'message' => MessageMask::class,
+        'attachment' => AttachmentMask::class,
+    ],
+];


### PR DESCRIPTION
## Summary
- Add `webklex/laravel-imap` `^6.2` to `composer.json`
- Publish `config/imap.php` (env-driven defaults, no real credentials)
- Default `accounts.default` entry preserved as safe env-driven stub; per-restaurant credentials remain on the `Restaurant` row (encrypted cast per PRD-003) and will be passed to `Client::make([...])` at runtime in the fetch job

## Why
Foundation for PRD-003 (E-Mail-Ingestion). Later issues add the fetch job, parser, and scheduling; this PR only installs and configures the package so a `Client` can be built.

## Acceptance criteria
- [x] Package added to `composer.json`
- [x] Config file published (`config/imap.php`)
- [x] Default driver set to one account per restaurant — runtime pattern via `Client::make([...])` supported by the published config; per-restaurant credentials live in DB (PRD-003)
- [x] No real credentials committed (only env() fallbacks and placeholder examples)

## Test plan
- `php artisan test` — 6 passed, 0 failures (191 pre-existing PHP 8.5 `PDO::MYSQL_ATTR_SSL_CA` deprecation warnings are unrelated)
- `./vendor/bin/pint --test` — pass
- `npm run lint` — pass
- `npm run format:check` — pass

Closes #32