### PR TITLE
Add email_message_id column for IMAP idempotency (#33)

### DIFF
--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -38,6 +38,7 @@ class ReservationRequest extends Model
         'message',
         'raw_payload',
         'needs_manual_review',
+        'email_message_id',
     ];
 
     /**

--- a/database/migrations/2026_04_19_105448_add_email_message_id_to_reservation_requests_table.php
+++ b/database/migrations/2026_04_19_105448_add_email_message_id_to_reservation_requests_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->string('email_message_id')->nullable()->after('raw_payload');
+            $table->unique('email_message_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->dropUnique(['email_message_id']);
+            $table->dropColumn('email_message_id');
+        });
+    }
+};

--- a/tests/Feature/Models/ReservationRequestTest.php
+++ b/tests/Feature/Models/ReservationRequestTest.php
@@ -121,6 +121,38 @@ class ReservationRequestTest extends TestCase
         $this->assertFalse($request->needs_manual_review);
     }
 
+    public function test_email_message_id_is_nullable_and_fillable(): void
+    {
+        $request = ReservationRequest::factory()->create([
+            'source' => ReservationSource::Email,
+            'email_message_id' => '<abc123@example.com>',
+        ]);
+
+        $this->assertSame('<abc123@example.com>', $request->fresh()->email_message_id);
+    }
+
+    public function test_email_message_id_allows_multiple_null_rows(): void
+    {
+        ReservationRequest::factory()->count(2)->create(['email_message_id' => null]);
+
+        $this->assertSame(2, ReservationRequest::query()->whereNull('email_message_id')->count());
+    }
+
+    public function test_duplicate_email_message_id_is_rejected_at_the_database_level(): void
+    {
+        ReservationRequest::factory()->create([
+            'source' => ReservationSource::Email,
+            'email_message_id' => '<dup@example.com>',
+        ]);
+
+        $this->expectException(QueryException::class);
+
+        ReservationRequest::factory()->create([
+            'source' => ReservationSource::Email,
+            'email_message_id' => '<dup@example.com>',
+        ]);
+    }
+
     public function test_reservation_requests_are_cascade_deleted_with_their_restaurant(): void
     {
         $restaurant = Restaurant::factory()->create();


### PR DESCRIPTION
## Summary
- Migration adds `email_message_id` (string, nullable) to `reservation_requests`
- DB-level unique index enforces idempotency (not an application check)
- `ReservationRequest::$fillable` updated so the upcoming fetch job can mass-assign it
- Tests cover the nullable/unique semantics at the Eloquent level

## Why
Foundation for PRD-003 option B (dedicated column, not a JSON path index on `raw_payload`). The unique index at the DB level is what makes the future `FetchReservationEmailsJob` idempotent even under race conditions — two parallel fetches of the same message will not both succeed.

## Acceptance criteria
- [x] New migration adds `email_message_id` string, nullable
- [x] Unique index enforced at DB level
- [x] Model `$fillable` updated
- [x] Idempotency test: inserting a duplicate `email_message_id` throws `QueryException`; multiple NULL rows coexist

## Test plan
- `php artisan test` — 200 tests, 505 assertions, 0 failures (191 pre-existing PHP 8.5 PDO deprecation warnings unrelated to this PR; 3 new tests added)
- `./vendor/bin/pint --test` — pass
- `npm run lint` — pass
- `npm run format:check` — pass

Closes #33