### PR TITLE
Add EmailReservationParser (#36)

### DIFF
--- a/app/Services/Email/EmailReservationParser.php
+++ b/app/Services/Email/EmailReservationParser.php
@@ -1,0 +1,257 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+use App\Services\Email\DTO\ParsedReservation;
+use Carbon\CarbonImmutable;
+use Throwable;
+use Webklex\PHPIMAP\Address;
+use Webklex\PHPIMAP\Message;
+
+final class EmailReservationParser
+{
+    private const PARTY_SIZE_PATTERN = '/(?:für|for)?\s*(\d{1,2})\s*(Personen|Pers\.?|Gäste|People|Guests)/iu';
+
+    private const TIME_PATTERN = '/\b(\d{1,2})[:.](\d{2})\s*(Uhr|h|am|pm)?\b/i';
+
+    private const TIME_WITH_SUFFIX_ONLY_PATTERN = '/\b(\d{1,2})\s*(Uhr|h|am|pm)\b/i';
+
+    private const ISO_DATE_PATTERN = '/\b(\d{4})-(\d{2})-(\d{2})\b/';
+
+    private const GERMAN_DOTTED_DATE_PATTERN = '/\b(\d{1,2})\.(\d{1,2})\.(\d{4})\b/';
+
+    private const GERMAN_LONG_DATE_PATTERN = '/\b(\d{1,2})\.?\s+(Januar|Februar|März|April|Mai|Juni|Juli|August|September|Oktober|November|Dezember)\s+(\d{4})\b/iu';
+
+    private const ENGLISH_DATE_PATTERN = '/\b(January|February|March|April|May|June|July|August|September|October|November|December)\s+(\d{1,2})(?:st|nd|rd|th)?,?\s+(\d{4})\b/i';
+
+    private const EMAIL_PATTERN = '/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/i';
+
+    private const NAME_FROM_BODY_PATTERN = '/Mein Name ist\s+([\p{Lu}][\p{L}\-\']*(?:\s+[\p{Lu}][\p{L}\-\']*){0,3})/u';
+
+    private const GERMAN_MONTHS = [
+        'januar' => 1, 'februar' => 2, 'märz' => 3, 'april' => 4, 'mai' => 5, 'juni' => 6,
+        'juli' => 7, 'august' => 8, 'september' => 9, 'oktober' => 10, 'november' => 11, 'dezember' => 12,
+    ];
+
+    private const ENGLISH_MONTHS = [
+        'january' => 1, 'february' => 2, 'march' => 3, 'april' => 4, 'may' => 5, 'june' => 6,
+        'july' => 7, 'august' => 8, 'september' => 9, 'october' => 10, 'november' => 11, 'december' => 12,
+    ];
+
+    private const NO_REPLY_PATTERN = '/(?:no[\-_.]?reply|do[\-_.]?not[\-_.]?reply)@/i';
+
+    public function parse(Message $message): ParsedReservation
+    {
+        $sender = $this->extractSenderAddress($message);
+
+        return $this->parseParts(
+            body: $this->extractBody($message),
+            senderEmail: $sender?->mail ?? '',
+            senderName: ($sender !== null && $sender->personal !== '') ? $sender->personal : null,
+            messageId: (string) $message->getMessageId(),
+        );
+    }
+
+    public function parseParts(
+        string $body,
+        string $senderEmail,
+        ?string $senderName,
+        string $messageId,
+    ): ParsedReservation {
+        $partySize = $this->extractPartySize($body);
+
+        [$date, $bodyWithoutDate] = $this->extractDate($body);
+        $time = $this->extractTime($bodyWithoutDate);
+
+        $desiredAt = ($date !== null && $time !== null)
+            ? $date->setTime($time[0], $time[1])
+            : null;
+
+        $guestEmail = $this->resolveGuestEmail($senderEmail, $body);
+        $guestName = $this->resolveGuestName($senderName, $body, $guestEmail);
+
+        return new ParsedReservation(
+            guestName: $guestName,
+            guestEmail: $guestEmail,
+            guestPhone: null,
+            partySize: $partySize,
+            desiredAt: $desiredAt,
+            message: trim($body),
+            confidence: $this->scoreConfidence($partySize, $date, $time),
+            messageId: $messageId,
+        );
+    }
+
+    private function extractBody(Message $message): string
+    {
+        if ($message->hasTextBody()) {
+            return $message->getTextBody();
+        }
+
+        if ($message->hasHTMLBody()) {
+            return trim(strip_tags($message->getHTMLBody()));
+        }
+
+        return '';
+    }
+
+    private function extractSenderAddress(Message $message): ?Address
+    {
+        try {
+            $from = $message->getFrom();
+        } catch (Throwable) {
+            return null;
+        }
+
+        if ($from === null) {
+            return null;
+        }
+
+        $first = is_array($from) ? ($from[0] ?? null) : (method_exists($from, 'first') ? $from->first() : null);
+
+        return $first instanceof Address ? $first : null;
+    }
+
+    private function extractPartySize(string $body): ?int
+    {
+        if (preg_match(self::PARTY_SIZE_PATTERN, $body, $matches) !== 1) {
+            return null;
+        }
+
+        $size = (int) $matches[1];
+
+        return $size > 0 ? $size : null;
+    }
+
+    /**
+     * @return array{0: CarbonImmutable|null, 1: string}
+     */
+    private function extractDate(string $body): array
+    {
+        $patterns = [
+            self::ISO_DATE_PATTERN => fn (array $m) => $this->safeCreateDate((int) $m[1], (int) $m[2], (int) $m[3]),
+            self::GERMAN_DOTTED_DATE_PATTERN => fn (array $m) => $this->safeCreateDate((int) $m[3], (int) $m[2], (int) $m[1]),
+            self::GERMAN_LONG_DATE_PATTERN => fn (array $m) => ($month = self::GERMAN_MONTHS[mb_strtolower($m[2])] ?? null)
+                ? $this->safeCreateDate((int) $m[3], $month, (int) $m[1])
+                : null,
+            self::ENGLISH_DATE_PATTERN => fn (array $m) => ($month = self::ENGLISH_MONTHS[strtolower($m[1])] ?? null)
+                ? $this->safeCreateDate((int) $m[3], $month, (int) $m[2])
+                : null,
+        ];
+
+        foreach ($patterns as $pattern => $builder) {
+            if (preg_match($pattern, $body, $matches, PREG_OFFSET_CAPTURE) === 1) {
+                $date = $builder(array_map(fn ($entry) => $entry[0], $matches));
+                if ($date === null) {
+                    continue;
+                }
+                $offset = $matches[0][1];
+                $length = strlen($matches[0][0]);
+                $stripped = substr_replace($body, str_repeat(' ', $length), $offset, $length);
+
+                return [$date, $stripped];
+            }
+        }
+
+        return [null, $body];
+    }
+
+    private function safeCreateDate(int $year, int $month, int $day): ?CarbonImmutable
+    {
+        if (! checkdate($month, $day, $year)) {
+            return null;
+        }
+
+        return CarbonImmutable::create($year, $month, $day, 0, 0, 0);
+    }
+
+    /**
+     * @return array{0: int, 1: int}|null
+     */
+    private function extractTime(string $body): ?array
+    {
+        if (preg_match(self::TIME_PATTERN, $body, $matches) === 1) {
+            $hour = (int) $matches[1];
+            $minute = (int) $matches[2];
+            $suffix = strtolower($matches[3] ?? '');
+        } elseif (preg_match(self::TIME_WITH_SUFFIX_ONLY_PATTERN, $body, $matches) === 1) {
+            $hour = (int) $matches[1];
+            $minute = 0;
+            $suffix = strtolower($matches[2]);
+        } else {
+            return null;
+        }
+
+        if ($suffix === 'pm' && $hour >= 1 && $hour <= 11) {
+            $hour += 12;
+        } elseif ($suffix === 'am' && $hour === 12) {
+            $hour = 0;
+        }
+
+        if ($hour < 0 || $hour > 23 || $minute < 0 || $minute > 59) {
+            return null;
+        }
+
+        return [$hour, $minute];
+    }
+
+    private function resolveGuestEmail(string $senderEmail, string $body): string
+    {
+        if ($senderEmail !== '' && ! $this->isNoReply($senderEmail)) {
+            return $senderEmail;
+        }
+
+        if (preg_match_all(self::EMAIL_PATTERN, $body, $matches) > 0) {
+            foreach ($matches[0] as $candidate) {
+                if (! $this->isNoReply($candidate)) {
+                    return $candidate;
+                }
+            }
+        }
+
+        return $senderEmail;
+    }
+
+    private function isNoReply(string $email): bool
+    {
+        return preg_match(self::NO_REPLY_PATTERN, $email) === 1;
+    }
+
+    private function resolveGuestName(?string $senderName, string $body, string $guestEmail): string
+    {
+        $trimmed = $senderName !== null ? trim($senderName) : '';
+
+        if ($trimmed !== '') {
+            return $trimmed;
+        }
+
+        if (preg_match(self::NAME_FROM_BODY_PATTERN, $body, $matches) === 1) {
+            return trim($matches[1]);
+        }
+
+        if ($guestEmail !== '' && str_contains($guestEmail, '@')) {
+            return strtok($guestEmail, '@') ?: '';
+        }
+
+        return '';
+    }
+
+    /**
+     * @param  array{0: int, 1: int}|null  $time
+     */
+    private function scoreConfidence(?int $partySize, ?CarbonImmutable $date, ?array $time): float
+    {
+        $fields = ($partySize !== null ? 1 : 0)
+            + ($date !== null ? 1 : 0)
+            + ($time !== null ? 1 : 0);
+
+        return match ($fields) {
+            3 => 1.0,
+            2 => 0.8,
+            1 => 0.6,
+            default => 0.2,
+        };
+    }
+}

--- a/tests/Unit/Services/Email/EmailReservationParserTest.php
+++ b/tests/Unit/Services/Email/EmailReservationParserTest.php
@@ -1,0 +1,255 @@
+<?php
+
+namespace Tests\Unit\Services\Email;
+
+use App\Services\Email\EmailReservationParser;
+use Tests\TestCase;
+
+class EmailReservationParserTest extends TestCase
+{
+    private EmailReservationParser $parser;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->parser = new EmailReservationParser;
+    }
+
+    public function test_it_extracts_all_fields_from_a_clean_german_request(): void
+    {
+        $body = 'Hallo, ich hätte gerne einen Tisch für 4 Personen am 12.05.2026 um 19:30 Uhr. Gruß, Anna Müller';
+
+        $result = $this->parser->parseParts(
+            body: $body,
+            senderEmail: 'anna@example.com',
+            senderName: 'Anna Müller',
+            messageId: '<abc@example.com>',
+        );
+
+        $this->assertSame('Anna Müller', $result->guestName);
+        $this->assertSame('anna@example.com', $result->guestEmail);
+        $this->assertSame(4, $result->partySize);
+        $this->assertNotNull($result->desiredAt);
+        $this->assertSame('2026-05-12 19:30:00', $result->desiredAt->format('Y-m-d H:i:s'));
+        $this->assertSame(1.0, $result->confidence);
+        $this->assertSame('<abc@example.com>', $result->messageId);
+    }
+
+    public function test_it_parses_iso_dates(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Table on 2026-05-01 at 19:00 for 2 people.',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertNotNull($result->desiredAt);
+        $this->assertSame('2026-05-01 19:00:00', $result->desiredAt->format('Y-m-d H:i:s'));
+    }
+
+    public function test_it_parses_german_long_dates_with_umlauts(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Gerne am 15. März 2026 um 20:00 Uhr für 3 Personen.',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertNotNull($result->desiredAt);
+        $this->assertSame('2026-03-15 20:00:00', $result->desiredAt->format('Y-m-d H:i:s'));
+    }
+
+    public function test_it_parses_english_dates_with_ordinal_suffixes_and_suffix_only_times(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Table for 6 guests on May 1st, 2026 at 7pm.',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertNotNull($result->desiredAt);
+        $this->assertSame('2026-05-01 19:00:00', $result->desiredAt->format('Y-m-d H:i:s'));
+        $this->assertSame(6, $result->partySize);
+    }
+
+    public function test_it_converts_12pm_and_12am_correctly(): void
+    {
+        $noon = $this->parser->parseParts(
+            body: 'Lunch for 2 on 2026-05-01 at 12:00pm',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+        $this->assertSame(12, $noon->desiredAt?->hour);
+
+        $midnight = $this->parser->parseParts(
+            body: 'Event on 2026-05-01 at 12:30am',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<2@example.com>',
+        );
+        $this->assertSame(0, $midnight->desiredAt?->hour);
+        $this->assertSame(30, $midnight->desiredAt?->minute);
+    }
+
+    public function test_it_rejects_invalid_calendar_dates(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Table on 31.02.2026 at 19:00',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertNull($result->desiredAt);
+    }
+
+    public function test_confidence_scales_with_extracted_fields(): void
+    {
+        $freetext = $this->parser->parseParts(
+            body: 'Haben Sie am Wochenende noch was frei?',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+        $this->assertSame(0.2, $freetext->confidence);
+
+        $oneField = $this->parser->parseParts(
+            body: 'Für 3 Personen, Tag und Zeit offen',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<2@example.com>',
+        );
+        $this->assertSame(0.6, $oneField->confidence);
+
+        $twoFields = $this->parser->parseParts(
+            body: 'Tisch am 01.05.2026 um 19:00, Personenzahl offen',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<3@example.com>',
+        );
+        $this->assertSame(0.8, $twoFields->confidence);
+    }
+
+    public function test_desired_at_is_null_when_time_is_missing(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Gerne am 01.05.2026 für 4 Personen',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertNull($result->desiredAt);
+        $this->assertSame(0.8, $result->confidence);
+    }
+
+    public function test_it_prefers_body_email_when_sender_is_no_reply(): void
+    {
+        $result = $this->parser->parseParts(
+            body: "Neue Reservierung. Kontakt: kunde@gmail.com\nTisch für 2 am 01.05.2026 um 18:00",
+            senderEmail: 'noreply@portal.de',
+            senderName: 'Portal',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertSame('kunde@gmail.com', $result->guestEmail);
+    }
+
+    public function test_it_recognises_various_no_reply_patterns(): void
+    {
+        foreach (['no-reply@x.de', 'donotreply@x.de', 'do-not-reply@x.de', 'no.reply@x.de'] as $noReply) {
+            $result = $this->parser->parseParts(
+                body: 'Gast: gast@example.com',
+                senderEmail: $noReply,
+                senderName: 'Portal',
+                messageId: '<1@example.com>',
+            );
+            $this->assertSame('gast@example.com', $result->guestEmail, "Failed for sender: {$noReply}");
+        }
+    }
+
+    public function test_it_keeps_sender_email_when_body_only_has_no_reply_candidates(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Siehe noreply@system.de',
+            senderEmail: 'noreply@portal.de',
+            senderName: null,
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertSame('noreply@portal.de', $result->guestEmail);
+    }
+
+    public function test_it_falls_back_to_body_name_when_sender_display_name_is_missing(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Mein Name ist Jürgen Müller und ich hätte gerne einen Tisch.',
+            senderEmail: 'j@example.com',
+            senderName: null,
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertSame('Jürgen Müller', $result->guestName);
+    }
+
+    public function test_it_falls_back_to_email_local_part_when_no_name_available(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Haben Sie frei?',
+            senderEmail: 'john.doe@example.com',
+            senderName: null,
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertSame('john.doe', $result->guestName);
+    }
+
+    public function test_it_uses_sender_display_name_verbatim_even_with_umlauts_and_comma(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Haben Sie frei?',
+            senderEmail: 'j@example.com',
+            senderName: 'Müller, Jürgen',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertSame('Müller, Jürgen', $result->guestName);
+    }
+
+    public function test_it_extracts_party_size_with_various_german_and_english_suffixes(): void
+    {
+        $cases = [
+            'Tisch für 4 Personen' => 4,
+            '5 Gäste' => 5,
+            'Table for 6 guests' => 6,
+            '3 Pers.' => 3,
+        ];
+
+        foreach ($cases as $body => $expected) {
+            $result = $this->parser->parseParts(
+                body: $body,
+                senderEmail: 'x@example.com',
+                senderName: 'X',
+                messageId: '<id@example.com>',
+            );
+            $this->assertSame($expected, $result->partySize, "Failed for: {$body}");
+        }
+    }
+
+    public function test_it_leaves_phone_null_for_v1(): void
+    {
+        $result = $this->parser->parseParts(
+            body: 'Tisch für 2 am 01.05.2026 um 19:00, Tel: 030 1234567',
+            senderEmail: 'x@example.com',
+            senderName: 'X',
+            messageId: '<1@example.com>',
+        );
+
+        $this->assertNull($result->guestPhone);
+    }
+}


### PR DESCRIPTION
## Summary
- `App\Services\Email\EmailReservationParser` implementing PRD-003's heuristic regex extraction
- Two public entry points:
  - `parse(Message $message)` — thin adapter pulling body / sender / message-id off a Webklex `Message`
  - `parseParts(string $body, string $senderEmail, ?string $senderName, string $messageId)` — pure function, no IMAP dependency (the actual parsing logic)
- Date formats: ISO, German dotted, German long (with umlauts), English (with optional ordinal suffixes). Invalid calendar dates are rejected via `checkdate()`
- Time formats: `HH:MM[.]MM` with optional `Uhr|h|am|pm` suffix, plus suffix-only times (`7pm`, `12pm`=noon, `12am`=midnight)
- Date match is stripped from the body before time extraction — otherwise `12.05.2026` leaks into the time regex as `12:05`
- Email resolution prefers in-body addresses when the sender is a no-reply pattern (`no-reply@`, `donotreply@`, etc.)
- Name resolution: sender display-name → "Mein Name ist ..." pattern → email local part
- Confidence: 3 fields → 1.0, 2 → 0.8, 1 → 0.6, 0 → 0.2 (maps onto PRD-003's tiers)

## Why
Prerequisite for `FetchReservationEmailsJob` (#35). The parser was split off so the job becomes pure plumbing (#35 stays small and reviewable), and so the heuristics can be iterated on without touching the job.

## Acceptance criteria
- [x] Input: `\Webklex\PHPIMAP\Message`
- [x] Output: `ParsedReservation` with `guestName`, `guestEmail`, `guestPhone?`, `partySize?`, `desiredAt?`, `message`, `confidence`, `messageId`
- [x] Party-size regex per PRD (German + English)
- [x] Date parsing covers ISO, `01.05.2026`, `1. Mai 2026`, `May 1, 2026`
- [x] Time regex per PRD + suffix-only fallback for `Npm`/`Nam`/`N Uhr`
- [x] Email resolution: in-body address preferred when sender is no-reply
- [x] Name resolution: display-name → body pattern fallback
- [x] Confidence tiers per PRD-003

## Out of scope (separate issues)
- HTML-to-plaintext conversion (#37)
- Fixture `.eml` files (#42) and fixture-based tests (#43)
- `FetchReservationEmailsJob` integration (#35)
- `Message` adapter coverage will arrive via the feature-test suite in #44

## Test plan
- `php artisan test` — 220 tests, 556 assertions, 0 failures (+16 new parser tests)
- `./vendor/bin/pint --test` — pass
- `npm run lint` — pass

Closes #36