### PR TITLE
Add FetchReservationEmailsJob with per-message isolation (#35)

### DIFF
--- a/app/Jobs/FetchReservationEmailsJob.php
+++ b/app/Jobs/FetchReservationEmailsJob.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Events\ReservationRequestReceived;
+use App\Models\FailedEmailImport;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Email\Contracts\ImapMailbox;
+use App\Services\Email\Contracts\ImapMailboxFactory;
+use App\Services\Email\DTO\FetchedEmail;
+use App\Services\Email\EmailReservationParser;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Queue\Queueable;
+use Throwable;
+
+final class FetchReservationEmailsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public function __construct(public int $restaurantId) {}
+
+    /**
+     * @return list<int>
+     */
+    public function backoff(): array
+    {
+        return [60, 300, 900];
+    }
+
+    public function handle(ImapMailboxFactory $factory, EmailReservationParser $parser): void
+    {
+        $restaurant = Restaurant::find($this->restaurantId);
+
+        if ($restaurant === null || $restaurant->imap_host === null || $restaurant->imap_host === '') {
+            return;
+        }
+
+        $mailbox = $factory->open($restaurant);
+
+        foreach ($mailbox->fetchUnseen() as $email) {
+            try {
+                $this->processEmail($email, $mailbox, $parser, $restaurant);
+            } catch (Throwable $e) {
+                $this->recordFailure($restaurant, $email, $e);
+            }
+        }
+    }
+
+    private function processEmail(
+        FetchedEmail $email,
+        ImapMailbox $mailbox,
+        EmailReservationParser $parser,
+        Restaurant $restaurant,
+    ): void {
+        if ($email->messageId !== '' && $this->alreadyImported($email->messageId)) {
+            $mailbox->markSeen($email);
+
+            return;
+        }
+
+        $parsed = $parser->parseParts(
+            body: $email->body,
+            senderEmail: $email->senderEmail,
+            senderName: $email->senderName,
+            messageId: $email->messageId,
+        );
+
+        try {
+            $request = ReservationRequest::create(
+                $parsed->toReservationRequestAttributes($restaurant->id)
+            );
+        } catch (QueryException $e) {
+            if ($this->isUniqueViolation($e)) {
+                $mailbox->markSeen($email);
+
+                return;
+            }
+
+            throw $e;
+        }
+
+        $mailbox->markSeen($email);
+
+        ReservationRequestReceived::dispatch($request);
+    }
+
+    private function alreadyImported(string $messageId): bool
+    {
+        return ReservationRequest::where('email_message_id', $messageId)->exists();
+    }
+
+    private function isUniqueViolation(QueryException $e): bool
+    {
+        $sqlState = $e->errorInfo[0] ?? null;
+        $driverCode = $e->errorInfo[1] ?? null;
+
+        return $sqlState === '23000' || $driverCode === 1062 || $driverCode === 19;
+    }
+
+    private function recordFailure(Restaurant $restaurant, FetchedEmail $email, Throwable $e): void
+    {
+        FailedEmailImport::create([
+            'restaurant_id' => $restaurant->id,
+            'message_id' => $email->messageId,
+            'raw_headers' => $email->rawHeaders,
+            'raw_body' => $email->rawBody,
+            'error' => $e->getMessage(),
+        ]);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Services\Email\Contracts\ImapMailboxFactory;
+use App\Services\Email\WebklexImapMailboxFactory;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -11,7 +13,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        $this->app->bind(ImapMailboxFactory::class, WebklexImapMailboxFactory::class);
     }
 
     /**

--- a/app/Services/Email/Contracts/ImapMailbox.php
+++ b/app/Services/Email/Contracts/ImapMailbox.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email\Contracts;
+
+use App\Services\Email\DTO\FetchedEmail;
+
+interface ImapMailbox
+{
+    /**
+     * @return list<FetchedEmail>
+     */
+    public function fetchUnseen(): array;
+
+    public function markSeen(FetchedEmail $email): void;
+}

--- a/app/Services/Email/Contracts/ImapMailboxFactory.php
+++ b/app/Services/Email/Contracts/ImapMailboxFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email\Contracts;
+
+use App\Models\Restaurant;
+
+interface ImapMailboxFactory
+{
+    public function open(Restaurant $restaurant): ImapMailbox;
+}

--- a/app/Services/Email/DTO/FetchedEmail.php
+++ b/app/Services/Email/DTO/FetchedEmail.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email\DTO;
+
+final readonly class FetchedEmail
+{
+    public function __construct(
+        public string $messageId,
+        public string $body,
+        public string $senderEmail,
+        public ?string $senderName,
+        public string $rawHeaders,
+        public string $rawBody,
+    ) {}
+}

--- a/app/Services/Email/WebklexImapMailbox.php
+++ b/app/Services/Email/WebklexImapMailbox.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+use App\Services\Email\Contracts\ImapMailbox;
+use App\Services\Email\DTO\FetchedEmail;
+use Throwable;
+use Webklex\PHPIMAP\Address;
+use Webklex\PHPIMAP\Folder;
+use Webklex\PHPIMAP\Message;
+
+final class WebklexImapMailbox implements ImapMailbox
+{
+    /** @var array<string, Message> */
+    private array $seenCache = [];
+
+    public function __construct(private readonly Folder $inbox) {}
+
+    public function fetchUnseen(): array
+    {
+        $messages = $this->inbox->messages()->unseen()->get();
+
+        $result = [];
+        foreach ($messages as $message) {
+            /** @var Message $message */
+            $messageId = (string) $message->getMessageId();
+            $body = $this->extractBody($message);
+            $sender = $this->extractSender($message);
+
+            $fetched = new FetchedEmail(
+                messageId: $messageId,
+                body: $body,
+                senderEmail: $sender?->mail ?? '',
+                senderName: ($sender !== null && $sender->personal !== '') ? $sender->personal : null,
+                rawHeaders: (string) $message->getHeader()->raw,
+                rawBody: $body,
+            );
+
+            $this->seenCache[$messageId] = $message;
+            $result[] = $fetched;
+        }
+
+        return $result;
+    }
+
+    public function markSeen(FetchedEmail $email): void
+    {
+        $message = $this->seenCache[$email->messageId] ?? null;
+        $message?->setFlag('Seen');
+    }
+
+    private function extractBody(Message $message): string
+    {
+        if ($message->hasTextBody()) {
+            return $message->getTextBody();
+        }
+
+        if ($message->hasHTMLBody()) {
+            return trim(strip_tags($message->getHTMLBody()));
+        }
+
+        return '';
+    }
+
+    private function extractSender(Message $message): ?Address
+    {
+        try {
+            $from = $message->getFrom();
+        } catch (Throwable) {
+            return null;
+        }
+
+        if ($from === null) {
+            return null;
+        }
+
+        $first = is_array($from) ? ($from[0] ?? null) : (method_exists($from, 'first') ? $from->first() : null);
+
+        return $first instanceof Address ? $first : null;
+    }
+}

--- a/app/Services/Email/WebklexImapMailboxFactory.php
+++ b/app/Services/Email/WebklexImapMailboxFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+use App\Models\Restaurant;
+use App\Services\Email\Contracts\ImapMailbox;
+use App\Services\Email\Contracts\ImapMailboxFactory;
+use RuntimeException;
+use Webklex\PHPIMAP\ClientManager;
+
+final class WebklexImapMailboxFactory implements ImapMailboxFactory
+{
+    public function __construct(private readonly ClientManager $manager) {}
+
+    public function open(Restaurant $restaurant): ImapMailbox
+    {
+        $client = $this->manager->make([
+            'host' => (string) $restaurant->imap_host,
+            'port' => 993,
+            'encryption' => 'ssl',
+            'validate_cert' => true,
+            'username' => (string) $restaurant->imap_username,
+            'password' => (string) $restaurant->imap_password,
+            'protocol' => 'imap',
+        ]);
+
+        $client->connect();
+
+        $inbox = $client->getFolderByPath('INBOX');
+
+        if ($inbox === null) {
+            throw new RuntimeException('INBOX folder not available on IMAP server');
+        }
+
+        return new WebklexImapMailbox($inbox);
+    }
+}

--- a/tests/Unit/Jobs/FetchReservationEmailsJobTest.php
+++ b/tests/Unit/Jobs/FetchReservationEmailsJobTest.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Events\ReservationRequestReceived;
+use App\Jobs\FetchReservationEmailsJob;
+use App\Models\FailedEmailImport;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Email\Contracts\ImapMailbox;
+use App\Services\Email\Contracts\ImapMailboxFactory;
+use App\Services\Email\DTO\FetchedEmail;
+use App\Services\Email\EmailReservationParser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class FetchReservationEmailsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_is_a_no_op_when_restaurant_has_no_imap_host(): void
+    {
+        $restaurant = Restaurant::factory()->create(['imap_host' => null]);
+        $factory = new FakeImapMailboxFactory([]);
+
+        $this->runJob($restaurant->id, $factory);
+
+        $this->assertFalse($factory->opened);
+        $this->assertSame(0, ReservationRequest::count());
+    }
+
+    public function test_it_is_a_no_op_when_restaurant_does_not_exist(): void
+    {
+        $factory = new FakeImapMailboxFactory([]);
+
+        $this->runJob(9999, $factory);
+
+        $this->assertFalse($factory->opened);
+    }
+
+    public function test_it_parses_unseen_messages_and_creates_reservation_requests(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+
+        $restaurant = Restaurant::factory()->create(['imap_host' => 'imap.example.com']);
+        $email = $this->makeEmail(
+            messageId: '<abc@example.com>',
+            body: 'Tisch für 4 Personen am 12.05.2026 um 19:30 Uhr. Gruß, Anna Müller',
+            senderEmail: 'anna@example.com',
+            senderName: 'Anna Müller',
+        );
+        $factory = new FakeImapMailboxFactory([$email]);
+
+        $this->runJob($restaurant->id, $factory);
+
+        $this->assertSame(1, ReservationRequest::count());
+        $request = ReservationRequest::first();
+        $this->assertSame('<abc@example.com>', $request->email_message_id);
+        $this->assertSame('Anna Müller', $request->guest_name);
+        $this->assertSame(4, $request->party_size);
+        $this->assertFalse($request->needs_manual_review);
+        $this->assertSame([$email], $factory->mailbox->seen);
+        Event::assertDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_it_skips_messages_whose_message_id_is_already_imported(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+
+        $restaurant = Restaurant::factory()->create(['imap_host' => 'imap.example.com']);
+        ReservationRequest::factory()->for($restaurant)->create([
+            'email_message_id' => '<dup@example.com>',
+        ]);
+
+        $email = $this->makeEmail(messageId: '<dup@example.com>');
+        $factory = new FakeImapMailboxFactory([$email]);
+
+        $this->runJob($restaurant->id, $factory);
+
+        $this->assertSame(1, ReservationRequest::count());
+        $this->assertSame([$email], $factory->mailbox->seen);
+        Event::assertNotDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_it_isolates_failures_per_message_and_keeps_processing(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+
+        $restaurant = Restaurant::factory()->create(['imap_host' => 'imap.example.com']);
+
+        $good = $this->makeEmail(
+            messageId: '<good@example.com>',
+            body: 'Tisch für 2 Personen am 01.05.2026 um 19:00 Uhr.',
+            senderEmail: 'ok@example.com',
+        );
+        $bad = $this->makeEmail(messageId: '<bad@example.com>', rawBody: 'raw-bad');
+
+        $factory = new FakeImapMailboxFactory([$bad, $good]);
+        $factory->mailbox->failOn = '<bad@example.com>';
+
+        $this->runJob($restaurant->id, $factory);
+
+        // Both reservations persist (bad failed on IMAP markSeen *after* DB create).
+        $this->assertSame(2, ReservationRequest::count());
+
+        $this->assertSame(1, FailedEmailImport::count());
+        $failure = FailedEmailImport::first();
+        $this->assertSame($restaurant->id, $failure->restaurant_id);
+        $this->assertSame('<bad@example.com>', $failure->message_id);
+        $this->assertSame('raw-bad', $failure->raw_body);
+        $this->assertNotSame('', $failure->error);
+
+        // markSeen threw for bad; good was still processed and marked seen.
+        $this->assertSame([$good], $factory->mailbox->seen);
+
+        // Event is only dispatched after markSeen succeeds — so bad is skipped.
+        Event::assertDispatchedTimes(ReservationRequestReceived::class, 1);
+    }
+
+    private function runJob(int $restaurantId, ImapMailboxFactory $factory): void
+    {
+        $job = new FetchReservationEmailsJob($restaurantId);
+        $job->handle($factory, new EmailReservationParser);
+    }
+
+    private function makeEmail(
+        string $messageId = '<m@example.com>',
+        string $body = 'Tisch für 2 Personen am 01.05.2026 um 19:00 Uhr',
+        string $senderEmail = 'guest@example.com',
+        ?string $senderName = 'Guest',
+        string $rawHeaders = 'raw-headers',
+        string $rawBody = 'raw-body',
+    ): FetchedEmail {
+        return new FetchedEmail(
+            messageId: $messageId,
+            body: $body,
+            senderEmail: $senderEmail,
+            senderName: $senderName,
+            rawHeaders: $rawHeaders,
+            rawBody: $rawBody,
+        );
+    }
+}
+
+final class FakeImapMailboxFactory implements ImapMailboxFactory
+{
+    public bool $opened = false;
+
+    public FakeImapMailbox $mailbox;
+
+    /**
+     * @param  list<FetchedEmail>  $emails
+     */
+    public function __construct(array $emails)
+    {
+        $this->mailbox = new FakeImapMailbox($emails);
+    }
+
+    public function open(Restaurant $restaurant): ImapMailbox
+    {
+        $this->opened = true;
+
+        return $this->mailbox;
+    }
+}
+
+final class FakeImapMailbox implements ImapMailbox
+{
+    /** @var list<FetchedEmail> */
+    public array $seen = [];
+
+    public ?string $failOn = null;
+
+    /**
+     * @param  list<FetchedEmail>  $emails
+     */
+    public function __construct(private array $emails) {}
+
+    public function fetchUnseen(): array
+    {
+        return $this->emails;
+    }
+
+    public function markSeen(FetchedEmail $email): void
+    {
+        if ($this->failOn !== null && $email->messageId === $this->failOn) {
+            throw new \RuntimeException('boom');
+        }
+        $this->seen[] = $email;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `App\Jobs\FetchReservationEmailsJob` — per-restaurant unseen-mail fetcher per PRD-003.
- Introduces a thin `ImapMailbox` contract (+ `FetchedEmail` DTO) and a Webklex-backed `WebklexImapMailboxFactory` so the IMAP coupling lives in one place and the job is fully unit-testable without a live server.
- Binds the factory in `AppServiceProvider`.

Job behaviour:
- Silent no-op when the restaurant row is missing or has no `imap_host`.
- Idempotent via the `email_message_id` unique index — already-imported messages are skipped and re-marked seen.
- Per-message `try/catch` records failures into `failed_email_imports` and keeps looping, so one bad mail never stalls a batch.
- Handles unique-index races (23000 / 1062 / SQLite 19) gracefully.
- Connection-level exceptions bubble up to the queue → `$tries = 3`, exponential `backoff() = [60, 300, 900]`.
- Messages are marked seen, never deleted. `ReservationRequestReceived` is dispatched only after a successful `markSeen`.
- No credentials are logged — the factory reads them directly from the encrypted `imap_password` cast and never echoes them.

## Why
Issue #35 is the ingest-side counterpart to the email-message-id column (#33) and the parser (#36). With this job in place, the scheduler can run per-restaurant fetches and funnel requests into the dashboard inbox. Full IMAP integration / feature tests are scoped to #44; this PR ships the job logic plus light unit coverage.

## Test plan
- [x] `php artisan test --filter=FetchReservationEmailsJobTest` → 5 passed
- [x] `php artisan test` → no new failures
- [x] `./vendor/bin/pint --test` → clean

Closes #35