### PR TITLE
Tighten IMAP retry policy and add credential-safe failure log (#87)

### DIFF
--- a/app/Jobs/FetchReservationEmailsJob.php
+++ b/app/Jobs/FetchReservationEmailsJob.php
@@ -15,6 +15,7 @@ use App\Services\Email\EmailReservationParser;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
 use Throwable;
 
 final class FetchReservationEmailsJob implements ShouldQueue
@@ -23,6 +24,8 @@ final class FetchReservationEmailsJob implements ShouldQueue
 
     public int $tries = 3;
 
+    public int $timeout = 120;
+
     public function __construct(public int $restaurantId) {}
 
     /**
@@ -30,7 +33,20 @@ final class FetchReservationEmailsJob implements ShouldQueue
      */
     public function backoff(): array
     {
-        return [60, 300, 900];
+        return [30, 120, 300];
+    }
+
+    public function failed(Throwable $exception): void
+    {
+        $restaurant = Restaurant::find($this->restaurantId);
+
+        Log::error('reservation.imap.fetch_failed', [
+            'restaurant_id' => $this->restaurantId,
+            'host' => $restaurant?->imap_host,
+            'username' => $restaurant?->imap_username,
+            'exception' => $exception::class,
+            'message' => $exception->getMessage(),
+        ]);
     }
 
     public function handle(ImapMailboxFactory $factory, EmailReservationParser $parser): void

--- a/tests/Unit/Jobs/FetchReservationEmailsJobTest.php
+++ b/tests/Unit/Jobs/FetchReservationEmailsJobTest.php
@@ -13,6 +13,8 @@ use App\Services\Email\DTO\FetchedEmail;
 use App\Services\Email\EmailReservationParser;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
 use Tests\TestCase;
 
 class FetchReservationEmailsJobTest extends TestCase
@@ -118,6 +120,57 @@ class FetchReservationEmailsJobTest extends TestCase
         Event::assertDispatchedTimes(ReservationRequestReceived::class, 1);
     }
 
+    public function test_retry_policy_exposes_three_tries_and_exponential_backoff(): void
+    {
+        $job = new FetchReservationEmailsJob(1);
+
+        $this->assertSame(3, $job->tries);
+        $this->assertSame(120, $job->timeout);
+        $this->assertSame([30, 120, 300], $job->backoff());
+    }
+
+    public function test_connection_failures_bubble_out_of_handle_so_the_queue_can_retry(): void
+    {
+        $restaurant = Restaurant::factory()->create(['imap_host' => 'imap.example.com']);
+        $factory = new ThrowingImapMailboxFactory(new RuntimeException('imap connect failed'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('imap connect failed');
+
+        $this->runJob($restaurant->id, $factory);
+    }
+
+    public function test_failed_hook_logs_context_without_credentials(): void
+    {
+        Log::spy();
+
+        $restaurant = Restaurant::factory()->create([
+            'imap_host' => 'imap.example.com',
+            'imap_username' => 'mailbox@example.com',
+            'imap_password' => 'super-secret-password-xyz',
+        ]);
+
+        $job = new FetchReservationEmailsJob($restaurant->id);
+        $job->failed(new RuntimeException('connection refused'));
+
+        Log::shouldHaveReceived('error')->once()->withArgs(function (string $message, array $context) use ($restaurant) {
+            $this->assertSame('reservation.imap.fetch_failed', $message);
+            $this->assertSame($restaurant->id, $context['restaurant_id']);
+            $this->assertSame('imap.example.com', $context['host']);
+            $this->assertSame('mailbox@example.com', $context['username']);
+            $this->assertSame(RuntimeException::class, $context['exception']);
+            $this->assertSame('connection refused', $context['message']);
+
+            $this->assertArrayNotHasKey('password', $context);
+            $this->assertArrayNotHasKey('imap_password', $context);
+
+            $serialised = json_encode($context);
+            $this->assertStringNotContainsString('super-secret-password-xyz', (string) $serialised);
+
+            return true;
+        });
+    }
+
     private function runJob(int $restaurantId, ImapMailboxFactory $factory): void
     {
         $job = new FetchReservationEmailsJob($restaurantId);
@@ -185,8 +238,18 @@ final class FakeImapMailbox implements ImapMailbox
     public function markSeen(FetchedEmail $email): void
     {
         if ($this->failOn !== null && $email->messageId === $this->failOn) {
-            throw new \RuntimeException('boom');
+            throw new RuntimeException('boom');
         }
         $this->seen[] = $email;
+    }
+}
+
+final class ThrowingImapMailboxFactory implements ImapMailboxFactory
+{
+    public function __construct(private \Throwable $exception) {}
+
+    public function open(Restaurant $restaurant): ImapMailbox
+    {
+        throw $this->exception;
     }
 }


### PR DESCRIPTION
## Summary
- Aligns `FetchReservationEmailsJob` with the retry contract from #87:
  - `public int $tries = 3;` (unchanged)
  - `backoff()` now returns `[30, 120, 300]` — the issue-specified exponential curve instead of the previous `[60, 300, 900]`
  - `public int $timeout = 120;` so a hung IMAP socket can't sit forever
- Adds a `failed(Throwable $exception)` hook that logs a single error-level entry with `restaurant_id`, `host`, `username`, exception class, and message — and nothing else. The IMAP password and mail bodies are deliberately absent.
- Three new unit tests:
  - `test_retry_policy_exposes_three_tries_and_exponential_backoff` — pins the getters.
  - `test_connection_failures_bubble_out_of_handle_so_the_queue_can_retry` — proves that an exception from `ImapMailboxFactory::open` isn't swallowed by the per-message loop, so Laravel's retry machinery sees the failure.
  - `test_failed_hook_logs_context_without_credentials` — spies on the logger, asserts the exact context keys, and grep-asserts the raw password string never appears in the serialised context.

## Why
PRD-003 pins the retry contract but #35 only implemented the tries + backoff pair. Without `$timeout` a stuck IMAP connection would eat worker capacity, and without `failed()` we'd lose the signal that a restaurant's mailbox has been unreachable for 3 attempts. The credential-safe log shape is the PRD-003 security invariant that also shows up in #40 — this PR is the enforcement point for the job itself.

## Acceptance criteria
- [x] Connection failure triggers up to 3 attempts with the defined backoff (tests + getters pinned)
- [x] After 3rd failure, a single `error` log entry is written with no credentials
- [x] Per-message parse errors do not count against `\$tries` (already the case from #35 — the outer handle loop swallows them into `failed_email_imports`)
- [x] Unit test with mocked IMAP factory asserts the bubble-through + log shape

## Out of scope
- True end-to-end retry count assertion (would need a real queue worker harness) — deferred to #44.
- Application-wide logging hygiene grep — scope of #40.

## Test plan
- [x] `php artisan test --filter=FetchReservationEmailsJobTest` → 8 passed, 36 assertions
- [x] `php artisan test` → no new failures
- [x] `./vendor/bin/pint --test` → clean

Closes #87