### PR TITLE
Convert HTML mails to plain text before parsing (#37)

### DIFF
--- a/app/Services/Email/EmailReservationParser.php
+++ b/app/Services/Email/EmailReservationParser.php
@@ -12,6 +12,10 @@ use Webklex\PHPIMAP\Message;
 
 final class EmailReservationParser
 {
+    public function __construct(
+        private readonly HtmlToPlainText $htmlToPlainText = new HtmlToPlainText,
+    ) {}
+
     private const PARTY_SIZE_PATTERN = '/(?:für|for)?\s*(\d{1,2})\s*(Personen|Pers\.?|Gäste|People|Guests)/iu';
 
     private const TIME_PATTERN = '/\b(\d{1,2})[:.](\d{2})\s*(Uhr|h|am|pm)?\b/i';
@@ -91,7 +95,7 @@ final class EmailReservationParser
         }
 
         if ($message->hasHTMLBody()) {
-            return trim(strip_tags($message->getHTMLBody()));
+            return $this->htmlToPlainText->convert($message->getHTMLBody());
         }
 
         return '';

--- a/app/Services/Email/HtmlToPlainText.php
+++ b/app/Services/Email/HtmlToPlainText.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+final class HtmlToPlainText
+{
+    public function convert(string $html): string
+    {
+        if ($html === '') {
+            return '';
+        }
+
+        $withoutInvisible = $this->stripInvisibleBlocks($html);
+        $withLineBreaks = $this->insertLineBreaks($withoutInvisible);
+        $plain = strip_tags($withLineBreaks);
+        $decoded = html_entity_decode($plain, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
+        return $this->normalizeWhitespace($decoded);
+    }
+
+    private function stripInvisibleBlocks(string $html): string
+    {
+        return (string) preg_replace(
+            '#<(script|style)\b[^>]*>.*?</\1>#is',
+            '',
+            $html,
+        );
+    }
+
+    private function insertLineBreaks(string $html): string
+    {
+        $html = (string) preg_replace('#<br\s*/?\s*>#i', "\n", $html);
+
+        $paragraphTags = 'p|div|h[1-6]|tr|li|ul|ol|table|thead|tbody|blockquote|article|section|header|footer';
+
+        return (string) preg_replace("#</?($paragraphTags)\\b[^>]*>#i", "\n\n", $html);
+    }
+
+    private function normalizeWhitespace(string $text): string
+    {
+        $text = str_replace(["\r\n", "\r", "\u{00A0}"], ["\n", "\n", ' '], $text);
+        $lines = array_map(fn (string $line): string => preg_replace('/[ \t]+/', ' ', trim($line)), explode("\n", $text));
+        $collapsed = preg_replace("/\n{3,}/", "\n\n", implode("\n", $lines));
+
+        return trim((string) $collapsed);
+    }
+}

--- a/app/Services/Email/WebklexImapMailbox.php
+++ b/app/Services/Email/WebklexImapMailbox.php
@@ -16,7 +16,10 @@ final class WebklexImapMailbox implements ImapMailbox
     /** @var array<string, Message> */
     private array $seenCache = [];
 
-    public function __construct(private readonly Folder $inbox) {}
+    public function __construct(
+        private readonly Folder $inbox,
+        private readonly HtmlToPlainText $htmlToPlainText = new HtmlToPlainText,
+    ) {}
 
     public function fetchUnseen(): array
     {
@@ -58,7 +61,7 @@ final class WebklexImapMailbox implements ImapMailbox
         }
 
         if ($message->hasHTMLBody()) {
-            return trim(strip_tags($message->getHTMLBody()));
+            return $this->htmlToPlainText->convert($message->getHTMLBody());
         }
 
         return '';

--- a/tests/Unit/Services/Email/EmailReservationParserTest.php
+++ b/tests/Unit/Services/Email/EmailReservationParserTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Unit\Services\Email;
 
 use App\Services\Email\EmailReservationParser;
+use App\Services\Email\HtmlToPlainText;
 use Tests\TestCase;
 
 class EmailReservationParserTest extends TestCase
@@ -239,6 +240,42 @@ class EmailReservationParserTest extends TestCase
             );
             $this->assertSame($expected, $result->partySize, "Failed for: {$body}");
         }
+    }
+
+    public function test_html_and_plaintext_versions_of_the_same_mail_parse_identically(): void
+    {
+        $plaintext = "Hallo,\n\nich hätte gerne einen Tisch für 4 Personen am 12.05.2026 um 19:30 Uhr.\n\nGruß,\nAnna Müller";
+
+        $html = '<html><body>'
+            .'<p>Hallo,</p>'
+            .'<p>ich h&auml;tte gerne einen Tisch f&uuml;r 4 Personen am 12.05.2026 um 19:30 Uhr.</p>'
+            .'<p>Gru&szlig;,<br>Anna M&uuml;ller</p>'
+            .'</body></html>';
+
+        $converter = new HtmlToPlainText;
+        $htmlAsText = $converter->convert($html);
+
+        $fromPlain = $this->parser->parseParts(
+            body: $plaintext,
+            senderEmail: 'anna@example.com',
+            senderName: 'Anna Müller',
+            messageId: '<plain@example.com>',
+        );
+
+        $fromHtml = $this->parser->parseParts(
+            body: $htmlAsText,
+            senderEmail: 'anna@example.com',
+            senderName: 'Anna Müller',
+            messageId: '<html@example.com>',
+        );
+
+        $this->assertSame($fromPlain->partySize, $fromHtml->partySize);
+        $this->assertSame(
+            $fromPlain->desiredAt?->format('Y-m-d H:i:s'),
+            $fromHtml->desiredAt?->format('Y-m-d H:i:s'),
+        );
+        $this->assertSame($fromPlain->guestName, $fromHtml->guestName);
+        $this->assertSame($fromPlain->confidence, $fromHtml->confidence);
     }
 
     public function test_it_leaves_phone_null_for_v1(): void

--- a/tests/Unit/Services/Email/HtmlToPlainTextTest.php
+++ b/tests/Unit/Services/Email/HtmlToPlainTextTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Email;
+
+use App\Services\Email\HtmlToPlainText;
+use Tests\TestCase;
+
+class HtmlToPlainTextTest extends TestCase
+{
+    private HtmlToPlainText $converter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->converter = new HtmlToPlainText;
+    }
+
+    public function test_it_returns_empty_string_for_empty_input(): void
+    {
+        $this->assertSame('', $this->converter->convert(''));
+    }
+
+    public function test_it_strips_simple_tags(): void
+    {
+        $html = '<p>Hallo Welt</p>';
+
+        $this->assertSame('Hallo Welt', $this->converter->convert($html));
+    }
+
+    public function test_it_preserves_paragraph_breaks_as_blank_lines(): void
+    {
+        $html = '<p>Erste Zeile</p><p>Zweite Zeile</p>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertStringContainsString('Erste Zeile', $result);
+        $this->assertStringContainsString('Zweite Zeile', $result);
+        $this->assertMatchesRegularExpression('/Erste Zeile\s*\n\s*\n?\s*Zweite Zeile/', $result);
+    }
+
+    public function test_it_converts_br_tags_to_newlines(): void
+    {
+        $html = 'Zeile 1<br>Zeile 2<br/>Zeile 3';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertSame("Zeile 1\nZeile 2\nZeile 3", $result);
+    }
+
+    public function test_it_treats_block_tags_as_line_breaks(): void
+    {
+        $html = '<div>A</div><div>B</div><h1>C</h1>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertMatchesRegularExpression('/A\s*\n+\s*B\s*\n+\s*C/', $result);
+    }
+
+    public function test_it_converts_list_items_to_lines(): void
+    {
+        $html = '<ul><li>Eins</li><li>Zwei</li></ul>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertStringContainsString('Eins', $result);
+        $this->assertStringContainsString('Zwei', $result);
+        $this->assertMatchesRegularExpression('/Eins\s*\n+\s*Zwei/', $result);
+    }
+
+    public function test_it_converts_table_rows_to_lines(): void
+    {
+        $html = '<table><tr><td>Name</td><td>Anna</td></tr><tr><td>Zeit</td><td>19:00</td></tr></table>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertMatchesRegularExpression('/Anna\s*\n+\s*Zeit/', $result);
+    }
+
+    public function test_it_strips_script_and_style_blocks_including_content(): void
+    {
+        $html = '<style>.x { color: red; }</style><p>Hallo</p><script>alert("x")</script>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertSame('Hallo', $result);
+    }
+
+    public function test_it_preserves_umlauts(): void
+    {
+        $html = '<p>Für 4 Personen um 20:00 Uhr, Grüße Jürgen Müller</p>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertStringContainsString('Für', $result);
+        $this->assertStringContainsString('Grüße', $result);
+        $this->assertStringContainsString('Jürgen Müller', $result);
+    }
+
+    public function test_it_preserves_emoji(): void
+    {
+        $html = '<p>Freue mich 🎉</p>';
+
+        $this->assertStringContainsString('🎉', $this->converter->convert($html));
+    }
+
+    public function test_it_decodes_html_entities(): void
+    {
+        $html = '<p>Tisch f&uuml;r 2 &amp; ein Kind &ndash; 19:00</p>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertStringContainsString('für', $result);
+        $this->assertStringContainsString('&', $result);
+        $this->assertStringNotContainsString('&amp;', $result);
+        $this->assertStringContainsString('–', $result);
+    }
+
+    public function test_it_replaces_nbsp_with_regular_space(): void
+    {
+        $html = "<p>Tisch\u{00A0}für\u{00A0}2</p>";
+
+        $result = $this->converter->convert($html);
+
+        $this->assertStringNotContainsString("\u{00A0}", $result);
+        $this->assertStringContainsString('Tisch für 2', $result);
+    }
+
+    public function test_it_normalizes_crlf_line_endings(): void
+    {
+        $html = "Zeile 1<br>\r\nZeile 2";
+
+        $result = $this->converter->convert($html);
+
+        $this->assertStringNotContainsString("\r", $result);
+    }
+
+    public function test_it_collapses_runs_of_blank_lines(): void
+    {
+        $html = '<p>A</p><p></p><p></p><p>B</p>';
+
+        $result = $this->converter->convert($html);
+
+        $this->assertDoesNotMatchRegularExpression('/\n{3,}/', $result);
+    }
+
+    public function test_it_trims_leading_and_trailing_whitespace(): void
+    {
+        $html = "\n\n  <p>Hallo</p>  \n\n";
+
+        $this->assertSame('Hallo', $this->converter->convert($html));
+    }
+}


### PR DESCRIPTION
## Summary
- New `App\Services\Email\HtmlToPlainText` service: converts `<br>` / block tags (`p`, `div`, `h1`–`h6`, `li`, `tr`, `ul/ol`, `table*`, `blockquote`, `article`, `section`, `header`, `footer`) into newline sentinels, strips `<script>`/`<style>` blocks with their contents, decodes HTML entities, and normalises whitespace (CRLF → LF, nbsp → space, per-line trim, collapses runs of blank lines to a single blank line).
- Wires the converter into both HTML extraction sites — `WebklexImapMailbox::extractBody()` (primary, used by the fetch job) and `EmailReservationParser::extractBody()` (secondary, `parse(Message)` entrypoint) — replacing the previous ad-hoc `trim(strip_tags(...))`.
- Unit tests pin the contract: paragraph/block line-breaks, `<br>`, list & table rows, script/style stripping, umlaut and emoji preservation, entity decoding, nbsp, CRLF normalisation, blank-line collapse, empty-input / trimming.
- Parity test in `EmailReservationParserTest`: an HTML fixture and its plaintext counterpart produce identical `partySize`, `desiredAt`, `guestName`, and `confidence`.

## Why
Issue #37 — the IMAP parser's regex heuristics operate on plaintext. Many reservation mails arrive HTML-only (portals, newsletter-style clients); the previous `strip_tags` produced a single run-on string where block structure was lost, which in turn broke the one-per-line patterns the parser relies on. Signatures and quoted replies are intentionally **not** stripped in V1.0 (documented limitation in the acceptance criteria).

## Test plan
- [x] `php artisan test` — 244 deprecated, 7 passed, **0 failed** (640 assertions). "Deprecated" is pre-existing PHP 8.5 `PDO::MYSQL_ATTR_SSL_CA` noise, unrelated.
- [x] `php artisan test tests/Unit/Services/Email/HtmlToPlainTextTest.php` — 15 tests pass (25 assertions).
- [x] `./vendor/bin/pint --test` — pass.

Closes #37