### PR TITLE
Schedule FetchReservationEmailsJob every 5 minutes (#39)

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -1,8 +1,22 @@
 <?php
 
+declare(strict_types=1);
+
+use App\Jobs\FetchReservationEmailsJob;
+use App\Models\Restaurant;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Schedule;
 
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+Schedule::call(function (): void {
+    Restaurant::query()
+        ->whereNotNull('imap_host')
+        ->each(fn (Restaurant $restaurant) => FetchReservationEmailsJob::dispatch($restaurant->id));
+})
+    ->name(FetchReservationEmailsJob::class)
+    ->everyFiveMinutes()
+    ->withoutOverlapping();

--- a/tests/Feature/Console/FetchReservationEmailsScheduleTest.php
+++ b/tests/Feature/Console/FetchReservationEmailsScheduleTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Jobs\FetchReservationEmailsJob;
+use App\Models\Restaurant;
+use Illuminate\Console\Scheduling\CallbackEvent;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\TestCase;
+
+class FetchReservationEmailsScheduleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_registers_a_five_minute_schedule_with_overlap_protection(): void
+    {
+        $event = $this->findFetchScheduleEvent();
+
+        $this->assertNotNull(
+            $event,
+            'Expected a scheduled callback that dispatches FetchReservationEmailsJob to be registered in routes/console.php.',
+        );
+        $this->assertSame('*/5 * * * *', $event->expression);
+        $this->assertNotNull(
+            $event->withoutOverlapping,
+            'Expected the schedule to call withoutOverlapping() to prevent stacked runs.',
+        );
+    }
+
+    public function test_it_dispatches_the_job_only_for_restaurants_with_imap_host(): void
+    {
+        Bus::fake([FetchReservationEmailsJob::class]);
+
+        $withImap = Restaurant::factory()->create(['imap_host' => 'imap.example.com']);
+        $withoutImap = Restaurant::factory()->create(['imap_host' => null]);
+
+        $event = $this->findFetchScheduleEvent();
+        $this->assertNotNull($event);
+
+        $event->run($this->app);
+
+        Bus::assertDispatched(
+            FetchReservationEmailsJob::class,
+            fn (FetchReservationEmailsJob $job) => $job->restaurantId === $withImap->id,
+        );
+        Bus::assertNotDispatched(
+            FetchReservationEmailsJob::class,
+            fn (FetchReservationEmailsJob $job) => $job->restaurantId === $withoutImap->id,
+        );
+        Bus::assertDispatchedTimes(FetchReservationEmailsJob::class, 1);
+    }
+
+    public function test_it_dispatches_nothing_when_no_restaurant_has_imap_configured(): void
+    {
+        Bus::fake([FetchReservationEmailsJob::class]);
+
+        Restaurant::factory()->create(['imap_host' => null]);
+
+        $event = $this->findFetchScheduleEvent();
+        $this->assertNotNull($event);
+
+        $event->run($this->app);
+
+        Bus::assertNothingDispatched();
+    }
+
+    private function findFetchScheduleEvent(): ?CallbackEvent
+    {
+        /** @var Schedule $schedule */
+        $schedule = $this->app->make(Schedule::class);
+
+        foreach ($schedule->events() as $event) {
+            if ($event instanceof CallbackEvent && $event->description === FetchReservationEmailsJob::class) {
+                return $event;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a `Schedule::call(...)` entry in `routes/console.php` that selects every restaurant with a non-null `imap_host` and dispatches one `FetchReservationEmailsJob` per restaurant.
- Cadence: `everyFiveMinutes()` (`*/5 * * * *`).
- `withoutOverlapping()` prevents a slow IMAP cycle from triggering a second run while the previous one is still executing.
- The schedule entry is `name()`-tagged with the job class so it is addressable via the `Schedule` container binding (used by the feature test) and visible in `schedule:list`.

## Why
Issue #39 — until now the fetch job had to be triggered manually. Production needs a recurring trigger that respects per-restaurant configuration and does not stack overlapping runs if IMAP is slow or the previous cycle is still imaginating. The job itself already no-ops for restaurants without IMAP, but filtering at the query level keeps the dispatcher proportional to the configured fleet.

## Test plan
- [x] `php artisan test tests/Feature/Console/FetchReservationEmailsScheduleTest.php` — 3 tests green (schedule registration assertions: cron expression `*/5 * * * *`, `withoutOverlapping` mutex, dispatches only for restaurants with `imap_host`, dispatches nothing when none are configured).
- [x] `php artisan test` — 254 tests, **0 failed** (649 assertions).
- [x] `php artisan schedule:list` — shows `*/5 * * * *  App\Jobs\FetchReservationEmailsJob`.
- [x] `./vendor/bin/pint --test` — pass.

Closes #39