### PR TITLE
Add 30-day retention policy and prune job for failed_email_imports (#41)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -91,3 +91,11 @@ OPENAI_MODEL=gpt-4o-mini
 IMAP_HOST=
 IMAP_USERNAME=
 IMAP_PASSWORD=
+
+# ──────────────────────────────────────────────────────────────────────
+# failed_email_imports retention (PRD-003, Issue #41)
+# DSGVO-compliant pruning of the email-ingest quarantine table.
+# See docs/decisions/failed-email-imports-retention.md for the policy.
+# ──────────────────────────────────────────────────────────────────────
+FAILED_EMAIL_IMPORTS_PRUNE_ENABLED=true
+FAILED_EMAIL_IMPORTS_RETENTION_DAYS=30

--- a/app/Jobs/PruneFailedEmailImportsJob.php
+++ b/app/Jobs/PruneFailedEmailImportsJob.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\FailedEmailImport;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+
+final class PruneFailedEmailImportsJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout = 300;
+
+    public function handle(): void
+    {
+        if (! config('reservations.failed_email_imports.prune.enabled')) {
+            return;
+        }
+
+        $retentionDays = (int) config('reservations.failed_email_imports.prune.retention_days');
+
+        if ($retentionDays < 1) {
+            return;
+        }
+
+        $cutoff = Carbon::now()->subDays($retentionDays);
+
+        $query = FailedEmailImport::withoutGlobalScopes()
+            ->where('created_at', '<', $cutoff);
+
+        $oldestDeletedAt = $query->clone()->min('created_at');
+        $deletedCount = $query->delete();
+
+        Log::info('reservation.failed_email_imports.pruned', [
+            'deleted_count' => $deletedCount,
+            'retention_days' => $retentionDays,
+            'cutoff' => $cutoff->toIso8601String(),
+            'oldest_deleted_at' => $oldestDeletedAt === null
+                ? null
+                : Carbon::parse($oldestDeletedAt)->toIso8601String(),
+        ]);
+    }
+}

--- a/config/reservations.php
+++ b/config/reservations.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Quarantine retention for failed_email_imports
+    |--------------------------------------------------------------------------
+    |
+    | DSGVO-driven retention policy for the email-ingest quarantine table.
+    | See docs/decisions/failed-email-imports-retention.md for the reasoning,
+    | audit-log shape, and triggers for changing the window.
+    |
+    */
+    'failed_email_imports' => [
+        'prune' => [
+            'enabled' => (bool) env('FAILED_EMAIL_IMPORTS_PRUNE_ENABLED', true),
+            'retention_days' => (int) env('FAILED_EMAIL_IMPORTS_RETENTION_DAYS', 30),
+        ],
+    ],
+];

--- a/docs/decisions/failed-email-imports-retention.md
+++ b/docs/decisions/failed-email-imports-retention.md
@@ -1,0 +1,77 @@
+# Entscheidung: 30-Tage-Retention für `failed_email_imports` (DSGVO)
+
+**Status:** angenommen
+**Datum:** 2026-04-24
+**Bezug:** PRD-003 (E-Mail-Ingestion) § Risiken & offene Fragen, Issue #41
+
+## Kontext
+
+Die Tabelle `failed_email_imports` ist die Quarantäne des E-Mail-Ingest-Jobs (`FetchReservationEmailsJob`). Sobald eine Mail den Parser crashen lässt oder aus anderen Gründen keinen `ReservationRequest` erzeugt, landet sie mit `raw_headers`, `raw_body` und einem `error`-String in dieser Tabelle. Der Fetch-Lauf bricht nicht ab – die Mail wird aufgehoben, damit der Betreiber das Parser-Problem in Ruhe analysieren kann.
+
+`raw_headers` und `raw_body` enthalten typischerweise personenbezogene Daten im Sinne der DSGVO: Absender-Adresse, Name, Uhrzeit, eventuell Telefonnummer, freier Text des Gastes. Art. 5 Abs. 1 lit. e DSGVO verlangt eine explizite, begründete Aufbewahrungsdauer und eine technische Umsetzung der Löschung. Ohne beides dürfen wir nicht produktiv gehen.
+
+PRD-003 hat 30 Tage als Vorschlag in die Offene-Fragen-Liste gestellt. Diese Entscheidung schreibt ihn als verbindliche Richtlinie für V1.0 fest.
+
+## Entscheidung
+
+**V1.0 löscht Einträge in `failed_email_imports` hart (kein Soft-Delete) nach 30 Tagen.** Die Löschung erfolgt über einen täglich laufenden Laravel-Job (`PruneFailedEmailImportsJob`), steuerbar über zwei Config-Keys in `config/reservations.php`:
+
+| Key                                                     | Default | Zweck                                                                   |
+|----------------------------------------------------------|---------|--------------------------------------------------------------------------|
+| `reservations.failed_email_imports.prune.enabled`        | `true`  | Feature-Flag zum Deaktivieren in Ausnahmefällen (z. B. Incident-Forensik) |
+| `reservations.failed_email_imports.prune.retention_days` | `30`    | Aufbewahrungsfrist in Tagen                                              |
+
+Beide Keys sind via `env()` überschreibbar:
+
+- `FAILED_EMAIL_IMPORTS_PRUNE_ENABLED`
+- `FAILED_EMAIL_IMPORTS_RETENTION_DAYS`
+
+Der Schedule-Eintrag läuft einmal pro Nacht um 03:00 mit `withoutOverlapping()`. Fehler im Job führen nicht zum Daten-Rollback – die nächste Nacht räumt erneut auf.
+
+## Audit-Log
+
+Jeder Lauf schreibt genau eine strukturierte Log-Zeile auf Level `info`:
+
+```
+channel:   default
+message:   reservation.failed_email_imports.pruned
+context:   { deleted_count: int, retention_days: int, oldest_deleted_at: iso8601|null, cutoff: iso8601 }
+```
+
+**Nicht geloggt werden:** `message_id`, Absender, `raw_headers`, `raw_body`, `error`, `restaurant_id`, Mail-Inhalte jeglicher Art. Das Audit-Log beantwortet ausschließlich die Frage *„Haben wir heute Nacht X Einträge gelöscht und wie alt war der älteste?"* – ausreichend für eine DSGVO-Rechenschaftspflicht (Art. 5 Abs. 2), ohne neue Personendaten in das Log-System zu tragen.
+
+`oldest_deleted_at` ist informativ (hilft, verpasste Läufe zu erkennen) und enthält keine personenbezogenen Daten, da es nur ein Zeitstempel ist.
+
+## Begründung
+
+- **30 Tage** sind im deutschsprachigen Raum eine etablierte Hausnummer für „operative E-Mail-Quarantäne" (vgl. Spam-Quarantänen bei gängigen Mail-Providern). Kürzer (7/14 Tage) killt das Feld-Debugging durch den Betreiber bei seltenen Parser-Fehlern; länger (60/90 Tage) erhöht die DSGVO-Exposition ohne Mehrwert, weil Parser-Bugs normalerweise innerhalb weniger Tage sichtbar werden.
+- **Hart statt Soft-Delete:** Die Tabelle ist eine Quarantäne, kein Archiv. Soft-Delete würde den Löschanspruch nach Art. 17 DSGVO nicht erfüllen – der Datensatz bliebe logisch vorhanden, nur ausgeblendet. Das wollen wir nicht.
+- **Feature-Flag statt Config-only:** Im Incident-Fall (z. B. systematischer Parser-Bug, der über Tage importiert wird und forensisch aufgeklärt werden soll) muss der Betreiber das Pruning per Deployment-Env-Var kurzfristig aussetzen können, ohne Code zu ändern. Das Flag kippt sichtbar, nicht still.
+- **Keine Per-Restaurant-Konfiguration** in V1.0. Solange alle Pilot-Restaurants auf derselben Instanz laufen und dieselbe DSGVO-Grundlage gilt, ist eine globale Frist das einfachste, juristisch und technisch sauber umsetzbare Modell.
+- **Tägliche Ausführung, nicht stündlich:** Die Datenmenge ist klein (Quarantäne-Tabelle), die Frist ist tage-, nicht stundenskaliert. Ein täglicher Lauf hält den Log-Stream ruhig und ist für Incident-Rekonstruktion fein genug.
+
+## Datenschutz-Dokumentation (DPA / Datenschutzerklärung)
+
+Die folgenden Formulierungen sind in die öffentliche Datenschutzerklärung des Betreibers und in den Auftragsverarbeitungsvertrag (DPA) aufzunehmen. Das ist **kein** Teil dieses Code-Repositorys, sondern eine operative Vorleistung vor Go-Live.
+
+- **Verarbeitungszweck:** Technische Fehlerdiagnose des E-Mail-Ingest-Parsers.
+- **Datenkategorien:** Vollständiger Inhalt der Quarantäne-Mail inkl. Absender, ggf. Telefon, Freitext.
+- **Rechtsgrundlage:** Art. 6 Abs. 1 lit. f DSGVO (berechtigtes Interesse: Funktionsfähigkeit des Reservierungssystems). Interessenabwägung dokumentieren.
+- **Speicherdauer:** 30 Tage ab Eintreffen der Mail, danach automatische, nicht wiederherstellbare Löschung.
+- **Auskunfts-/Löschrecht:** Betroffene können jederzeit die sofortige Löschung eines Quarantäne-Eintrags vor Ablauf der 30-Tage-Frist verlangen. Ausführung: manueller `DELETE` durch den Betreiber; kein UI in V1.0.
+
+## Trigger für Änderung des Zeitfensters
+
+Wechsel von 30 Tagen auf eine andere Frist wird dann angefasst, sobald **einer** dieser Punkte greift:
+
+1. **Betreiber-Feedback:** Parser-Fehler werden nach eigener Aussage regelmäßig erst nach > 20 Tagen bemerkt. Dann ist 30 Tage zu knapp, Verlängerung auf 45 oder 60 Tage sinnvoll.
+2. **Aufsichtsrechtliche Vorgabe:** Landesdatenschutzbehörde oder Branchenverband gibt eine abweichende Höchst-/Mindestfrist vor.
+3. **Menge:** Die Tabelle wächst dauerhaft über 10.000 Einträge an, was auf einen systematischen Parser-Bug hinweist. Dann ist der Bug zu fixen, nicht das Fenster zu verkürzen – die Entscheidung hier bleibt unverändert, der Ingest wird vorübergehend pausiert.
+
+Jede Änderung erfordert Update dieser Datei, Anpassung der Datenschutzerklärung und ein Folge-Issue.
+
+## Nicht in diesem Dokument
+
+- UI für Betroffenen-Löschantrag (V2.0, eigenes Issue)
+- Export von Quarantäne-Einträgen zur Offline-Analyse (nicht geplant)
+- Separate Retention-Frist für `reservation_requests` (eigene Entscheidung, wenn relevant)

--- a/routes/console.php
+++ b/routes/console.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Jobs\FetchReservationEmailsJob;
+use App\Jobs\PruneFailedEmailImportsJob;
 use App\Models\Restaurant;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -19,4 +20,9 @@ Schedule::call(function (): void {
 })
     ->name(FetchReservationEmailsJob::class)
     ->everyFiveMinutes()
+    ->withoutOverlapping();
+
+Schedule::job(new PruneFailedEmailImportsJob)
+    ->name(PruneFailedEmailImportsJob::class)
+    ->dailyAt('03:00')
     ->withoutOverlapping();

--- a/tests/Feature/Console/PruneFailedEmailImportsScheduleTest.php
+++ b/tests/Feature/Console/PruneFailedEmailImportsScheduleTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Jobs\PruneFailedEmailImportsJob;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PruneFailedEmailImportsScheduleTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_registers_a_daily_3am_schedule_with_overlap_protection(): void
+    {
+        $event = $this->findPruneScheduleEvent();
+
+        $this->assertNotNull(
+            $event,
+            'Expected a scheduled job for PruneFailedEmailImportsJob to be registered in routes/console.php.',
+        );
+        $this->assertSame('0 3 * * *', $event->expression);
+        $this->assertNotNull(
+            $event->withoutOverlapping,
+            'Expected the schedule to call withoutOverlapping() to prevent stacked runs.',
+        );
+    }
+
+    private function findPruneScheduleEvent(): ?Event
+    {
+        /** @var Schedule $schedule */
+        $schedule = $this->app->make(Schedule::class);
+
+        foreach ($schedule->events() as $event) {
+            if ($event->description === PruneFailedEmailImportsJob::class) {
+                return $event;
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Feature/Jobs/PruneFailedEmailImportsJobTest.php
+++ b/tests/Feature/Jobs/PruneFailedEmailImportsJobTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Jobs\PruneFailedEmailImportsJob;
+use App\Models\FailedEmailImport;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class PruneFailedEmailImportsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'reservations.failed_email_imports.prune.enabled' => true,
+            'reservations.failed_email_imports.prune.retention_days' => 30,
+        ]);
+    }
+
+    public function test_it_deletes_entries_older_than_retention_window(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $this->createFailureAt($restaurant, Carbon::now()->subDays(31));
+        $this->createFailureAt($restaurant, Carbon::now()->subDays(45));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $this->assertSame(0, FailedEmailImport::withoutGlobalScopes()->count());
+    }
+
+    public function test_it_keeps_entries_within_retention_window(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $fresh = $this->createFailureAt($restaurant, Carbon::now()->subDays(5));
+        $atBoundary = $this->createFailureAt($restaurant, Carbon::now()->subDays(30));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $remaining = FailedEmailImport::withoutGlobalScopes()->pluck('id')->all();
+        $this->assertEqualsCanonicalizing([$fresh->id, $atBoundary->id], $remaining);
+    }
+
+    public function test_it_respects_a_custom_retention_window(): void
+    {
+        config(['reservations.failed_email_imports.prune.retention_days' => 7]);
+
+        $restaurant = Restaurant::factory()->create();
+
+        $this->createFailureAt($restaurant, Carbon::now()->subDays(8));
+        $kept = $this->createFailureAt($restaurant, Carbon::now()->subDays(6));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $this->assertSame(
+            [$kept->id],
+            FailedEmailImport::withoutGlobalScopes()->pluck('id')->all(),
+        );
+    }
+
+    public function test_it_is_a_noop_when_flag_is_disabled(): void
+    {
+        config(['reservations.failed_email_imports.prune.enabled' => false]);
+
+        $restaurant = Restaurant::factory()->create();
+        $ancient = $this->createFailureAt($restaurant, Carbon::now()->subDays(365));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $this->assertTrue(FailedEmailImport::withoutGlobalScopes()->whereKey($ancient->id)->exists());
+    }
+
+    public function test_it_is_a_noop_when_retention_days_is_zero_or_negative(): void
+    {
+        config(['reservations.failed_email_imports.prune.retention_days' => 0]);
+
+        $restaurant = Restaurant::factory()->create();
+        $entry = $this->createFailureAt($restaurant, Carbon::now()->subDays(100));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $this->assertTrue(FailedEmailImport::withoutGlobalScopes()->whereKey($entry->id)->exists());
+    }
+
+    public function test_it_logs_a_pii_free_audit_summary(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $oldest = $this->createFailureAt($restaurant, Carbon::now()->subDays(90));
+        $this->createFailureAt($restaurant, Carbon::now()->subDays(40));
+
+        $captured = null;
+        Log::shouldReceive('info')
+            ->once()
+            ->with('reservation.failed_email_imports.pruned', \Mockery::capture($captured));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $this->assertIsArray($captured);
+        $this->assertSame(2, $captured['deleted_count']);
+        $this->assertSame(30, $captured['retention_days']);
+        $this->assertNotNull($captured['cutoff']);
+        $this->assertSame(
+            $oldest->created_at->toIso8601String(),
+            $captured['oldest_deleted_at'],
+        );
+
+        $forbiddenKeys = ['message_id', 'raw_headers', 'raw_body', 'error', 'restaurant_id', 'sender', 'body'];
+        foreach ($forbiddenKeys as $key) {
+            $this->assertArrayNotHasKey($key, $captured, "Audit log must not contain '{$key}'");
+        }
+    }
+
+    public function test_audit_log_oldest_deleted_at_is_null_when_nothing_is_deleted(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->createFailureAt($restaurant, Carbon::now()->subDays(5));
+
+        $captured = null;
+        Log::shouldReceive('info')
+            ->once()
+            ->with('reservation.failed_email_imports.pruned', \Mockery::capture($captured));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $this->assertSame(0, $captured['deleted_count']);
+        $this->assertNull($captured['oldest_deleted_at']);
+    }
+
+    public function test_it_crosses_the_restaurant_global_scope(): void
+    {
+        $a = Restaurant::factory()->create();
+        $b = Restaurant::factory()->create();
+
+        $this->createFailureAt($a, Carbon::now()->subDays(60));
+        $this->createFailureAt($b, Carbon::now()->subDays(60));
+
+        (new PruneFailedEmailImportsJob)->handle();
+
+        $this->assertSame(0, FailedEmailImport::withoutGlobalScopes()->count());
+    }
+
+    private function createFailureAt(Restaurant $restaurant, Carbon $createdAt): FailedEmailImport
+    {
+        return FailedEmailImport::factory()
+            ->forRestaurant($restaurant)
+            ->create(['created_at' => $createdAt]);
+    }
+}


### PR DESCRIPTION
## Summary

- Documents the DSGVO-driven retention policy for `failed_email_imports` in `docs/decisions/failed-email-imports-retention.md` (30-day hard delete, with rationale, audit-log shape, DPA language, and triggers for changing the window).
- Introduces `config/reservations.php` with two env-overridable flags:
  - `FAILED_EMAIL_IMPORTS_PRUNE_ENABLED` (default `true`) — lets the operator pause the job during incident forensics.
  - `FAILED_EMAIL_IMPORTS_RETENTION_DAYS` (default `30`).
- Adds `App\Jobs\PruneFailedEmailImportsJob`, a scheduled daily 03:00 prune (`withoutOverlapping`) that hard-deletes rows older than the retention window.
- Emits a structured audit log (`reservation.failed_email_imports.pruned`) with `deleted_count`, `retention_days`, `cutoff`, `oldest_deleted_at` — and nothing else (no PII, no mail content, no restaurant_id).

## Why

PRD-003 § Risiken & offene Fragen required a retention policy for the email-ingest quarantine before go-live, because `raw_headers` and `raw_body` contain personal data under DSGVO Art. 5(1)(e). Issue #41 asked for the decision plus technical enforcement. 30 days is the PRD's proposed window; the decision doc explains why it is the right trade-off between operational parser debugging and DSGVO exposure, and lists the triggers that would move it.

## Test plan

- [x] `php artisan test --filter=PruneFailedEmailImports` — 9 new tests, all green
  - deletes rows older than retention window
  - keeps rows at and within the window
  - respects a custom `retention_days`
  - no-op when flag is disabled
  - no-op when `retention_days <= 0`
  - audit log carries count + retention + cutoff + oldest, and contains no PII keys
  - audit log sets `oldest_deleted_at = null` when nothing was deleted
  - crosses the `RestaurantScope` global scope (system-level prune, no tenant context)
  - schedule registered daily at 03:00 with `withoutOverlapping()`
- [x] Full suite: `php artisan test` — 274 tests, 706 assertions, 0 failures
- [x] `./vendor/bin/pint --test` — pass

Closes #41