### PR TITLE
Surface V1.0 threading limitation on the dashboard (#45)

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem, type SharedData } from '@/types';
 import { Head, usePage } from '@inertiajs/vue3';
+import { Info } from 'lucide-vue-next';
 import { computed } from 'vue';
 
 const breadcrumbs: BreadcrumbItem[] = [
@@ -34,6 +36,31 @@ const restaurantName = computed(() => page.props.restaurant?.name ?? '');
                 <p class="text-lg font-medium">Noch keine Reservierungen</p>
                 <p class="mt-1 text-sm text-muted-foreground">Sobald eine Anfrage eingeht, erscheint sie hier.</p>
             </section>
+
+            <TooltipProvider :delay-duration="150">
+                <Tooltip>
+                    <TooltipTrigger as-child>
+                        <aside
+                            data-testid="known-limitation-threading"
+                            class="flex cursor-help items-start gap-3 rounded-lg border border-amber-200 bg-amber-50 p-4 text-left text-sm text-amber-900 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-200"
+                        >
+                            <Info class="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                            <div>
+                                <p class="font-medium">Hinweis V1.0: Antworten des Gastes erzeugen eine neue Anfrage</p>
+                                <p class="mt-1 text-amber-900/80 dark:text-amber-200/80">
+                                    Wenn ein Gast auf eine versendete Bestätigung antwortet, erscheint die Antwort aktuell als neue
+                                    Reservierungsanfrage. Automatisches Threading folgt in V2.0 – bis dahin bitte Einträge manuell zusammenführen.
+                                </p>
+                            </div>
+                        </aside>
+                    </TooltipTrigger>
+                    <TooltipContent class="max-w-sm text-xs leading-relaxed">
+                        In V1.0 akzeptieren wir Dubletten im Dashboard und verlassen uns auf manuellen Merge durch den Gastronom. Threading (Zuordnung
+                        späterer Mails zur ursprünglichen Reservierung) ist für V2.0 geplant. Details: docs/PRD-003-email-ingestion.md § Risiken &amp;
+                        offene Fragen.
+                    </TooltipContent>
+                </Tooltip>
+            </TooltipProvider>
         </div>
     </AppLayout>
 </template>


### PR DESCRIPTION
## Summary

- Adds a small inline notice block to `resources/js/pages/Dashboard.vue` that warns operators: guest replies to confirmations appear as brand-new reservation requests in V1.0, and must be merged manually until V2.0 ships threading.
- Wraps the notice in a Reka `Tooltip` so the full explanation (matching the PRD-003 §"Risiken & offene Fragen" wording) is a hover away, without cluttering the dashboard.
- Styled with Tailwind amber tokens and `data-testid="known-limitation-threading"` for later test coverage.

## Why

Issue #45 flags this as a "Known issue" to prevent testers from filing duplicate-reservation bugs during V1.0 pilot usage. The limitation is already documented in `docs/PRD-003-email-ingestion.md` § Risiken & offene Fragen — that section is the "V2.0 threading roadmap" reference. This PR makes the limitation visible where it matters: on the dashboard itself.

## Acceptance criteria

- [x] Dashboard documentation (help text or inline tooltip) mentions the limitation — notice + tooltip on `Dashboard.vue`
- [x] Link to the V2.0 threading roadmap added to this issue — will be posted as an issue comment pointing to `docs/PRD-003-email-ingestion.md#risiken--offene-fragen` once this PR is merged (the comment cannot link to a `dev`-only path before merge)

## Test plan

- [x] `npm run build` — Vite/TypeScript compiles cleanly, Dashboard bundle rebuilt
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean (Prettier applied)
- [x] `php artisan test` — 280 tests, 742 assertions, 0 failures (no regressions in existing `DashboardTest` suite)
- [x] `./vendor/bin/pint --test` — pass
- [ ] **Browser smoke not performed** (no browser available in this session). The notice and Tooltip follow the exact pattern used by `AppHeader.vue`, so structural failure is unlikely, but hover/rendering should be eyed before shipping to pilot users.

Closes #45