### PR TITLE
Add DashboardFilterRequest with explicit filter rules (#48)

### DIFF
--- a/app/Http/Requests/DashboardFilterRequest.php
+++ b/app/Http/Requests/DashboardFilterRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class DashboardFilterRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'status' => ['array'],
+            'status.*' => [Rule::enum(ReservationStatus::class)],
+            'source' => ['array'],
+            'source.*' => [Rule::enum(ReservationSource::class)],
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date', 'after_or_equal:from'],
+            'q' => ['nullable', 'string', 'max:120'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'status.array' => 'Der Statusfilter muss als Liste übergeben werden.',
+            'status.*.enum' => 'Mindestens ein Status ist ungültig.',
+            'source.array' => 'Der Quellfilter muss als Liste übergeben werden.',
+            'source.*.enum' => 'Mindestens eine Quelle ist ungültig.',
+            'from.date' => 'Das Von-Datum ist ungültig.',
+            'to.date' => 'Das Bis-Datum ist ungültig.',
+            'to.after_or_equal' => 'Das Bis-Datum darf nicht vor dem Von-Datum liegen.',
+            'q.string' => 'Der Suchbegriff muss aus Text bestehen.',
+            'q.max' => 'Der Suchbegriff darf höchstens 120 Zeichen lang sein.',
+        ];
+    }
+}

--- a/tests/Unit/Http/Requests/DashboardFilterRequestTest.php
+++ b/tests/Unit/Http/Requests/DashboardFilterRequestTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Unit\Http\Requests;
+
+use App\Http\Requests\DashboardFilterRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+class DashboardFilterRequestTest extends TestCase
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function validate(array $data): \Illuminate\Validation\Validator
+    {
+        return Validator::make($data, (new DashboardFilterRequest)->rules());
+    }
+
+    public function test_empty_payload_is_valid(): void
+    {
+        $this->assertTrue($this->validate([])->passes());
+    }
+
+    public function test_accepts_every_reservation_status(): void
+    {
+        $validator = $this->validate([
+            'status' => ['new', 'in_review', 'replied', 'confirmed', 'declined', 'cancelled'],
+        ]);
+
+        $this->assertTrue($validator->passes(), json_encode($validator->errors()->all()));
+    }
+
+    public function test_rejects_unknown_status_value(): void
+    {
+        $validator = $this->validate(['status' => ['new', 'bogus']]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('status.1', $validator->errors()->toArray());
+    }
+
+    public function test_status_must_be_an_array(): void
+    {
+        $validator = $this->validate(['status' => 'new']);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('status', $validator->errors()->toArray());
+    }
+
+    public function test_accepts_every_reservation_source(): void
+    {
+        $validator = $this->validate(['source' => ['web_form', 'email']]);
+
+        $this->assertTrue($validator->passes(), json_encode($validator->errors()->all()));
+    }
+
+    public function test_rejects_unknown_source_value(): void
+    {
+        $validator = $this->validate(['source' => ['carrier_pigeon']]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('source.0', $validator->errors()->toArray());
+    }
+
+    public function test_source_must_be_an_array(): void
+    {
+        $validator = $this->validate(['source' => 'email']);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('source', $validator->errors()->toArray());
+    }
+
+    public function test_from_and_to_are_nullable(): void
+    {
+        $this->assertTrue($this->validate(['from' => null, 'to' => null])->passes());
+    }
+
+    public function test_from_must_be_a_valid_date(): void
+    {
+        $validator = $this->validate(['from' => 'not-a-date']);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('from', $validator->errors()->toArray());
+    }
+
+    public function test_to_must_be_after_or_equal_to_from(): void
+    {
+        $validator = $this->validate(['from' => '2026-05-10', 'to' => '2026-05-09']);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('to', $validator->errors()->toArray());
+    }
+
+    public function test_to_equal_to_from_is_allowed(): void
+    {
+        $this->assertTrue(
+            $this->validate(['from' => '2026-05-10', 'to' => '2026-05-10'])->passes(),
+        );
+    }
+
+    public function test_to_after_from_is_allowed(): void
+    {
+        $this->assertTrue(
+            $this->validate(['from' => '2026-05-10', 'to' => '2026-05-11'])->passes(),
+        );
+    }
+
+    public function test_q_is_nullable(): void
+    {
+        $this->assertTrue($this->validate(['q' => null])->passes());
+    }
+
+    public function test_q_accepts_search_string(): void
+    {
+        $this->assertTrue($this->validate(['q' => 'Müller'])->passes());
+    }
+
+    public function test_q_is_capped_at_120_characters(): void
+    {
+        $validator = $this->validate(['q' => str_repeat('a', 121)]);
+
+        $this->assertTrue($validator->fails());
+        $this->assertArrayHasKey('q', $validator->errors()->toArray());
+    }
+
+    public function test_q_at_exactly_120_characters_is_allowed(): void
+    {
+        $this->assertTrue($this->validate(['q' => str_repeat('a', 120)])->passes());
+    }
+
+    public function test_validated_payload_drops_unknown_keys(): void
+    {
+        $validator = $this->validate([
+            'status' => ['new'],
+            'malicious_key' => 'value',
+            'restaurant_id' => 999,
+        ]);
+
+        $this->assertTrue($validator->passes());
+
+        $validated = $validator->validated();
+        $this->assertArrayHasKey('status', $validated);
+        $this->assertArrayNotHasKey('malicious_key', $validated);
+        $this->assertArrayNotHasKey('restaurant_id', $validated);
+    }
+}


### PR DESCRIPTION
## Summary
- New `App\Http\Requests\DashboardFilterRequest` validating every parameter accepted by the upcoming dashboard list view.
- Status/source multi-select rules delegate to `Rule::enum(ReservationStatus::class)` / `Rule::enum(ReservationSource::class)` instead of hardcoded `in:...` lists so adding a new enum case can't silently desync the filter.
- Date range rule uses `after_or_equal:from`; `q` is capped at 120 chars, as spec'd in PRD-004.
- 17 new unit tests cover every AC — accepted values, rejected values, array-vs-scalar input, inverted ranges, boundary lengths, and the `->validated()` contract that drops unknown keys.

## Why
PRD-004 requires every dashboard query parameter to go through an explicit rule set so the controller's `$request->validated()` can be piped safely into `ReservationRequest::scopeFilter(...)` (#49). Without this gate, `where('restaurant_id', …)`-style smuggling via unknown keys would be trivial. The enum-based rule is a minor deviation from PRD wording (which shows literal `in:new,…`) but keeps the validator and the DB cast on a single source of truth — documented in the commit.

## Test plan
- [x] `php artisan test --filter=DashboardFilterRequestTest` — 17/17 green
- [x] `php artisan test` — full suite green (279 preexisting deprecation notices only, unchanged from `dev`)
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` — clean (exit 0)
- [x] `npm run format:check` — all matched files pass

Closes #48