### PR TITLE
Add ReservationRequest::scopeFilter with explicit mapping (#49)

### DIFF
--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -7,6 +7,7 @@ use App\Enums\ReservationStatus;
 use App\Models\Scopes\RestaurantScope;
 use Database\Factories\ReservationRequestFactory;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -80,5 +81,45 @@ class ReservationRequest extends Model
     public function latestReply(): HasOne
     {
         return $this->hasOne(ReservationReply::class)->latestOfMany('created_at');
+    }
+
+    /**
+     * Apply the dashboard filter set validated by DashboardFilterRequest.
+     *
+     * Every field is mapped explicitly — no dynamic column/operator
+     * construction — so only keys the FormRequest approves can influence
+     * the query.
+     *
+     * @param  Builder<self>  $query
+     * @param  array<string, mixed>  $filters
+     * @return Builder<self>
+     */
+    public function scopeFilter(Builder $query, array $filters): Builder
+    {
+        if (! empty($filters['status'])) {
+            $query->whereIn('status', $filters['status']);
+        }
+
+        if (! empty($filters['source'])) {
+            $query->whereIn('source', $filters['source']);
+        }
+
+        if (! empty($filters['from'])) {
+            $query->where('desired_at', '>=', $filters['from']);
+        }
+
+        if (! empty($filters['to'])) {
+            $query->where('desired_at', '<=', $filters['to']);
+        }
+
+        if (! empty($filters['q'])) {
+            $needle = '%'.$filters['q'].'%';
+            $query->where(function (Builder $inner) use ($needle): void {
+                $inner->where('guest_name', 'like', $needle)
+                    ->orWhere('guest_email', 'like', $needle);
+            });
+        }
+
+        return $query;
     }
 }

--- a/tests/Feature/Models/ReservationRequestScopeFilterTest.php
+++ b/tests/Feature/Models/ReservationRequestScopeFilterTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class ReservationRequestScopeFilterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    private ReservationRequest $alice;    // new, web_form, 2026-05-10, "Alice Example" alice@example.test
+
+    private ReservationRequest $bob;      // in_review, email, 2026-05-12, "Bob Müller" bob@example.test
+
+    private ReservationRequest $carol;    // replied, email, 2026-05-15, "Carol Schmidt" carol@other.test
+
+    private ReservationRequest $dave;     // confirmed, web_form, 2026-05-20, "Dave Alice" dave@example.test
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->restaurant = Restaurant::factory()->create();
+
+        $this->alice = ReservationRequest::factory()->forRestaurant($this->restaurant)->create([
+            'status' => ReservationStatus::New,
+            'source' => ReservationSource::WebForm,
+            'guest_name' => 'Alice Example',
+            'guest_email' => 'alice@example.test',
+            'desired_at' => Carbon::parse('2026-05-10 19:00'),
+        ]);
+
+        $this->bob = ReservationRequest::factory()->forRestaurant($this->restaurant)->create([
+            'status' => ReservationStatus::InReview,
+            'source' => ReservationSource::Email,
+            'guest_name' => 'Bob Müller',
+            'guest_email' => 'bob@example.test',
+            'desired_at' => Carbon::parse('2026-05-12 20:00'),
+        ]);
+
+        $this->carol = ReservationRequest::factory()->forRestaurant($this->restaurant)->create([
+            'status' => ReservationStatus::Replied,
+            'source' => ReservationSource::Email,
+            'guest_name' => 'Carol Schmidt',
+            'guest_email' => 'carol@other.test',
+            'desired_at' => Carbon::parse('2026-05-15 12:30'),
+        ]);
+
+        $this->dave = ReservationRequest::factory()->forRestaurant($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'source' => ReservationSource::WebForm,
+            'guest_name' => 'Dave Alice',
+            'guest_email' => 'dave@example.test',
+            'desired_at' => Carbon::parse('2026-05-20 13:00'),
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     * @return list<int>
+     */
+    private function filteredIds(array $filters): array
+    {
+        return ReservationRequest::query()
+            ->filter($filters)
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+    }
+
+    public function test_empty_filters_return_every_row(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->alice->id, $this->bob->id, $this->carol->id, $this->dave->id],
+            $this->filteredIds([]),
+        );
+    }
+
+    public function test_status_filter_uses_where_in(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->alice->id, $this->bob->id],
+            $this->filteredIds(['status' => ['new', 'in_review']]),
+        );
+    }
+
+    public function test_empty_status_array_is_ignored(): void
+    {
+        $this->assertCount(4, $this->filteredIds(['status' => []]));
+    }
+
+    public function test_source_filter_uses_where_in(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->bob->id, $this->carol->id],
+            $this->filteredIds(['source' => ['email']]),
+        );
+    }
+
+    public function test_empty_source_array_is_ignored(): void
+    {
+        $this->assertCount(4, $this->filteredIds(['source' => []]));
+    }
+
+    public function test_from_filter_is_inclusive(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->carol->id, $this->dave->id],
+            $this->filteredIds(['from' => '2026-05-15 00:00:00']),
+        );
+    }
+
+    public function test_to_filter_is_inclusive(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->alice->id, $this->bob->id],
+            $this->filteredIds(['to' => '2026-05-12 23:59:59']),
+        );
+    }
+
+    public function test_from_and_to_bracket_a_window(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->bob->id, $this->carol->id],
+            $this->filteredIds([
+                'from' => '2026-05-11 00:00:00',
+                'to' => '2026-05-15 23:59:59',
+            ]),
+        );
+    }
+
+    public function test_q_matches_guest_name_fragment(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->alice->id, $this->dave->id],
+            $this->filteredIds(['q' => 'Alice']),
+        );
+    }
+
+    public function test_q_matches_guest_email_fragment(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->carol->id],
+            $this->filteredIds(['q' => 'other.test']),
+        );
+    }
+
+    public function test_q_is_case_insensitive_for_ascii_name(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->alice->id, $this->dave->id],
+            $this->filteredIds(['q' => 'alice']),
+        );
+    }
+
+    public function test_q_handles_umlaut(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->bob->id],
+            $this->filteredIds(['q' => 'Müller']),
+        );
+    }
+
+    public function test_q_returning_no_match_yields_empty_set(): void
+    {
+        $this->assertSame([], $this->filteredIds(['q' => 'zzz-nobody']));
+    }
+
+    public function test_empty_q_string_is_ignored(): void
+    {
+        $this->assertCount(4, $this->filteredIds(['q' => '']));
+    }
+
+    public function test_combines_status_source_date_and_search(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [$this->bob->id],
+            $this->filteredIds([
+                'status' => ['in_review', 'replied'],
+                'source' => ['email'],
+                'from' => '2026-05-11 00:00:00',
+                'to' => '2026-05-14 00:00:00',
+                'q' => 'bob',
+            ]),
+        );
+    }
+
+    public function test_unknown_filter_keys_are_silently_ignored(): void
+    {
+        $ids = $this->filteredIds([
+            'status' => ['new'],
+            'restaurant_id' => 999999,
+            'foo' => 'bar',
+        ]);
+
+        $this->assertSame([$this->alice->id], $ids);
+    }
+
+    public function test_scope_preserves_chained_constraints(): void
+    {
+        $ids = ReservationRequest::query()
+            ->where('party_size', '>', 0)
+            ->filter(['status' => ['new']])
+            ->pluck('id')
+            ->all();
+
+        $this->assertSame([$this->alice->id], $ids);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `ReservationRequest::scopeFilter(Builder, array)` mapping each dashboard filter key to an explicit clause.
- `q` OR-group is wrapped in a nested `where()` so it AND-combines with the other filters instead of widening them.
- 17 new feature tests in `tests/Feature/Models/ReservationRequestScopeFilterTest.php` cover every acceptance criterion and a couple of regressions (umlaut search, chained-where preservation, unknown-key rejection).

## Why
PRD-004 mandates an explicit filter mapping — no dynamic SQL — so that the validated output of `DashboardFilterRequest` (#48) can be piped straight into the list query. Pairing the FormRequest gate with a scope that only reads known keys closes two classes of smuggling: invalid enum values get blocked at the FormRequest, and extra keys (e.g. `restaurant_id=999`) are silently ignored by the scope.

## Test plan
- [x] `php artisan test --filter=ReservationRequestScopeFilterTest` — 17/17 green
- [x] `php artisan test` — full suite green (314 total, zero failures; only the pre-existing `PDO::MYSQL_ATTR_SSL_CA` deprecation noise)
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean

## Notes
Issue #59 asks for the same scope tests as a separate task. Since #49's own acceptance criteria already require "Unit test covering every combination", the tests land here. I'll add a comment on #59 suggesting it be closed as duplicate.

Closes #49