### PR TITLE
Add Restaurant::availableSeatsAt() + tests (#17)

### DIFF
--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -2,15 +2,25 @@
 
 namespace App\Models;
 
+use App\Enums\ReservationStatus;
 use App\Enums\Tonality;
+use App\Support\OpeningHours;
+use Carbon\CarbonInterface;
 use Database\Factories\RestaurantFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Restaurant extends Model
 {
     /** @use HasFactory<RestaurantFactory> */
     use HasFactory;
+
+    /**
+     * Symmetric window (in hours) around a query time used to sum
+     * already-confirmed party sizes. Per PRD-005.
+     */
+    private const int AVAILABILITY_WINDOW_HOURS = 2;
 
     /**
      * The attributes that are mass assignable.
@@ -51,5 +61,42 @@ class Restaurant extends Model
             'tonality' => Tonality::class,
             'imap_password' => 'encrypted',
         ];
+    }
+
+    /**
+     * @return HasMany<ReservationRequest, $this>
+     */
+    public function reservationRequests(): HasMany
+    {
+        return $this->hasMany(ReservationRequest::class);
+    }
+
+    /**
+     * Free seats at a given point in time, or null if the restaurant is
+     * closed then.
+     *
+     * `null` = closed (outside opening hours or Ruhetag).
+     * `0`    = open but fully booked.
+     * `> 0`  = open with remaining capacity.
+     *
+     * Calculation (per PRD-005): capacity minus the sum of `party_size`
+     * of all **confirmed** reservations whose `desired_at` falls within
+     * a ±2h window around the query time.
+     */
+    public function availableSeatsAt(CarbonInterface $time): ?int
+    {
+        if (! OpeningHours::fromRestaurant($this)->isOpenAt($time)) {
+            return null;
+        }
+
+        $from = $time->copy()->subHours(self::AVAILABILITY_WINDOW_HOURS);
+        $to = $time->copy()->addHours(self::AVAILABILITY_WINDOW_HOURS);
+
+        $taken = (int) $this->reservationRequests()
+            ->where('status', ReservationStatus::Confirmed)
+            ->whereBetween('desired_at', [$from, $to])
+            ->sum('party_size');
+
+        return max(0, $this->capacity - $taken);
     }
 }

--- a/tests/Feature/Models/RestaurantAvailableSeatsAtTest.php
+++ b/tests/Feature/Models/RestaurantAvailableSeatsAtTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Carbon\CarbonInterface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class RestaurantAvailableSeatsAtTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Monday 2026-04-20 in Europe/Berlin (CEST, +02:00).
+     * Monday schedule per RestaurantFactory: lunch 11:30–14:30, dinner 18:00–22:30.
+     */
+    private function monday19Berlin(): CarbonInterface
+    {
+        return Carbon::create(2026, 4, 20, 19, 0, 0, 'Europe/Berlin');
+    }
+
+    private function makeRestaurant(int $capacity = 40): Restaurant
+    {
+        return Restaurant::factory()->create([
+            'capacity' => $capacity,
+            'timezone' => 'Europe/Berlin',
+        ]);
+    }
+
+    private function confirmReservationAt(
+        Restaurant $restaurant,
+        CarbonInterface $at,
+        int $partySize,
+    ): ReservationRequest {
+        return ReservationRequest::factory()
+            ->confirmed()
+            ->forRestaurant($restaurant)
+            ->create([
+                'desired_at' => $at,
+                'party_size' => $partySize,
+            ]);
+    }
+
+    public function test_empty_restaurant_reports_full_capacity(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 40);
+
+        $seats = $restaurant->availableSeatsAt($this->monday19Berlin());
+
+        $this->assertSame(40, $seats);
+    }
+
+    public function test_half_booked_restaurant_reports_remaining_seats(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 40);
+
+        // Two confirmed parties inside the ±2h window around 19:00.
+        $this->confirmReservationAt($restaurant, $this->monday19Berlin(), partySize: 6);
+        $this->confirmReservationAt(
+            $restaurant,
+            $this->monday19Berlin()->copy()->addMinutes(30),
+            partySize: 8,
+        );
+
+        $seats = $restaurant->availableSeatsAt($this->monday19Berlin());
+
+        $this->assertSame(40 - 14, $seats);
+    }
+
+    public function test_fully_booked_restaurant_reports_zero(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 20);
+
+        $this->confirmReservationAt($restaurant, $this->monday19Berlin(), partySize: 10);
+        $this->confirmReservationAt(
+            $restaurant,
+            $this->monday19Berlin()->copy()->addMinutes(15),
+            partySize: 10,
+        );
+
+        $this->assertSame(0, $restaurant->availableSeatsAt($this->monday19Berlin()));
+    }
+
+    public function test_overbooked_restaurant_clamps_to_zero_not_negative(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 10);
+
+        $this->confirmReservationAt($restaurant, $this->monday19Berlin(), partySize: 8);
+        $this->confirmReservationAt(
+            $restaurant,
+            $this->monday19Berlin()->copy()->addMinutes(15),
+            partySize: 8,
+        );
+
+        $this->assertSame(0, $restaurant->availableSeatsAt($this->monday19Berlin()));
+    }
+
+    public function test_outside_opening_hours_returns_null(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // Monday 16:00 Berlin — between lunch (11:30–14:30) and dinner (18:00–22:30).
+        $closed = Carbon::create(2026, 4, 20, 16, 0, 0, 'Europe/Berlin');
+
+        $this->assertNull($restaurant->availableSeatsAt($closed));
+    }
+
+    public function test_ruhetag_returns_null(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // Tuesday 2026-04-21 — Ruhetag per factory schedule.
+        $ruhetag = Carbon::create(2026, 4, 21, 19, 0, 0, 'Europe/Berlin');
+
+        $this->assertNull($restaurant->availableSeatsAt($ruhetag));
+    }
+
+    public function test_non_confirmed_reservations_do_not_occupy_seats(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 40);
+
+        $at = $this->monday19Berlin();
+
+        foreach ([
+            ReservationStatus::New,
+            ReservationStatus::InReview,
+            ReservationStatus::Replied,
+            ReservationStatus::Declined,
+            ReservationStatus::Cancelled,
+        ] as $status) {
+            ReservationRequest::factory()
+                ->forRestaurant($restaurant)
+                ->create([
+                    'status' => $status,
+                    'desired_at' => $at,
+                    'party_size' => 8,
+                ]);
+        }
+
+        $this->assertSame(40, $restaurant->availableSeatsAt($at));
+    }
+
+    public function test_reservations_of_other_restaurants_are_ignored(): void
+    {
+        $mine = $this->makeRestaurant(capacity: 40);
+        $other = $this->makeRestaurant(capacity: 40);
+
+        $this->confirmReservationAt($other, $this->monday19Berlin(), partySize: 20);
+
+        $this->assertSame(40, $mine->availableSeatsAt($this->monday19Berlin()));
+    }
+
+    public function test_reservation_just_inside_window_counts(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 40);
+
+        // Query at 19:00; window is 17:00–21:00. A booking at 17:01 is inside.
+        $insideEarly = $this->monday19Berlin()->copy()->subHours(2)->addMinute();
+        $this->confirmReservationAt($restaurant, $insideEarly, partySize: 6);
+
+        $this->assertSame(34, $restaurant->availableSeatsAt($this->monday19Berlin()));
+    }
+
+    public function test_reservation_just_outside_window_is_ignored(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 40);
+
+        // Lunch sitting at 13:00 Berlin → 6h before a 19:00 query, well outside ±2h.
+        $lunch = Carbon::create(2026, 4, 20, 13, 0, 0, 'Europe/Berlin');
+        $this->confirmReservationAt($restaurant, $lunch, partySize: 10);
+
+        $this->assertSame(40, $restaurant->availableSeatsAt($this->monday19Berlin()));
+    }
+
+    public function test_utc_input_produces_same_result_as_local_input(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 40);
+
+        $this->confirmReservationAt($restaurant, $this->monday19Berlin(), partySize: 12);
+
+        $localQuery = $this->monday19Berlin();
+        $utcQuery = $localQuery->copy()->setTimezone('UTC');
+
+        $this->assertSame(28, $restaurant->availableSeatsAt($localQuery));
+        $this->assertSame(28, $restaurant->availableSeatsAt($utcQuery));
+    }
+
+    public function test_utc_input_whose_weekday_differs_from_local_is_resolved_correctly(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // Monday 2026-04-20 23:30 UTC = Tuesday 2026-04-21 01:30 Berlin (Ruhetag) → null.
+        $utcTueBerlin = Carbon::create(2026, 4, 20, 23, 30, 0, 'UTC');
+
+        $this->assertNull($restaurant->availableSeatsAt($utcTueBerlin));
+    }
+
+    public function test_reservation_at_exact_window_upper_bound_is_included(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 40);
+
+        // Query 19:00, window upper bound = 21:00. `whereBetween` is inclusive.
+        $upper = $this->monday19Berlin()->copy()->addHours(2);
+        $this->confirmReservationAt($restaurant, $upper, partySize: 5);
+
+        $this->assertSame(35, $restaurant->availableSeatsAt($this->monday19Berlin()));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `Restaurant::reservationRequests()` HasMany relation.
- Adds `Restaurant::availableSeatsAt(CarbonInterface $time): ?int`.
- 13 feature tests in `tests/Feature/Models/RestaurantAvailableSeatsAtTest.php` covering every AC plus regressions.

## Why
PRD-005 (\`ReservationContextBuilder\`) needs a deterministic seat count for any given time so that the AI never decides availability — Laravel does. Locating the math on the `Restaurant` model keeps the call site short (`$restaurant->availableSeatsAt($t)`) and matches the issue title.

## Return contract (decision: nullable `?int`)
- `null` → restaurant is **closed** at that time (outside opening hours or Ruhetag)
- `0`    → open but fully booked
- `> 0`  → open with that many seats free

This separates "not reservable" from "reservable but full" without forcing every caller to consult `OpeningHours::isOpenAt()` redundantly. PRD-005's context JSON needs both signals (\`is_open_at_desired_time\` and \`seats_free_at_desired\`) anyway.

## Calculation (per PRD-005)
\`\`\`
seats_free = max(0, capacity − Σ party_size of confirmed reservations
                              with desired_at within ±2h of query)
\`\`\`
- Only `ReservationStatus::Confirmed` occupies seats — `replied`/`new`/`in_review`/`declined`/`cancelled` do not.
- Window is symmetric ±2h, inclusive on both bounds (Eloquent `whereBetween` semantics).
- Overbooking clamps to `0` (the result type is "free seats", not "deficit").

## Acceptance criteria coverage
- [x] Empty restaurant → full capacity
- [x] Half-booked → correct remaining seats
- [x] Fully booked → 0
- [x] Outside opening hours → \`null\` (documented closed sentinel — chose \`null\` over \`0\` for semantic clarity)
- [x] Timezone: input is in any zone, output is identical for `Europe/Berlin` and equivalent UTC; UTC input that flips weekday into Ruhetag is correctly resolved

## Note on test location
Issue says "unit tests" but the calculation hits the DB (sum query, status filter, window comparison). Pure unit tests would mock the relation and lose coverage of the actual SQL. Tests live in `tests/Feature/Models/` next to the existing `RestaurantTest.php` and use `RefreshDatabase`.

## Test plan
- [x] `php artisan test --filter=RestaurantAvailableSeatsAtTest` — 13/13 green
- [x] `php artisan test` — full suite 342 tests, zero failures (only pre-existing PDO::MYSQL_ATTR_SSL_CA noise)
- [x] `./vendor/bin/pint --test` — clean
- [x] No JS changes → ESLint/Prettier unaffected

Closes #17