### PR TITLE
Implement DashboardController@index with pagination and stats (#47)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\ReservationStatus;
+use App\Http\Requests\DashboardFilterRequest;
+use App\Http\Resources\ReservationRequestResource;
+use App\Models\ReservationRequest;
+use Inertia\Inertia;
+use Inertia\Response;
+
+final class DashboardController extends Controller
+{
+    public function index(DashboardFilterRequest $request): Response
+    {
+        $filters = $request->validated();
+
+        $requests = ReservationRequest::query()
+            ->filter($filters)
+            ->with(['latestReply'])
+            ->orderByDesc('created_at')
+            ->paginate(25)
+            ->withQueryString();
+
+        return Inertia::render('Dashboard', [
+            'filters' => $filters,
+            'requests' => ReservationRequestResource::collection($requests),
+            'stats' => [
+                'new' => ReservationRequest::query()
+                    ->where('status', ReservationStatus::New)
+                    ->count(),
+                'in_review' => ReservationRequest::query()
+                    ->where('status', ReservationStatus::InReview)
+                    ->count(),
+            ],
+        ]);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\ReservationRequestController;
 use Illuminate\Support\Facades\Route;
@@ -9,9 +10,9 @@ Route::get('/', function () {
     return Inertia::render('Welcome');
 })->name('home');
 
-Route::get('dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+Route::get('dashboard', [DashboardController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('dashboard');
 
 Route::get('reservations/{reservation}', [ReservationRequestController::class, 'show'])
     ->whereNumber('reservation')

--- a/tests/Feature/Http/Controllers/DashboardControllerTest.php
+++ b/tests/Feature/Http/Controllers/DashboardControllerTest.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Controllers;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class DashboardControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function ownerOf(Restaurant $restaurant): User
+    {
+        return User::factory()->forRestaurant($restaurant)->create();
+    }
+
+    public function test_dashboard_renders_with_filters_requests_and_stats_props(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        ReservationRequest::factory()->forRestaurant($restaurant)->count(3)->create();
+
+        $this->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->has('filters')
+                ->has('requests.data', 3)
+                ->has('requests.meta')
+                ->has('stats.new')
+                ->has('stats.in_review')
+                ->etc()
+            );
+    }
+
+    public function test_requests_are_scoped_to_the_authenticated_users_restaurant(): void
+    {
+        $mine = Restaurant::factory()->create();
+        $other = Restaurant::factory()->create();
+
+        ReservationRequest::factory()->forRestaurant($mine)->count(2)->create();
+        ReservationRequest::factory()->forRestaurant($other)->count(5)->create();
+
+        $this->actingAs($this->ownerOf($mine));
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('requests.meta.total', 2)
+                ->etc()
+            );
+    }
+
+    public function test_results_are_paginated_at_25_per_page_ordered_by_created_at_desc(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->count(26)
+            ->sequence(fn ($seq) => ['created_at' => now()->subMinutes($seq->index)])
+            ->create();
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('requests.meta.per_page', 25)
+                ->where('requests.meta.total', 26)
+                ->where('requests.meta.current_page', 1)
+                ->has('requests.data', 25)
+                ->etc()
+            );
+
+        $this->get(route('dashboard', ['page' => 2]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('requests.meta.current_page', 2)
+                ->has('requests.data', 1)
+                ->etc()
+            );
+    }
+
+    public function test_filters_propagate_to_the_query_via_scope_filter(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'status' => ReservationStatus::New,
+        ]);
+        ReservationRequest::factory()->forRestaurant($restaurant)->confirmed()->create();
+        ReservationRequest::factory()->forRestaurant($restaurant)->confirmed()->create();
+
+        $this->get(route('dashboard', ['status' => ['confirmed']]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('filters.status', ['confirmed'])
+                ->where('requests.meta.total', 2)
+                ->etc()
+            );
+    }
+
+    public function test_filters_prop_round_trips_validated_input(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        $this->get(route('dashboard', [
+            'status' => ['new', 'in_review'],
+            'source' => ['email'],
+            'q' => 'mueller',
+        ]))->assertInertia(fn (AssertableInertia $page) => $page
+            ->where('filters.status', ['new', 'in_review'])
+            ->where('filters.source', ['email'])
+            ->where('filters.q', 'mueller')
+            ->etc()
+        );
+    }
+
+    public function test_invalid_filter_input_is_rejected(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        $this->get(route('dashboard', ['status' => ['not-a-real-status']]))
+            ->assertSessionHasErrors('status.0');
+    }
+
+    public function test_stats_count_only_the_authenticated_users_restaurant(): void
+    {
+        $mine = Restaurant::factory()->create();
+        $other = Restaurant::factory()->create();
+
+        ReservationRequest::factory()->forRestaurant($mine)->count(4)->create([
+            'status' => ReservationStatus::New,
+        ]);
+        ReservationRequest::factory()->forRestaurant($mine)->count(2)->state(['status' => ReservationStatus::InReview])->create();
+        ReservationRequest::factory()->forRestaurant($other)->count(7)->create([
+            'status' => ReservationStatus::New,
+        ]);
+
+        $this->actingAs($this->ownerOf($mine));
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('stats.new', 4)
+                ->where('stats.in_review', 2)
+                ->etc()
+            );
+    }
+
+    public function test_stats_are_unaffected_by_active_list_filters(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        ReservationRequest::factory()->forRestaurant($restaurant)->count(3)->create([
+            'status' => ReservationStatus::New,
+        ]);
+        ReservationRequest::factory()->forRestaurant($restaurant)->confirmed()->create();
+
+        // Filter the list to confirmed only — stats must still report total new/in_review counts.
+        $this->get(route('dashboard', ['status' => ['confirmed']]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('requests.meta.total', 1)
+                ->where('stats.new', 3)
+                ->where('stats.in_review', 0)
+                ->etc()
+            );
+    }
+
+    public function test_request_resource_shape_is_present_in_list(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'source' => ReservationSource::Email,
+            'guest_name' => 'Anna Probe',
+        ]);
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->has('requests.data.0', fn (AssertableInertia $row) => $row
+                    ->where('guest_name', 'Anna Probe')
+                    ->where('source', 'email')
+                    ->where('has_raw_email', true)
+                    ->etc()
+                )
+                ->etc()
+            );
+    }
+
+    public function test_guests_are_redirected_to_login(): void
+    {
+        $this->get(route('dashboard'))->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds \`app/Http/Controllers/DashboardController\` matching the signature and shape from PRD-004 §"Controller".
- Replaces the closure on \`GET /dashboard\` with the controller in \`routes/web.php\`. Auth + verified middleware preserved.
- 10 feature tests in \`tests/Feature/Http/Controllers/DashboardControllerTest.php\`.

## Why
The dashboard route was a placeholder closure rendering an empty \`Dashboard\` page. With the FormRequest (#48), scope filter (#49), and Resource (#50) all in place, this PR wires them together so the page receives the full \`filters/requests/stats\` props. From here, #53 (Build Dashboard.vue) can render against a real, paginated, validated server contract.

## Behaviour
- \`filters\`: the validated FormRequest array, round-tripped into the page (controls the filter UI on first paint and after \`router.reload\`).
- \`requests\`: \`ReservationRequestResource::collection(...->paginate(25)->withQueryString())\` — both the data rows and pagination meta in one prop, query-string-preserving for filter+page links.
- \`stats\`: tenant-wide counts of \`new\` and \`in_review\`.
  - Deliberately **not** filtered. A "show only confirmed" view should still surface the actual open-work counters; otherwise the stats become useless when the user is filtering for a closed status.
  - Locked in by \`test_stats_are_unaffected_by_active_list_filters\`.

## Tenant isolation
No \`where('restaurant_id', …)\` in the controller. The existing global \`RestaurantScope\` handles it for both the list query and the stats counts. Verified by:
- \`test_requests_are_scoped_to_the_authenticated_users_restaurant\`
- \`test_stats_count_only_the_authenticated_users_restaurant\`

## Acceptance criteria
- [x] Signature: \`index(DashboardFilterRequest \$request): Response\`
- [x] Uses \`ReservationRequest::query()->filter()->with(['latestReply'])->orderByDesc('created_at')->paginate(25)->withQueryString()\`
- [x] Inertia response carries \`filters\`, \`requests\`, \`stats\`
- [x] Stats include counts for \`new\` and \`in_review\`
- [x] Multi-tenant scoping via \`RestaurantScope\` — no manual \`where('restaurant_id', …)\`

## Test plan
- [x] \`php artisan test --filter=DashboardControllerTest\` — 10/10 green
- [x] \`php artisan test --filter=DashboardTest\` — 5/5 green (existing shell tests untouched)
- [x] \`php artisan test\` — full suite 360 tests, zero failures
- [x] \`./vendor/bin/pint --test\` — clean
- [x] Route name \`dashboard\` unchanged → no \`ziggy:generate\` drift

## Notes
- \`Dashboard.vue\` itself stays as today's empty-state shell — the actual UI consuming \`requests/stats\` is owned by #53.
- A user without a restaurant (\`restaurant_id = null\`) still loads the page (RestaurantScope short-circuits to an empty result set instead of 500). Existing \`DashboardTest::test_user_without_restaurant_receives_null_restaurant_prop\` confirms this remains true.

Closes #47