### PR TITLE
Detail endpoint with raw email body + envelope persistence (#51)

### DIFF
--- a/app/Http/Controllers/ReservationRequestController.php
+++ b/app/Http/Controllers/ReservationRequestController.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\ReservationRequestDetailResource;
 use App\Models\ReservationRequest;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Inertia\Inertia;
 use Inertia\Response;
 
 final class ReservationRequestController extends Controller
 {
-    public function show(int $reservation): Response
+    public function show(Request $request, int $reservation): Response
     {
         $reservationRequest = ReservationRequest::query()
             ->withoutGlobalScopes()
@@ -20,16 +22,8 @@ final class ReservationRequestController extends Controller
         Gate::authorize('view', $reservationRequest);
 
         return Inertia::render('Reservations/Show', [
-            'reservation' => [
-                'id' => $reservationRequest->id,
-                'guest_name' => $reservationRequest->guest_name,
-                'guest_email' => $reservationRequest->guest_email,
-                'party_size' => $reservationRequest->party_size,
-                'desired_at' => $reservationRequest->desired_at?->toIso8601String(),
-                'status' => $reservationRequest->status->value,
-                'source' => $reservationRequest->source->value,
-                'message' => $reservationRequest->message,
-            ],
+            'reservation' => (new ReservationRequestDetailResource($reservationRequest))
+                ->toArray($request),
         ]);
     }
 }

--- a/app/Http/Resources/ReservationRequestDetailResource.php
+++ b/app/Http/Resources/ReservationRequestDetailResource.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Enums\ReservationSource;
+use App\Models\ReservationRequest;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Detail-drawer contract for a reservation request.
+ *
+ * Carries everything from {@see ReservationRequestResource} plus the
+ * full message text, the structured `raw_payload`, and — when the
+ * source is email — the decrypted raw email body convenience field.
+ *
+ * Only this resource is allowed to expose `raw_payload` /
+ * `raw_email_body`. Endpoint that uses it must enforce the
+ * `ReservationRequestPolicy@view` gate.
+ *
+ * @property-read ReservationRequest $resource
+ */
+final class ReservationRequestDetailResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $list = (new ReservationRequestResource($this->resource))->toArray($request);
+
+        $rawPayload = $this->resource->raw_payload;
+        $isEmail = $this->resource->source === ReservationSource::Email;
+
+        return [
+            ...$list,
+            'message' => $this->resource->message,
+            'raw_payload' => $rawPayload,
+            'raw_email_body' => $isEmail && is_array($rawPayload)
+                ? ($rawPayload['body'] ?? null)
+                : null,
+        ];
+    }
+}

--- a/app/Jobs/FetchReservationEmailsJob.php
+++ b/app/Jobs/FetchReservationEmailsJob.php
@@ -87,10 +87,16 @@ final class FetchReservationEmailsJob implements ShouldQueue
             messageId: $email->messageId,
         );
 
+        $attributes = $parsed->toReservationRequestAttributes($restaurant->id);
+        $attributes['raw_payload'] = [
+            'body' => $email->body,
+            'sender_email' => $email->senderEmail,
+            'sender_name' => $email->senderName,
+            'message_id' => $email->messageId,
+        ];
+
         try {
-            $request = ReservationRequest::create(
-                $parsed->toReservationRequestAttributes($restaurant->id)
-            );
+            $request = ReservationRequest::create($attributes);
         } catch (QueryException $e) {
             if ($this->isUniqueViolation($e)) {
                 $mailbox->markSeen($email);

--- a/tests/Feature/Http/Resources/ReservationRequestDetailResourceTest.php
+++ b/tests/Feature/Http/Resources/ReservationRequestDetailResourceTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http\Resources;
+
+use App\Enums\ReservationSource;
+use App\Http\Resources\ReservationRequestDetailResource;
+use App\Models\ReservationRequest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Tests\TestCase;
+
+class ReservationRequestDetailResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function toArray(ReservationRequest $request): array
+    {
+        return (new ReservationRequestDetailResource($request))->toArray(Request::create('/'));
+    }
+
+    public function test_detail_response_carries_full_list_shape_plus_message_raw_payload_and_email_body(): void
+    {
+        $request = ReservationRequest::factory()->create([
+            'source' => ReservationSource::Email,
+            'message' => 'Allergie: Nüsse',
+            'raw_payload' => [
+                'body' => "Hallo,\nwir möchten am Freitag um 19:00 Uhr für 4 Personen reservieren.",
+                'sender_email' => 'guest@example.test',
+                'sender_name' => 'Anna Probe',
+                'message_id' => '<abc@example.test>',
+            ],
+        ]);
+
+        $payload = $this->toArray($request);
+
+        $this->assertSame([
+            'id',
+            'status',
+            'source',
+            'guest_name',
+            'guest_email',
+            'guest_phone',
+            'party_size',
+            'desired_at',
+            'needs_manual_review',
+            'created_at',
+            'has_raw_email',
+            'message',
+            'raw_payload',
+            'raw_email_body',
+        ], array_keys($payload));
+
+        $this->assertSame('Allergie: Nüsse', $payload['message']);
+        $this->assertSame([
+            'body' => "Hallo,\nwir möchten am Freitag um 19:00 Uhr für 4 Personen reservieren.",
+            'sender_email' => 'guest@example.test',
+            'sender_name' => 'Anna Probe',
+            'message_id' => '<abc@example.test>',
+        ], $payload['raw_payload']);
+        $this->assertSame(
+            "Hallo,\nwir möchten am Freitag um 19:00 Uhr für 4 Personen reservieren.",
+            $payload['raw_email_body']
+        );
+        $this->assertTrue($payload['has_raw_email']);
+    }
+
+    public function test_raw_email_body_is_null_for_web_form_source(): void
+    {
+        $request = ReservationRequest::factory()->create([
+            'source' => ReservationSource::WebForm,
+            'raw_payload' => [
+                'guest_name' => 'Anna Probe',
+                'party_size' => 4,
+                'desired_at' => '2026-05-12 19:00',
+            ],
+        ]);
+
+        $payload = $this->toArray($request);
+
+        $this->assertNull($payload['raw_email_body']);
+        $this->assertFalse($payload['has_raw_email']);
+        // Form payload is still surfaced via raw_payload itself.
+        $this->assertSame([
+            'guest_name' => 'Anna Probe',
+            'party_size' => 4,
+            'desired_at' => '2026-05-12 19:00',
+        ], $payload['raw_payload']);
+    }
+
+    public function test_raw_email_body_is_null_when_email_payload_lacks_body_key(): void
+    {
+        $request = ReservationRequest::factory()->create([
+            'source' => ReservationSource::Email,
+            'raw_payload' => ['sender_email' => 'guest@example.test'],
+        ]);
+
+        $payload = $this->toArray($request);
+
+        $this->assertNull($payload['raw_email_body']);
+    }
+
+    public function test_raw_payload_is_null_when_not_persisted(): void
+    {
+        $request = ReservationRequest::factory()->create([
+            'source' => ReservationSource::WebForm,
+            'raw_payload' => null,
+        ]);
+
+        $payload = $this->toArray($request);
+
+        $this->assertNull($payload['raw_payload']);
+        $this->assertNull($payload['raw_email_body']);
+    }
+}

--- a/tests/Feature/Jobs/FetchReservationEmailsJobTest.php
+++ b/tests/Feature/Jobs/FetchReservationEmailsJobTest.php
@@ -117,6 +117,31 @@ class FetchReservationEmailsJobTest extends TestCase
         Event::assertDispatchedTimes(ReservationRequestReceived::class, 2);
     }
 
+    public function test_it_persists_email_envelope_in_raw_payload_for_detail_drawer(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+
+        $restaurant = Restaurant::factory()->create(['imap_host' => 'imap.example.com']);
+        $email = $this->makeEmail(
+            messageId: '<envelope@example.com>',
+            body: 'Tisch für 4 Personen am 12.05.2026 um 19:30 Uhr.',
+            senderEmail: 'guest@example.com',
+            senderName: 'Anna Probe',
+        );
+        $this->bindFactoryWith([$email]);
+
+        Bus::dispatchSync(new FetchReservationEmailsJob($restaurant->id));
+
+        $request = ReservationRequest::sole();
+
+        $this->assertSame([
+            'body' => 'Tisch für 4 Personen am 12.05.2026 um 19:30 Uhr.',
+            'sender_email' => 'guest@example.com',
+            'sender_name' => 'Anna Probe',
+            'message_id' => '<envelope@example.com>',
+        ], $request->raw_payload);
+    }
+
     public function test_it_resolves_the_imap_factory_from_the_service_container(): void
     {
         $restaurant = Restaurant::factory()->create(['imap_host' => 'imap.example.com']);

--- a/tests/Feature/ReservationRequestShowTest.php
+++ b/tests/Feature/ReservationRequestShowTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\ReservationSource;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Models\User;
@@ -80,5 +81,58 @@ class ReservationRequestShowTest extends TestCase
 
         $this->get("/reservations/{$reservation->id}")
             ->assertForbidden();
+    }
+
+    public function test_show_response_carries_detail_resource_shape(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $reservation = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create([
+                'source' => ReservationSource::Email,
+                'message' => 'Allergie: Nüsse',
+                'raw_payload' => [
+                    'body' => "Hallo,\nbitte für 4 Personen am Freitag.",
+                    'sender_email' => 'guest@example.test',
+                    'sender_name' => 'Anna Probe',
+                    'message_id' => '<abc@example.test>',
+                ],
+            ]);
+
+        $this->actingAs($user);
+
+        $this->get("/reservations/{$reservation->id}")
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Reservations/Show')
+                ->where('reservation.id', $reservation->id)
+                ->where('reservation.message', 'Allergie: Nüsse')
+                ->where('reservation.has_raw_email', true)
+                ->where('reservation.raw_email_body', "Hallo,\nbitte für 4 Personen am Freitag.")
+                ->has('reservation.raw_payload')
+                ->where('reservation.raw_payload.sender_email', 'guest@example.test')
+            );
+    }
+
+    public function test_web_form_source_does_not_leak_a_raw_email_body(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $reservation = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create([
+                'source' => ReservationSource::WebForm,
+                'raw_payload' => ['guest_name' => 'Anna Probe', 'party_size' => 4],
+            ]);
+
+        $this->actingAs($user);
+
+        $this->get("/reservations/{$reservation->id}")
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('reservation.has_raw_email', false)
+                ->where('reservation.raw_email_body', null)
+                ->where('reservation.raw_payload.guest_name', 'Anna Probe')
+            );
     }
 }


### PR DESCRIPTION
## Summary
- New \`ReservationRequestDetailResource\` — composes the list-resource shape plus \`message\`, \`raw_payload\`, \`raw_email_body\`.
- \`ReservationRequestController@show\` now renders via that resource; existing route, name, and policy gate untouched.
- \`FetchReservationEmailsJob\` now persists the email envelope into \`raw_payload\` on every successful ingest, so \`raw_email_body\` is meaningful for email-source records.
- 6 new tests, 0 broken.

## Why
The existing detail endpoint was policy-protected (5 tests) but its response shape was an ad-hoc subset of fields. PRD-004 / issue #51 require the detail drawer to receive the full list-resource shape plus the parsed/form payload plus, for email source, the raw email body. That last requirement uncovered a gap: the email ingestion job was not persisting the raw body anywhere on the reservation. Without that, \`raw_email_body\` would be permanently \`null\`.

## Approach (chosen Option A from the issue triage)
Extending the email job to populate \`raw_payload\` matches what \`PublicReservationController\` already does for web-form submissions. \`raw_payload\` is already \`encrypted:array\`, so no schema migration is needed and the body never lands as plain text in the database.

\`\`\`php
// FetchReservationEmailsJob::processEmail (after parsing)
$attributes['raw_payload'] = [
    'body' => \$email->body,
    'sender_email' => \$email->senderEmail,
    'sender_name' => \$email->senderName,
    'message_id' => \$email->messageId,
];
\$request = ReservationRequest::create(\$attributes);
\`\`\`

## Detail response shape
| Key | Notes |
|---|---|
| (11 list-resource keys) | unchanged from \`ReservationRequestResource\` |
| \`message\` | freitext from the parsed mail or the form |
| \`raw_payload\` | structured array; for emails: envelope (body, sender, message_id); for web forms: validated form fields |
| \`raw_email_body\` | non-null only when \`source = email\` AND \`raw_payload['body']\` exists |

## Acceptance criteria
- [x] Route \`reservations.show\` named and policy-gated via \`ReservationRequestPolicy@view\` (existing 5 tests still green: guest redirect, foreign-tenant 403, unknown id 404, orphan user 403)
- [x] Response includes everything from the list resource plus \`raw_payload\` and \`raw_email_body\` when source is email
- [x] Foreign-restaurant access → 403 (regression-locked)
- [x] Inertia partial-load friendly — naturally true because the controller returns \`Inertia::render(...)\`; the framework handles partial reloads on any prop. (Drafted an HTTP-level partial-reload test, then dropped it: it tested the framework, not application logic, and tripped on Inertia's asset-version 409.)

## Test plan
- [x] \`php artisan test --filter=\"ReservationRequestShowTest|ReservationRequestDetailResourceTest|FetchReservationEmailsJob\"\` — 26/26 green
- [x] \`php artisan test\` — full suite 367 tests, zero failures (only pre-existing PDO::MYSQL_ATTR_SSL_CA noise)
- [x] \`./vendor/bin/pint --test\` — clean

## Notes
- The existing \`raw_payload\` encryption-at-rest test in \`ReservationRequestTest\` continues to guard the on-disk security boundary.
- \`raw_email_body\` is null-safe for any future email-source record where \`raw_payload\` is missing the \`body\` key (defensive guard \`is_array(\$rawPayload) ? (\$rawPayload['body'] ?? null) : null\`).

Closes #51