### PR TITLE
Apply default dashboard filters on first visit (#52)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -8,6 +8,7 @@ use App\Enums\ReservationStatus;
 use App\Http\Requests\DashboardFilterRequest;
 use App\Http\Resources\ReservationRequestResource;
 use App\Models\ReservationRequest;
+use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -15,7 +16,9 @@ final class DashboardController extends Controller
 {
     public function index(DashboardFilterRequest $request): Response
     {
-        $filters = $request->validated();
+        $filters = $request->query() === []
+            ? $this->defaultFilters($request)
+            : $request->validated();
 
         $requests = ReservationRequest::query()
             ->filter($filters)
@@ -36,5 +39,25 @@ final class DashboardController extends Controller
                     ->count(),
             ],
         ]);
+    }
+
+    /**
+     * Defaults applied only when the query string is fully empty
+     * (first visit, no user-supplied filter). Any querystring at all —
+     * including filter clears that send `?status[]=` — bypasses these.
+     *
+     * @return array<string, mixed>
+     */
+    private function defaultFilters(DashboardFilterRequest $request): array
+    {
+        $timezone = $request->user()?->restaurant?->timezone ?? config('app.timezone');
+
+        return [
+            'status' => [
+                ReservationStatus::New->value,
+                ReservationStatus::InReview->value,
+            ],
+            'from' => Carbon::now($timezone)->startOfDay()->toDateString(),
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/DashboardControllerTest.php
+++ b/tests/Feature/Http/Controllers/DashboardControllerTest.php
@@ -10,6 +10,7 @@ use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Inertia\Testing\AssertableInertia;
 use Tests\TestCase;
 
@@ -200,5 +201,101 @@ class DashboardControllerTest extends TestCase
     public function test_guests_are_redirected_to_login(): void
     {
         $this->get(route('dashboard'))->assertRedirect(route('login'));
+    }
+
+    public function test_first_visit_injects_status_and_from_defaults_into_filters_prop(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+        $this->actingAs($this->ownerOf($restaurant));
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('filters.status', ['new', 'in_review'])
+                ->where('filters.from', Carbon::now('Europe/Berlin')->toDateString())
+                ->etc()
+            );
+    }
+
+    public function test_first_visit_defaults_hide_records_outside_the_default_set(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+        $this->actingAs($this->ownerOf($restaurant));
+
+        // Will pass the default filter (status=new, future desired_at).
+        $included = ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'status' => ReservationStatus::New,
+            'desired_at' => Carbon::now('Europe/Berlin')->addDays(2),
+        ]);
+        // Confirmed status — excluded by default filter.
+        ReservationRequest::factory()->forRestaurant($restaurant)->confirmed()->create([
+            'desired_at' => Carbon::now('Europe/Berlin')->addDays(2),
+        ]);
+        // Past desired_at — excluded by default `from = today`.
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'status' => ReservationStatus::New,
+            'desired_at' => Carbon::now('Europe/Berlin')->subDays(3),
+        ]);
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('requests.meta.total', 1)
+                ->where('requests.data.0.id', $included->id)
+                ->etc()
+            );
+    }
+
+    public function test_any_filter_query_string_suppresses_defaults(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        // status=[confirmed] is user-driven — must NOT also re-inject the from=today default.
+        $this->get(route('dashboard', ['status' => ['confirmed']]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('filters.status', ['confirmed'])
+                ->missing('filters.from')
+                ->etc()
+            );
+    }
+
+    public function test_unrelated_query_string_still_suppresses_defaults(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $this->actingAs($this->ownerOf($restaurant));
+
+        // `?page=2` is not a filter key at all but still indicates user-driven navigation;
+        // defaults must NOT be re-applied (otherwise paginating would change the visible result set
+        // mid-session and any non-default filter would silently fight the from=today injection).
+        $this->get(route('dashboard', ['page' => 2]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->missing('filters.status')
+                ->missing('filters.from')
+                ->etc()
+            );
+    }
+
+    public function test_defaults_use_restaurant_timezone_for_today_calculation(): void
+    {
+        // A restaurant in a far-east timezone where "today" can disagree with UTC for several hours.
+        $restaurant = Restaurant::factory()->create(['timezone' => 'Pacific/Auckland']);
+        $this->actingAs($this->ownerOf($restaurant));
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('filters.from', Carbon::now('Pacific/Auckland')->toDateString())
+                ->etc()
+            );
+    }
+
+    public function test_user_without_restaurant_falls_back_to_app_timezone(): void
+    {
+        $orphan = User::factory()->create(['restaurant_id' => null]);
+        $this->actingAs($orphan);
+
+        $this->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('filters.from', Carbon::now(config('app.timezone'))->toDateString())
+                ->etc()
+            );
     }
 }


### PR DESCRIPTION
## Summary
- \`DashboardController@index\` now injects defaults when the request query string is fully empty: \`status = [new, in_review]\`, \`from = today (restaurant timezone)\`.
- Any non-empty querystring — including unrelated keys like \`?page=2\` and explicit clears like \`?status[]=\` — bypasses the defaults completely.
- 6 new tests, 10 existing controller tests still green.

## Why
A dashboard that loads to "everything ever" buries the actually-actionable rows. The PRD-004 default — only open work, only forward in time — gives the operator something they can act on the moment they log in. PRD-004 §"Tests" lists \`it applies default filters on first visit\` exactly for this reason.

## Behaviour matrix

| Request URL | \`filters\` returned | List filtered? |
|---|---|---|
| \`/dashboard\` | \`{status: [new,in_review], from: '2026-04-25'}\` | yes — defaults |
| \`/dashboard?status[]=confirmed\` | \`{status: [confirmed]}\` | yes — user choice; \`from\` NOT injected |
| \`/dashboard?page=2\` | \`{}\` | no — pagination only |
| \`/dashboard?source[]=email\` | \`{source: [email]}\` | yes — user choice; status/from NOT injected |

## Why \`\$request->query() === []\` (not "validated() is empty")
Validation rules in \`DashboardFilterRequest\` are all \`nullable\`, so \`validated()\` is empty whenever the user submits an empty filter (e.g. ?status[]=&from=). Treating that as "fresh visit" would re-inject defaults on every "clear filters" click, which would defeat the clear button. Reading the raw query string is the only signal that survives the FormRequest's defaulting.

This also aligns with the AC's emphasis on respecting empty-array filters: any user-touched URL — even \`?status[]=\` — bypasses defaults.

## Timezone resolution for "today"
\`from\` is computed in the authenticated user's restaurant timezone:
\`Carbon::now(\$user->restaurant->timezone)->startOfDay()->toDateString()\`. A test against \`Pacific/Auckland\` (where local "today" can be a different calendar date than UTC for several hours) pins this in.

Users without a restaurant fall back to \`config('app.timezone')\` so the dashboard never 500s for an orphan account; that path is also covered by a test.

## Acceptance criteria
- [x] When the filter query string is empty, the controller injects the defaults
- [x] User-supplied empty-array filters (e.g. \`?status[]=\`) are respected — they show up in the URL → query() is non-empty → defaults are not re-injected
- [x] Feature tests assert the default behaviour (\`test_first_visit_injects_status_and_from_defaults_into_filters_prop\`, \`test_first_visit_defaults_hide_records_outside_the_default_set\`)

## Test plan
- [x] \`php artisan test --filter=DashboardControllerTest\` — 16/16 green (10 existing + 6 new)
- [x] \`php artisan test\` — full suite 373 tests, zero failures
- [x] \`./vendor/bin/pint --test\` — clean

Closes #52