### PR TITLE
Read-side dashboard: filter bar, table, pagination, Prüfen chip (#53)

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,20 +1,176 @@
 <script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import AppLayout from '@/layouts/AppLayout.vue';
-import { type BreadcrumbItem, type SharedData } from '@/types';
-import { Head, usePage } from '@inertiajs/vue3';
+import {
+    type BreadcrumbItem,
+    type DashboardFilters,
+    type DashboardStats,
+    type PaginatedReservationRequests,
+    type ReservationRequestRow,
+    type ReservationSource,
+    type ReservationStatus,
+    type SharedData,
+} from '@/types';
+import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import { Info } from 'lucide-vue-next';
-import { computed } from 'vue';
+import { computed, ref, watch } from 'vue';
 
-const breadcrumbs: BreadcrumbItem[] = [
-    {
-        title: 'Dashboard',
-        href: '/dashboard',
-    },
-];
+interface DashboardProps {
+    filters: DashboardFilters;
+    requests: PaginatedReservationRequests;
+    stats: DashboardStats;
+}
+
+const props = defineProps<DashboardProps>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'Dashboard', href: '/dashboard' }];
 
 const page = usePage<SharedData>();
 const restaurantName = computed(() => page.props.restaurant?.name ?? '');
+
+const STATUS_OPTIONS: { value: ReservationStatus; label: string }[] = [
+    { value: 'new', label: 'Neu' },
+    { value: 'in_review', label: 'In Bearbeitung' },
+    { value: 'replied', label: 'Beantwortet' },
+    { value: 'confirmed', label: 'Bestätigt' },
+    { value: 'declined', label: 'Abgelehnt' },
+    { value: 'cancelled', label: 'Storniert' },
+];
+
+const SOURCE_OPTIONS: { value: ReservationSource; label: string }[] = [
+    { value: 'web_form', label: 'Webformular' },
+    { value: 'email', label: 'E-Mail' },
+];
+
+const STATUS_BADGE_CLASS: Record<ReservationStatus, string> = {
+    new: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-200',
+    in_review: 'bg-indigo-100 text-indigo-900 dark:bg-indigo-900/40 dark:text-indigo-200',
+    replied: 'bg-purple-100 text-purple-900 dark:bg-purple-900/40 dark:text-purple-200',
+    confirmed: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200',
+    declined: 'bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-200',
+    cancelled: 'bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300',
+};
+
+const STATUS_LABEL: Record<ReservationStatus, string> = Object.fromEntries(STATUS_OPTIONS.map((s) => [s.value, s.label])) as Record<
+    ReservationStatus,
+    string
+>;
+
+const SOURCE_LABEL: Record<ReservationSource, string> = Object.fromEntries(SOURCE_OPTIONS.map((s) => [s.value, s.label])) as Record<
+    ReservationSource,
+    string
+>;
+
+const search = ref(props.filters.q ?? '');
+const fromDate = ref(props.filters.from ?? '');
+const toDate = ref(props.filters.to ?? '');
+
+watch(
+    () => props.filters,
+    (next) => {
+        search.value = next.q ?? '';
+        fromDate.value = next.from ?? '';
+        toDate.value = next.to ?? '';
+    },
+);
+
+function buildQuery(overrides: DashboardFilters): Record<string, unknown> {
+    const next: Record<string, unknown> = {
+        ...props.filters,
+        ...overrides,
+    };
+
+    for (const key of Object.keys(next)) {
+        const value = next[key];
+        const isEmptyArray = Array.isArray(value) && value.length === 0;
+        const isEmptyString = typeof value === 'string' && value.length === 0;
+        const isNullish = value === null || value === undefined;
+
+        if (isEmptyArray || isEmptyString || isNullish) {
+            delete next[key];
+        }
+    }
+
+    return next;
+}
+
+function applyFilter(overrides: DashboardFilters) {
+    router.get(route('dashboard'), buildQuery(overrides), {
+        preserveScroll: true,
+        preserveState: true,
+        replace: true,
+        only: ['filters', 'requests', 'stats'],
+    });
+}
+
+function toggleStatus(value: ReservationStatus) {
+    const current = props.filters.status ?? [];
+    const next = current.includes(value) ? current.filter((s) => s !== value) : [...current, value];
+    applyFilter({ status: next });
+}
+
+function toggleSource(value: ReservationSource) {
+    const current = props.filters.source ?? [];
+    const next = current.includes(value) ? current.filter((s) => s !== value) : [...current, value];
+    applyFilter({ source: next });
+}
+
+function submitSearch() {
+    applyFilter({ q: search.value });
+}
+
+function commitDateRange() {
+    applyFilter({ from: fromDate.value, to: toDate.value });
+}
+
+function clearAllFilters() {
+    router.get(
+        route('dashboard'),
+        { clear: '1' },
+        { preserveScroll: true, preserveState: true, replace: true, only: ['filters', 'requests', 'stats'] },
+    );
+}
+
+function isStatusActive(value: ReservationStatus): boolean {
+    return (props.filters.status ?? []).includes(value);
+}
+
+function isSourceActive(value: ReservationSource): boolean {
+    return (props.filters.source ?? []).includes(value);
+}
+
+const hasActiveFilters = computed(() => {
+    const f = props.filters;
+    return (
+        (f.status && f.status.length > 0) ||
+        (f.source && f.source.length > 0) ||
+        (f.from && f.from.length > 0) ||
+        (f.to && f.to.length > 0) ||
+        (f.q && f.q.length > 0)
+    );
+});
+
+function formatDateTime(iso: string | null): string {
+    if (!iso) {
+        return '–';
+    }
+
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+        return '–';
+    }
+
+    return new Intl.DateTimeFormat('de-DE', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+    }).format(date);
+}
+
+function rowDetailHref(row: ReservationRequestRow): string {
+    return route('reservations.show', row.id);
+}
 </script>
 
 <template>
@@ -22,20 +178,185 @@ const restaurantName = computed(() => page.props.restaurant?.name ?? '');
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="flex h-full flex-1 flex-col gap-6 p-6">
-            <header data-testid="restaurant-header">
-                <h1 class="text-2xl font-semibold tracking-tight">
-                    {{ restaurantName }}
-                </h1>
-                <p class="text-sm text-muted-foreground">Willkommen im Reservierungs-Dashboard.</p>
+            <header class="flex flex-wrap items-end justify-between gap-4" data-testid="restaurant-header">
+                <div>
+                    <h1 class="text-2xl font-semibold tracking-tight">{{ restaurantName }}</h1>
+                    <p class="text-sm text-muted-foreground">Reservierungs-Dashboard</p>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-3 text-sm" data-testid="dashboard-stats">
+                    <span
+                        class="rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-200"
+                    >
+                        Neu: <strong>{{ props.stats.new }}</strong>
+                    </span>
+                    <span
+                        class="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-indigo-900 dark:border-indigo-900/40 dark:bg-indigo-950/40 dark:text-indigo-200"
+                    >
+                        In Bearbeitung: <strong>{{ props.stats.in_review }}</strong>
+                    </span>
+                </div>
             </header>
 
             <section
+                class="flex flex-col gap-4 rounded-lg border border-border p-4"
+                data-testid="dashboard-filter-bar"
+                aria-label="Reservierungs-Filter"
+            >
+                <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Status</span>
+                    <button
+                        v-for="opt in STATUS_OPTIONS"
+                        :key="`status-${opt.value}`"
+                        type="button"
+                        class="rounded-full border px-3 py-1 text-xs font-medium transition-colors"
+                        :class="
+                            isStatusActive(opt.value)
+                                ? 'border-primary bg-primary text-primary-foreground'
+                                : 'border-input bg-background text-foreground hover:bg-muted'
+                        "
+                        :aria-pressed="isStatusActive(opt.value)"
+                        @click="toggleStatus(opt.value)"
+                    >
+                        {{ opt.label }}
+                    </button>
+                </div>
+
+                <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Quelle</span>
+                    <button
+                        v-for="opt in SOURCE_OPTIONS"
+                        :key="`source-${opt.value}`"
+                        type="button"
+                        class="rounded-full border px-3 py-1 text-xs font-medium transition-colors"
+                        :class="
+                            isSourceActive(opt.value)
+                                ? 'border-primary bg-primary text-primary-foreground'
+                                : 'border-input bg-background text-foreground hover:bg-muted'
+                        "
+                        :aria-pressed="isSourceActive(opt.value)"
+                        @click="toggleSource(opt.value)"
+                    >
+                        {{ opt.label }}
+                    </button>
+                </div>
+
+                <div class="flex flex-wrap items-end gap-3">
+                    <label class="flex flex-col gap-1 text-xs">
+                        <span class="font-semibold uppercase tracking-wide text-muted-foreground">Von</span>
+                        <Input v-model="fromDate" type="date" class="h-9" data-testid="filter-from" @change="commitDateRange" />
+                    </label>
+                    <label class="flex flex-col gap-1 text-xs">
+                        <span class="font-semibold uppercase tracking-wide text-muted-foreground">Bis</span>
+                        <Input v-model="toDate" type="date" class="h-9" data-testid="filter-to" @change="commitDateRange" />
+                    </label>
+
+                    <form class="flex flex-1 items-end gap-2" @submit.prevent="submitSearch">
+                        <label class="flex flex-1 flex-col gap-1 text-xs">
+                            <span class="font-semibold uppercase tracking-wide text-muted-foreground">Suche</span>
+                            <Input
+                                v-model="search"
+                                type="search"
+                                class="h-9"
+                                data-testid="filter-search"
+                                placeholder="Name oder E-Mail"
+                                @blur="submitSearch"
+                            />
+                        </label>
+                        <Button type="submit" variant="secondary" class="h-9">Suchen</Button>
+                    </form>
+
+                    <Button v-if="hasActiveFilters" type="button" variant="ghost" class="h-9" data-testid="filter-clear" @click="clearAllFilters">
+                        Filter zurücksetzen
+                    </Button>
+                </div>
+            </section>
+
+            <section
+                v-if="props.requests.data.length === 0"
                 data-testid="reservations-empty-state"
                 class="flex flex-1 flex-col items-center justify-center rounded-xl border border-dashed border-sidebar-border/70 p-12 text-center dark:border-sidebar-border"
             >
-                <p class="text-lg font-medium">Noch keine Reservierungen</p>
-                <p class="mt-1 text-sm text-muted-foreground">Sobald eine Anfrage eingeht, erscheint sie hier.</p>
+                <p class="text-lg font-medium">Keine Reservierungen</p>
+                <p class="mt-1 text-sm text-muted-foreground">Es gibt aktuell keine Anfragen, die zu deinen Filtern passen.</p>
             </section>
+
+            <section v-else class="overflow-x-auto rounded-lg border border-border" data-testid="reservations-table">
+                <table class="w-full text-left text-sm">
+                    <thead class="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+                        <tr>
+                            <th class="px-3 py-2 font-medium">Eingegangen</th>
+                            <th class="px-3 py-2 font-medium">Wunschzeit</th>
+                            <th class="px-3 py-2 font-medium">Personen</th>
+                            <th class="px-3 py-2 font-medium">Name</th>
+                            <th class="px-3 py-2 font-medium">Quelle</th>
+                            <th class="px-3 py-2 font-medium">Status</th>
+                            <th class="px-3 py-2 font-medium">Aktionen</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-border">
+                        <tr v-for="row in props.requests.data" :key="row.id" class="hover:bg-muted/30" :data-testid="`reservation-row-${row.id}`">
+                            <td class="whitespace-nowrap px-3 py-2 text-muted-foreground">
+                                {{ formatDateTime(row.created_at) }}
+                            </td>
+                            <td class="whitespace-nowrap px-3 py-2">{{ formatDateTime(row.desired_at) }}</td>
+                            <td class="px-3 py-2">{{ row.party_size }}</td>
+                            <td class="px-3 py-2">{{ row.guest_name }}</td>
+                            <td class="px-3 py-2 text-xs text-muted-foreground">{{ SOURCE_LABEL[row.source] }}</td>
+                            <td class="px-3 py-2">
+                                <div class="flex flex-wrap items-center gap-1.5">
+                                    <span
+                                        class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium"
+                                        :class="STATUS_BADGE_CLASS[row.status]"
+                                    >
+                                        {{ STATUS_LABEL[row.status] }}
+                                    </span>
+                                    <span
+                                        v-if="row.needs_manual_review"
+                                        data-testid="needs-review-chip"
+                                        class="inline-flex items-center rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-900 dark:bg-amber-900/40 dark:text-amber-200"
+                                        title="Beim automatischen Parsen waren nicht alle Felder eindeutig — bitte manuell prüfen."
+                                    >
+                                        Prüfen
+                                    </span>
+                                </div>
+                            </td>
+                            <td class="px-3 py-2">
+                                <Link :href="rowDetailHref(row)" class="text-sm font-medium text-primary hover:underline"> Details </Link>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </section>
+
+            <nav
+                v-if="props.requests.meta.last_page > 1"
+                class="flex items-center justify-between gap-3 text-sm"
+                data-testid="dashboard-pagination"
+                aria-label="Seitennavigation"
+            >
+                <span class="text-muted-foreground">
+                    Seite {{ props.requests.meta.current_page }} von {{ props.requests.meta.last_page }} — {{ props.requests.meta.total }} Einträge
+                </span>
+                <div class="flex flex-wrap items-center gap-1">
+                    <Link
+                        v-for="(link, index) in props.requests.meta.links"
+                        :key="`page-${index}`"
+                        :href="link.url ?? ''"
+                        :as="link.url ? 'a' : 'span'"
+                        class="rounded-md border px-3 py-1 text-xs font-medium transition-colors"
+                        :class="[
+                            link.active ? 'border-primary bg-primary text-primary-foreground' : 'border-input bg-background text-foreground',
+                            !link.url ? 'cursor-not-allowed opacity-50' : 'hover:bg-muted',
+                        ]"
+                        :preserve-scroll="true"
+                        :preserve-state="true"
+                        :only="['filters', 'requests', 'stats']"
+                    >
+                        <span v-html="link.label" />
+                    </Link>
+                </div>
+            </nav>
 
             <TooltipProvider :delay-duration="150">
                 <Tooltip>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -52,3 +52,54 @@ export interface User {
 }
 
 export type BreadcrumbItemType = BreadcrumbItem;
+
+export type ReservationStatus = 'new' | 'in_review' | 'replied' | 'confirmed' | 'declined' | 'cancelled';
+export type ReservationSource = 'web_form' | 'email';
+
+export interface ReservationRequestRow {
+    id: number;
+    status: ReservationStatus;
+    source: ReservationSource;
+    guest_name: string;
+    guest_email: string | null;
+    guest_phone: string | null;
+    party_size: number;
+    desired_at: string | null;
+    needs_manual_review: boolean;
+    created_at: string | null;
+    has_raw_email: boolean;
+}
+
+export interface PaginatorMeta {
+    current_page: number;
+    last_page: number;
+    per_page: number;
+    total: number;
+    from: number | null;
+    to: number | null;
+}
+
+export interface PaginatorLink {
+    url: string | null;
+    label: string;
+    active: boolean;
+}
+
+export interface PaginatedReservationRequests {
+    data: ReservationRequestRow[];
+    meta: PaginatorMeta & { links: PaginatorLink[] };
+    links: { first: string | null; last: string | null; prev: string | null; next: string | null };
+}
+
+export interface DashboardFilters {
+    status?: ReservationStatus[];
+    source?: ReservationSource[];
+    from?: string;
+    to?: string;
+    q?: string;
+}
+
+export interface DashboardStats {
+    new: number;
+    in_review: number;
+}


### PR DESCRIPTION
## Summary
- Replaces the placeholder empty-state in \`resources/js/pages/Dashboard.vue\` with the full read-side dashboard: filter bar, table, pagination, and the \"Prüfen\" review chip.
- Adds typed \`DashboardFilters\` / \`PaginatedReservationRequests\` / \`DashboardStats\` / \`ReservationRequestRow\` shapes to \`resources/js/types/index.ts\`.
- All interactions go through Inertia partial reloads — no \`fetch\` / \`axios\` anywhere.

## Why
The dashboard route already produces \`filters\`, \`requests\`, and \`stats\` props (PRs #144, #146) but the UI still showed an empty-state shell. This PR consumes those props end-to-end.

## Scope decision (split posted on #53 comment)
The original issue bundles a substantial chunk of UI; some pieces are already split off elsewhere. This PR delivers the **read side**:

| Concern | Lives in |
|---|---|
| Filter bar (status / source / date range / search) | this PR |
| HTML/Tailwind table with 7 columns | this PR |
| Pagination via paginator meta.links | this PR |
| Prüfen chip for \`needs_manual_review\` | this PR |
| Inertia partial reloads only — no fetch/axios | this PR |
| Bulk-select checkboxes | **#147** (new follow-up) |
| Bulk-select persistence across polling | **#84** |
| \`desired_at\` in restaurant timezone | **#83** |

## UX / interaction details

**Filter chips**: status and source rows render as multi-select toggle buttons (\`aria-pressed\`). Clicking a chip dispatches \`router.get(route('dashboard'), {...filters, status: next}, { only: ['filters','requests','stats'], replace: true })\` — partial reload, no full navigation, no scroll jump.

**Date range**: two native \`<Input type=\"date\">\` controls. \`@change\` commits the range. The FormRequest already validates \`to >= from\`.

**Search**: text input. Commits on blur, Enter, or the explicit \"Suchen\" button. Empty string = no filter (the URL key gets dropped before the partial reload).

**Filter zurücksetzen**: appears only when at least one filter is active. Navigates to \`/dashboard?clear=1\` so the **first-visit defaults from #52 are not re-injected** mid-session — this is the meaningful interaction with the controller-side default logic.

**Pagination**: renders \`requests.meta.links\` directly; preserves \`only\` partial reload, no full re-render. Disabled prev / next links render as opacity-50 spans.

**Prüfen chip**: amber pill next to the status badge, only when \`needs_manual_review\`. Tooltip explains \"Beim automatischen Parsen waren nicht alle Felder eindeutig\".

**Date formatting**: \`Intl.DateTimeFormat('de-DE', { dateStyle: 'medium', timeStyle: 'short' })\`. This uses the **browser** timezone for now — #83 will swap this to the shared \`restaurant.timezone\` prop. Documented in the commit message.

## Acceptance criteria
- [x] Filter bar: status chips, source chips, date range picker, search input
- [x] Table — using HTML \`<table>\` with Tailwind. (No Reka UI \`<Table>\` primitive exists in the project today; rather than ship a new primitive in this PR I used plain HTML, which is small, accessible, and the standard fallback when the design system doesn't yet have a table.)
- [x] Columns: Eingegangen / Wunschzeit / Personen / Name / Quelle / Status / Aktionen
- [x] Pagination controls with \`withQueryString\` state preserved by Inertia
- [ ] Bulk-select checkboxes — moved to **#147**
- [x] \`needs_manual_review = true\` rows marked with yellow \"Prüfen\" chip
- [ ] Timezone display from shared Inertia prop — **#83** (this PR uses browser TZ as a temporary)
- [ ] Row selection persisted by id across partial reloads — **#84** (and depends on #147 first)
- [x] No \`fetch\` / \`axios\` — Inertia partial reloads only

## Test plan
- [x] \`php artisan test\` — full suite 373 tests, zero failures (existing 16 DashboardController tests + 5 DashboardTest tests still green; the prop wiring contract is unchanged)
- [x] \`./vendor/bin/pint --test\` — clean
- [x] \`npm run lint\` — clean (initial \`v-html\` on \`<Link>\` lint warning resolved by wrapping in a \`<span>\`)
- [x] \`npm run format:check\` — clean
- [x] \`npm run build\` — clean (Dashboard chunk is 12 kB / 4.4 kB gzipped)

## ⚠️ Browser verification
I was not able to start the dev server and click through the UI in this session. The implementation is type-checked, lint-clean, build-clean, and the prop contract is verified by the existing backend tests, but a manual browser pass — chip toggles, date filter, search, pagination, empty-state, Prüfen chip render — should still happen before merge. CLAUDE.md flags this expectation explicitly.

Closes #53