### PR TITLE
Fix #149: APP_URL/serve port mismatch breaks Inertia link navigation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,7 @@ APP_NAME=reservation-agent
 APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://localhost:8000
 
 APP_LOCALE=de
 APP_FALLBACK_LOCALE=en

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 /public/build
 /public/hot
 /public/storage
+/resources/js/ziggy.js
 npm-debug.log
 yarn-error.log
 

--- a/app/Http/Middleware/WarnOnAppUrlMismatch.php
+++ b/app/Http/Middleware/WarnOnAppUrlMismatch.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Logs a warning when the URL the browser used to reach the app differs from
+ * APP_URL. Ziggy serialises APP_URL into window.Ziggy, so a mismatch causes
+ * Inertia <Link> clicks to navigate to the wrong origin (classic dev footgun
+ * when APP_URL=http://localhost but `php artisan serve` runs on :8000).
+ *
+ * Active only in the `local` environment.
+ */
+final class WarnOnAppUrlMismatch
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (app()->environment('local')) {
+            $accessed = $request->getSchemeAndHttpHost();
+            $configured = rtrim((string) config('app.url'), '/');
+
+            if ($accessed !== '' && $accessed !== $configured) {
+                Log::warning('APP_URL mismatch — Inertia/Ziggy links will point to the wrong origin. Update APP_URL in .env to match the URL you open in the browser.', [
+                    'configured_app_url' => $configured,
+                    'accessed_url' => $accessed,
+                ]);
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Middleware\HandleInertiaRequests;
+use App\Http\Middleware\WarnOnAppUrlMismatch;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -18,6 +19,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
+            WarnOnAppUrlMismatch::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/tests/Feature/AppUrlMismatchWarningTest.php
+++ b/tests/Feature/AppUrlMismatchWarningTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class AppUrlMismatchWarningTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_logs_warning_when_accessed_url_differs_from_app_url_in_local_env(): void
+    {
+        $this->app->detectEnvironment(fn () => 'local');
+        config(['app.url' => 'http://configured-host:1234']);
+        Log::spy();
+
+        $this->get('http://accessed-host:5678/');
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn (string $message, array $context = []) => str_contains($message, 'APP_URL mismatch')
+                && ($context['configured_app_url'] ?? null) === 'http://configured-host:1234'
+                && ($context['accessed_url'] ?? null) === 'http://accessed-host:5678'
+            )
+            ->atLeast()->once();
+    }
+
+    public function test_does_not_log_when_accessed_url_matches_app_url(): void
+    {
+        $this->app->detectEnvironment(fn () => 'local');
+        config(['app.url' => 'http://matching-host:8000']);
+        Log::spy();
+
+        $this->get('http://matching-host:8000/');
+
+        Log::shouldNotHaveReceived('warning');
+    }
+
+    public function test_does_not_log_in_non_local_environments(): void
+    {
+        $this->app->detectEnvironment(fn () => 'production');
+        config(['app.url' => 'http://configured-host:1234']);
+        Log::spy();
+
+        $this->get('http://accessed-host:5678/');
+
+        Log::shouldNotHaveReceived('warning');
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #149 — Klick auf **Log in** und **Register** auf der Welcome-Page reagierte nicht.

- **Root cause:** `APP_URL=http://localhost` (ohne Port) im committed `.env.example` und lokalem `.env`. `composer run dev` startet `php artisan serve` auf `:8000`. Ziggy serialisiert `APP_URL` in `window.Ziggy`, also lieferte `route('login')` `http://localhost/login` — Port 80, kein Server. Inertia's `<Link>` erkannte unterschiedliche Origins (`localhost` ≠ `127.0.0.1`/`localhost:8000`) und fiel auf `window.location =` zurück → Navigation in den Leerraum, sichtbar als „nichts passiert".
- **Verifizierung vor Fix:** `route('login')` → `http://localhost/login`. **Nach Fix:** `route('login')` → `http://localhost:8000/login`.

## Why

`APP_URL` ist bei Inertia/Ziggy-Setups nicht nur kosmetisch — die clientseitigen Klick-Ziele werden daraus generiert. Ein Port-Mismatch zwischen `APP_URL` und der tatsächlich geöffneten URL ist ein klassischer Footgun, der in vergleichbaren Stacks immer wieder auftritt. Der Fix macht den Default committet korrekt UND fügt einen Runtime-Guardrail hinzu, damit zukünftige `.env`-Driften sofort sichtbar werden.

## Changes

- `.env.example`: `APP_URL=http://localhost:8000` (passt zum `composer run dev`-Default)
- `app/Http/Middleware/WarnOnAppUrlMismatch.php`: neue Middleware, die im `local`-Env eine `Log::warning()` schreibt, wenn die Browser-URL nicht zur `APP_URL` passt. Sichtbar via `php artisan pail` (Teil von `composer run dev`).
- `bootstrap/app.php`: Middleware ans Ende der `web`-Group angehängt
- `.gitignore`: `/resources/js/ziggy.js` aufgenommen — die Datei wird von `app.ts` nicht importiert (`@routes`-Blade-Direktive ist die Source of Truth) und wurde vorher als untracked Stale-Snapshot herumgeschleppt

## Heads-up für Reviewer

Lokales `.env` muss synchronisiert werden:
```diff
- APP_URL=http://localhost
+ APP_URL=http://localhost:8000
```
Danach `php artisan config:clear` und `composer run dev` neu starten. App über `http://localhost:8000` öffnen (nicht `127.0.0.1:8000`, sonst greift derselbe Mismatch erneut — die Guardrail-Warnung weist darauf hin).

## Test plan

- [x] `php artisan test` — 376 Tests grün, 1089 Assertions, 0 Failures (343 mit PHP-8.5-Deprecation-Noise aus `config/database.php`, betrifft nicht diesen PR)
- [x] `tests/Feature/AppUrlMismatchWarningTest.php` — 3 neue Tests: warning bei Mismatch / kein warning bei Match / kein warning außerhalb `local`
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint:check` — pass
- [x] `npm run format:check` — pass
- [x] `route('login')` und `route('register')` per `php artisan tinker` verifiziert — liefern jetzt URLs mit `:8000`
- [ ] Manuell im Browser: `http://localhost:8000` öffnen, **Log in**/**Register** klicken, Navigation prüfen (Reviewer)

Closes #149