### PR TITLE
Fix #149 (part 2): PHP 8.5 deprecation HTML corrupts Inertia JSON responses

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Support\Str;
+use Pdo\Mysql;
 
 return [
 
@@ -58,7 +59,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 
@@ -78,7 +79,7 @@ return [
             'strict' => true,
             'engine' => null,
             'options' => extension_loaded('pdo_mysql') ? array_filter([
-                PDO::MYSQL_ATTR_SSL_CA => env('MYSQL_ATTR_SSL_CA'),
+                (defined('Pdo\Mysql::ATTR_SSL_CA') ? Mysql::ATTR_SSL_CA : PDO::MYSQL_ATTR_SSL_CA) => env('MYSQL_ATTR_SSL_CA'),
             ]) : [],
         ],
 

--- a/tests/Unit/Config/DatabaseConfigTest.php
+++ b/tests/Unit/Config/DatabaseConfigTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Config;
+
+use Tests\TestCase;
+
+/**
+ * Guards against PHP deprecation notices triggered while loading
+ * `config/database.php`. Such notices are written to HTTP output by PHP and
+ * corrupt every Inertia XHR response (the leading HTML breaks JSON parsing
+ * and the page never swaps). Caught us once on PHP 8.5 with PDO::MYSQL_ATTR_SSL_CA.
+ */
+class DatabaseConfigTest extends TestCase
+{
+    public function test_loading_database_config_emits_no_php_deprecations(): void
+    {
+        $deprecations = [];
+
+        $previous = set_error_handler(function (int $errno, string $errstr) use (&$deprecations): bool {
+            if ($errno === E_DEPRECATED || $errno === E_USER_DEPRECATED) {
+                $deprecations[] = $errstr;
+
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            // Re-evaluate the file so its top-level constant lookups run again.
+            include __DIR__.'/../../../config/database.php';
+        } finally {
+            set_error_handler($previous);
+        }
+
+        $this->assertSame(
+            [],
+            $deprecations,
+            'config/database.php triggered PHP deprecation notices: '.implode(' | ', $deprecations)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Zweite Hälfte des #149-Fixes (Login/Register-Klicks rührten sich nicht). Nach dem APP_URL-Fix (PR #150, gemerged) ging die Navigation in Browser-DevTools immer noch kaputt — `Cannot read properties of undefined (reading 'toString')` aus `@inertiajs/vue3`.

## Why

PHP 8.5 hat `PDO::MYSQL_ATTR_SSL_CA` zugunsten von `\Pdo\Mysql::ATTR_SSL_CA` deprecated. Mit `APP_DEBUG=true` schreibt PHP die Notice als HTML in den Output, **bevor** Laravel den Response-Body sendet:

```
<br /><b>Deprecated</b>: Constant PDO::MYSQL_ATTR_SSL_CA is deprecated since 8.5...<br />
{"component":"auth/Register","props":...}
```

Bei HTML-Responses toleriert der Browser das Präfix (Garbage vor dem Doctype). Bei Inertia-XHR-Responses zerschießt es den JSON-Parser → Inertia's `setPage()` knallt → kein Page-Swap → User sieht „nichts passiert". Verifiziert per Playwright-Reproduction (Klick auf Sign-up → Console-Error → URL bleibt).

## Fix

`config/database.php`: bevorzugt `\Pdo\Mysql::ATTR_SSL_CA` wenn definiert, sonst Fallback auf `PDO::MYSQL_ATTR_SSL_CA`. Auf PHP <8.5 existiert die neue Klasse nicht und der alte Konstant ist dort noch nicht deprecated — beide Pfade emit-frei. `defined()` verursacht keinen Class-Lookup-Fehler bei nicht-existenter Klasse.

## Regression test

`tests/Unit/Config/DatabaseConfigTest.php`: registriert einen Error-Handler, lädt `config/database.php` neu und schlägt fehl, wenn beim Laden irgendein `E_DEPRECATED`/`E_USER_DEPRECATED` ausgelöst wird. Schützt nicht nur diesen Fall, sondern auch zukünftige Deprecations in dieser Datei.

## Bonus-Effekt im Test-Output

Vorher: `343 deprecated, 33 passed (1089 assertions)` — fast jeder Test war als „deprecated" markiert wegen der gleichen Notice.
Nachher: `377 passed (1090 assertions)` — komplett sauber.

## Test plan

- [x] `php artisan test` — 377 grün, 1090 Assertions, 0 Failures, 0 Deprecation-Markierungen
- [x] `tests/Unit/Config/DatabaseConfigTest.php` — neuer Regression-Test grün
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint:check` — pass
- [x] Playwright-Roundtrip: `/login` → Klick „Sign up" → URL wechselt zu `/register`, Title aktualisiert, 0 Console-Errors
- [x] Playwright-Roundtrip: `/` → Klick „Log in" → URL wechselt zu `/login`, 0 Console-Errors
- [x] Curl-Probe: Inertia-XHR-Response auf `/register` ist valides JSON ohne HTML-Präfix

Refs #149