### PR TITLE
feat(#55): 30s dashboard polling honoring document.visibilityState

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -16,8 +16,11 @@ import {
     type SharedData,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
+import { useDocumentVisibility, useIntervalFn } from '@vueuse/core';
 import { ChevronDown, Info } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
+
+const POLL_MS = 30_000;
 
 interface DashboardProps {
     filters: DashboardFilters;
@@ -205,6 +208,34 @@ watch(
         rawEmailOpen.value = false;
     },
 );
+
+function pollOnly(): string[] {
+    const keys = ['requests', 'stats'];
+    if (props.selectedRequest != null) {
+        keys.push('selectedRequest');
+    }
+    return keys;
+}
+
+const visibility = useDocumentVisibility();
+
+const { pause: pausePolling, resume: resumePolling } = useIntervalFn(
+    () => router.reload({ only: pollOnly(), preserveScroll: true, preserveState: true }),
+    POLL_MS,
+    { immediate: false, immediateCallback: false },
+);
+
+if (visibility.value === 'visible') {
+    resumePolling();
+}
+
+watch(visibility, (state) => {
+    if (state === 'visible') {
+        resumePolling();
+    } else {
+        pausePolling();
+    }
+});
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

- \`useIntervalFn\` from \`@vueuse/core\` drives a 30 s \`router.reload\` on the dashboard.
- \`useDocumentVisibility\` pauses the interval whenever the tab is hidden and resumes it on \`visible\`. On mount the interval starts only if the tab is currently visible (no initial poll for backgrounded tabs).
- The reload's \`only\` set is drawer-aware: \`['requests', 'stats']\` by default, plus \`'selectedRequest'\` when the detail drawer is open. Keeps the open drawer in sync with the list.

## Why

PRD-004 specifies polling as the V1.0 update mechanism (decision documented in [\`docs/decisions/polling-vs-websockets-v1.md\`](https://github.com/Psheikomaniac/reservation-agent/blob/dev/docs/decisions/polling-vs-websockets-v1.md), #60). \`@vueuse/core\` is already in the dependency tree — its primitives handle SSR safety, single-interval guarantees and component-unmount cleanup, so the application code stays in three lines of glue rather than a hand-rolled \`setInterval\` + \`addEventListener\` ceremony.

## Decisions baked in (per discussion)

- **Stop logic**: visibility-aware only. Polling does **not** stop when there are zero pending items — the whole point of polling is to discover new pending items. CLAUDE.md's "stop when no pending" wording was self-contradictory in this regard; the issue AC wins.
- **Drawer-aware**: include \`selectedRequest\` in \`only\` when the drawer is open, so its content does not go stale while the underlying reservation changes (e.g. another operator just replied).

## Acceptance criteria (Issue #55)

- [x] \`POLL_MS = 30_000\`
- [x] \`router.reload({ only: ['requests', 'stats' (+ 'selectedRequest' if drawer open)] })\` every 30 s
- [x] \`document.visibilityState\` respected — \`useDocumentVisibility\` watcher pauses on \`hidden\`, resumes on \`visible\`
- [x] Single-interval guard — \`useIntervalFn\` manages exactly one timer; \`resume()\` is idempotent
- [x] Cleanup on unmount — handled by \`useIntervalFn\`'s built-in lifecycle hook
- [ ] **Unit / e2e test** — deliberately not added in this PR; carved out into #157 (Vitest setup). The composition is small (3 useable \`@vueuse\` calls) and the underlying primitives are tested upstream; rather than add Vitest as a side effect of this PR, the infra decision lives in its own issue.

## Test plan

- [x] \`php artisan test --filter=DashboardTest\` — 19/19 green (no PHP-side regressions)
- [x] \`npm run lint\` — clean
- [x] \`npm run format:check\` — clean
- [x] \`npm run build\` — TS + Vite green
- [ ] **Browser smoke test pending**: open \`/dashboard\`, verify network panel shows a partial reload of \`requests\`/\`stats\` every 30 s; switch tab away → no requests; switch back → requests resume.

Closes #55
Refs #157