### PR TITLE
Add composite index (restaurant_id, status, created_at) (#57)

### DIFF
--- a/database/migrations/2026_04_27_172941_add_dashboard_composite_index_to_reservation_requests_table.php
+++ b/database/migrations/2026_04_27_172941_add_dashboard_composite_index_to_reservation_requests_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const string INDEX_NAME = 'reservation_requests_dashboard_index';
+
+    public function up(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table): void {
+            $table->index(['restaurant_id', 'status', 'created_at'], self::INDEX_NAME);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table): void {
+            $table->dropIndex(self::INDEX_NAME);
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- New migration `add_dashboard_composite_index_to_reservation_requests_table` adds a composite index on `(restaurant_id, status, created_at)` named `reservation_requests_dashboard_index`.
- Original `create_reservation_requests_table` migration is **not** edited – additive migration only.
- `down()` drops the index by name.

## Why
The dashboard query (`DashboardController::index`) always filters by `restaurant_id` via the `RestaurantScope` global scope, narrows on `status` (`whereIn`) and orders by `created_at desc`. Without a supporting index, SQLite/MySQL fall back to a full table scan + filesort. The column order matches the access pattern: equality on `restaurant_id`, IN on `status`, range/order on `created_at`.

## Benchmark (acceptance criterion)
Local SQLite seeded with **10,500 rows** for one restaurant:

```
SQL : select * from reservation_requests
       where restaurant_id = ?
         and status in ('new','in_review')
       order by created_at desc limit 25

PLAN: SEARCH reservation_requests USING INDEX reservation_requests_dashboard_index
        (restaurant_id=? AND status=?)
      USE TEMP B-TREE FOR ORDER BY

Time: ~0.17 ms
```

The temp B-tree for ORDER BY is a SQLite quirk with multi-value `IN` predicates – the index still removes the full scan and reduces the candidate set to a single `restaurant_id` partition before sorting.

## Test plan
- [x] `php artisan migrate` applies the new migration cleanly
- [x] `php artisan migrate:rollback --step=1` reverts it cleanly, re-running `migrate` re-applies it
- [x] `EXPLAIN QUERY PLAN` confirms the dashboard query uses `reservation_requests_dashboard_index`
- [x] `php artisan test` – 388 passed
- [x] `./vendor/bin/pint --test` – pass
- [x] `npm run lint` and `npm run format:check` – clean

Closes #57