### PR TITLE
Implement POST /reservations/bulk-status with transition guards (#56)

### DIFF
--- a/app/Http/Controllers/ReservationRequestController.php
+++ b/app/Http/Controllers/ReservationRequestController.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\ReservationStatus;
+use App\Http\Requests\BulkStatusRequest;
+use App\Models\ReservationRequest;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Gate;
 
 final class ReservationRequestController extends Controller
 {
@@ -17,5 +21,59 @@ final class ReservationRequestController extends Controller
     public function show(int $reservation): RedirectResponse
     {
         return redirect()->route('dashboard', ['selected' => $reservation]);
+    }
+
+    /**
+     * Apply a single target status to a batch of reservations. Each id is
+     * checked individually – ids that fail the per-id `update` policy or
+     * cannot legally transition to the target status are reported back as
+     * `skipped` instead of aborting the whole batch. The actual mutation is
+     * a single bulk `update()` to keep the write path O(1) regardless of
+     * batch size.
+     */
+    public function bulkStatus(BulkStatusRequest $request): RedirectResponse
+    {
+        $validated = $request->validated();
+        /** @var list<int> $requestedIds */
+        $requestedIds = array_map('intval', $validated['ids']);
+        $targetStatus = ReservationStatus::from($validated['status']);
+
+        $reservations = ReservationRequest::query()
+            ->whereIn('id', $requestedIds)
+            ->get(['id', 'restaurant_id', 'status']);
+
+        $loadedIds = $reservations->pluck('id')->all();
+        $skipped = array_values(array_diff($requestedIds, $loadedIds));
+
+        $updatableIds = [];
+        foreach ($reservations as $reservation) {
+            $allowedByPolicy = Gate::forUser($request->user())
+                ->allows('update', $reservation);
+
+            if (! $allowedByPolicy || ! $reservation->status->canTransitionTo($targetStatus)) {
+                $skipped[] = $reservation->id;
+
+                continue;
+            }
+
+            $updatableIds[] = $reservation->id;
+        }
+
+        $updated = 0;
+        if ($updatableIds !== []) {
+            $updated = ReservationRequest::query()
+                ->whereIn('id', $updatableIds)
+                ->update([
+                    'status' => $targetStatus->value,
+                    'updated_at' => now(),
+                ]);
+        }
+
+        sort($skipped);
+
+        return back()->with('bulkStatus', [
+            'updated' => $updated,
+            'skipped' => array_values($skipped),
+        ]);
     }
 }

--- a/app/Http/Requests/BulkStatusRequest.php
+++ b/app/Http/Requests/BulkStatusRequest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+
+class BulkStatusRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return Gate::allows('bulkUpdate', ReservationRequest::class);
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'ids' => ['required', 'array', 'min:1', 'max:200'],
+            'ids.*' => ['integer', 'min:1', 'distinct'],
+            'status' => ['required', 'string', Rule::enum(ReservationStatus::class)],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'ids.required' => 'Bitte mindestens eine Reservierung auswählen.',
+            'ids.array' => 'Die Auswahl muss als Liste übergeben werden.',
+            'ids.min' => 'Bitte mindestens eine Reservierung auswählen.',
+            'ids.max' => 'Es dürfen höchstens 200 Reservierungen auf einmal aktualisiert werden.',
+            'ids.*.integer' => 'Jede Reservierungs-ID muss eine ganze Zahl sein.',
+            'ids.*.min' => 'Jede Reservierungs-ID muss positiv sein.',
+            'ids.*.distinct' => 'Reservierungs-IDs dürfen sich nicht wiederholen.',
+            'status.required' => 'Bitte einen Zielstatus angeben.',
+            'status.enum' => 'Der Zielstatus ist ungültig.',
+        ];
+    }
+}

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -9,6 +9,7 @@ declare module 'ziggy-js' {
             "required": true
         }
     ],
+    "reservations.bulk-status": [],
     "public.reservations.create": [
         {
             "name": "restaurant",

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,6 +19,10 @@ Route::get('reservations/{reservation}', [ReservationRequestController::class, '
     ->middleware(['auth', 'verified'])
     ->name('reservations.show');
 
+Route::post('reservations/bulk-status', [ReservationRequestController::class, 'bulkStatus'])
+    ->middleware(['auth', 'verified'])
+    ->name('reservations.bulk-status');
+
 Route::get('r/{restaurant:slug}/reservations', [PublicReservationController::class, 'create'])
     ->name('public.reservations.create');
 

--- a/tests/Feature/BulkStatusEndpointTest.php
+++ b/tests/Feature/BulkStatusEndpointTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class BulkStatusEndpointTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_unauthenticated_user_is_redirected_to_login(): void
+    {
+        $response = $this->post(route('reservations.bulk-status'), [
+            'ids' => [1],
+            'status' => ReservationStatus::Declined->value,
+        ]);
+
+        $response->assertRedirect(route('login'));
+    }
+
+    public function test_user_without_restaurant_is_forbidden(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [1],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $response->assertForbidden();
+    }
+
+    public function test_validation_requires_at_least_one_id(): void
+    {
+        $user = $this->memberWithRestaurant();
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHasErrors('ids');
+    }
+
+    public function test_validation_rejects_unknown_status_value(): void
+    {
+        $user = $this->memberWithRestaurant();
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [1],
+                'status' => 'not-a-status',
+            ]
+        );
+
+        $response->assertSessionHasErrors('status');
+    }
+
+    public function test_validation_rejects_non_integer_ids(): void
+    {
+        $user = $this->memberWithRestaurant();
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => ['abc'],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $response->assertSessionHasErrors('ids.0');
+    }
+
+    public function test_happy_path_bulk_transitions_allowed_ids(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $first = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['status' => ReservationStatus::New]);
+        $second = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['status' => ReservationStatus::New]);
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [$first->id, $second->id],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $response->assertRedirect(route('dashboard'));
+        $response->assertSessionHas('bulkStatus', [
+            'updated' => 2,
+            'skipped' => [],
+        ]);
+
+        $this->assertSame(
+            ReservationStatus::Declined,
+            $first->fresh()->status,
+        );
+        $this->assertSame(
+            ReservationStatus::Declined,
+            $second->fresh()->status,
+        );
+    }
+
+    public function test_skips_ids_whose_status_cannot_transition_to_target(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        // Confirmed -> Declined is not allowed by the state machine.
+        $confirmed = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['status' => ReservationStatus::Confirmed]);
+        $newOne = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['status' => ReservationStatus::New]);
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [$confirmed->id, $newOne->id],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $response->assertSessionHas('bulkStatus', [
+            'updated' => 1,
+            'skipped' => [$confirmed->id],
+        ]);
+
+        $this->assertSame(
+            ReservationStatus::Confirmed,
+            $confirmed->fresh()->status,
+            'Confirmed reservation must not have been touched.'
+        );
+        $this->assertSame(
+            ReservationStatus::Declined,
+            $newOne->fresh()->status,
+        );
+    }
+
+    public function test_skips_ids_belonging_to_another_restaurant(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $user = User::factory()->forRestaurant($home)->create();
+
+        $own = ReservationRequest::factory()
+            ->forRestaurant($home)
+            ->create(['status' => ReservationStatus::New]);
+        $foreignReservation = ReservationRequest::factory()
+            ->forRestaurant($foreign)
+            ->create(['status' => ReservationStatus::New]);
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [$own->id, $foreignReservation->id],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $response->assertSessionHas('bulkStatus', [
+            'updated' => 1,
+            'skipped' => [$foreignReservation->id],
+        ]);
+
+        $this->assertSame(
+            ReservationStatus::New,
+            $foreignReservation->fresh()->status,
+            'Foreign reservation must not have been mutated.'
+        );
+        $this->assertSame(
+            ReservationStatus::Declined,
+            $own->fresh()->status,
+        );
+    }
+
+    public function test_skips_ids_that_do_not_exist(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $existing = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['status' => ReservationStatus::New]);
+        $missingId = $existing->id + 999;
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [$existing->id, $missingId],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $response->assertSessionHas('bulkStatus', [
+            'updated' => 1,
+            'skipped' => [$missingId],
+        ]);
+    }
+
+    public function test_uses_bounded_query_count_no_n_plus_one(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $reservations = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->count(20)
+            ->create(['status' => ReservationStatus::New]);
+
+        $this->actingAs($user);
+
+        DB::enableQueryLog();
+        DB::flushQueryLog();
+
+        $response = $this->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => $reservations->pluck('id')->all(),
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $queries = collect(DB::getQueryLog())
+            ->pluck('query')
+            ->filter(fn (string $sql): bool => str_contains($sql, 'reservation_requests'))
+            ->all();
+
+        DB::disableQueryLog();
+
+        $response->assertSessionHas('bulkStatus', [
+            'updated' => 20,
+            'skipped' => [],
+        ]);
+
+        $selects = array_filter(
+            $queries,
+            fn (string $sql): bool => str_starts_with(strtolower(trim($sql)), 'select')
+        );
+        $updates = array_filter(
+            $queries,
+            fn (string $sql): bool => str_starts_with(strtolower(trim($sql)), 'update')
+        );
+
+        $this->assertCount(
+            1,
+            $selects,
+            'Expected exactly one SELECT against reservation_requests, got: '
+                .json_encode(array_values($selects))
+        );
+        $this->assertCount(
+            1,
+            $updates,
+            'Expected exactly one UPDATE against reservation_requests, got: '
+                .json_encode(array_values($updates))
+        );
+    }
+
+    public function test_skipped_list_is_sorted_and_deduplicated(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $confirmed = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['status' => ReservationStatus::Confirmed]);
+
+        $missing = $confirmed->id + 5_000;
+
+        $response = $this->actingAs($user)->from(route('dashboard'))->post(
+            route('reservations.bulk-status'),
+            [
+                'ids' => [$missing, $confirmed->id],
+                'status' => ReservationStatus::Declined->value,
+            ]
+        );
+
+        $skipped = session('bulkStatus.skipped');
+        $this->assertSame([$confirmed->id, $missing], $skipped);
+        $this->assertSame($skipped, array_values(array_unique($skipped)));
+        $this->assertSame($skipped, [...$skipped]);
+        $this->assertSame($skipped, collect($skipped)->sort()->values()->all());
+        $response->assertRedirect(route('dashboard'));
+    }
+
+    private function memberWithRestaurant(): User
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        return User::factory()->forRestaurant($restaurant)->create();
+    }
+}


### PR DESCRIPTION
## Summary
- New endpoint `POST /reservations/bulk-status` (named route `reservations.bulk-status`) applies a single target status to a batch of reservation requests, behind `auth` + `verified` middleware
- `BulkStatusRequest` (FormRequest): validates `{ ids: int[], status: string }` and gates on the existing `ReservationRequestPolicy@bulkUpdate` (user must have a restaurant)
- `ReservationRequestController::bulkStatus`: per-id `update` policy check + `ReservationStatus::canTransitionTo()` state-machine guard, single bulk `update()` write, Inertia `back()->with('bulkStatus', [...])` flash with `{ updated: int, skipped: int[] }`
- 11 new feature tests covering auth, validation, transition guard, tenant isolation, non-existent ids, N+1 budget, and skipped-list shape

## Why
PRD-004 requires a multi-select bulk action on the dashboard so a restaurant owner can e.g. mark a stack of stale `new` requests as `declined` in one go. The endpoint had to satisfy three properties at once:
1. **Robust** – one bad id (foreign tenant, missing, illegal transition) must not abort the whole batch
2. **Safe** – no leak of foreign-tenant data, no silent overrides of the state machine
3. **Cheap** – a single `whereIn` load and a single bulk `update()` regardless of batch size, since this contract is the template the approval endpoint in PRD-005 will mirror

## Design notes
- "Skipped" is a single bucket: any id that cannot legally be updated (foreign tenant, missing, illegal transition) ends up in `skipped`. From the caller's perspective these are equivalent and the response shape stays simple. No information leak about foreign-tenant ids.
- The N+1 guarantee is enforced by an actual query-log assertion in the test (one SELECT + one UPDATE), not by a comment. A future observer or accidental relation load would break the test immediately.
- `BulkStatusRequest::authorize()` gates on `bulkUpdate` (broad guard); per-id `update` policy is a defense-in-depth check on top of the global `RestaurantScope`.

## Test plan
- [x] `php artisan test` – 399 passed (388 + 11 new)
- [x] `./vendor/bin/pint --test` – pass
- [x] `npm run lint` – pass
- [x] `npm run format:check` – pass
- [x] `php artisan ziggy:generate` ran (Ziggy file is gitignored, CI drift check covers it)

Closes #56