### PR TITLE
Add dashboard performance benchmark (#61)

### DIFF
--- a/app/Console/Commands/BenchmarkDashboardCommand.php
+++ b/app/Console/Commands/BenchmarkDashboardCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class BenchmarkDashboardCommand extends Command
+{
+    protected $signature = 'dashboard:benchmark
+        {--restaurant= : Restaurant id to benchmark against (defaults to first benchmark-restaurant-* slug, then the first restaurant in the table)}
+        {--iterations=20 : Number of timed query runs}
+        {--warmup=2 : Untimed runs to prime the SQLite page cache}';
+
+    protected $description = 'Time the default dashboard query and dump EXPLAIN QUERY PLAN to validate index usage.';
+
+    public function handle(): int
+    {
+        $restaurant = $this->resolveRestaurant();
+
+        if ($restaurant === null) {
+            $this->error('No restaurant available. Run `php artisan db:seed --class=PerformanceBenchmarkSeeder` first.');
+
+            return self::FAILURE;
+        }
+
+        $rowCount = DB::table('reservation_requests')->count();
+        $tenantRowCount = DB::table('reservation_requests')
+            ->where('restaurant_id', $restaurant->id)
+            ->count();
+
+        $this->line(sprintf(
+            'Driver: %s | total rows: %d | tenant rows: %d | restaurant: #%d %s',
+            DB::connection()->getDriverName(),
+            $rowCount,
+            $tenantRowCount,
+            $restaurant->id,
+            $restaurant->name,
+        ));
+
+        $iterations = max(1, (int) $this->option('iterations'));
+        $warmup = max(0, (int) $this->option('warmup'));
+
+        for ($i = 0; $i < $warmup; $i++) {
+            $this->buildQuery($restaurant->id)->paginate(25);
+        }
+
+        $samples = [];
+
+        for ($i = 0; $i < $iterations; $i++) {
+            $start = hrtime(true);
+            $this->buildQuery($restaurant->id)
+                ->with(['latestReply'])
+                ->paginate(25);
+            $samples[] = (hrtime(true) - $start) / 1_000_000;
+        }
+
+        $this->printStats($samples);
+        $this->printExplain($restaurant->id);
+
+        return self::SUCCESS;
+    }
+
+    private function resolveRestaurant(): ?Restaurant
+    {
+        $explicit = $this->option('restaurant');
+
+        if ($explicit !== null) {
+            return Restaurant::query()->find((int) $explicit);
+        }
+
+        return Restaurant::query()
+            ->where('slug', 'like', 'benchmark-restaurant-%')
+            ->orderBy('id')
+            ->first()
+            ?? Restaurant::query()->orderBy('id')->first();
+    }
+
+    /**
+     * Mirrors `DashboardController::index` for the default filter set:
+     * status ∈ {new, in_review} AND desired_at >= today, ordered by
+     * created_at DESC. Restaurant scope is applied manually because the
+     * command runs without an authenticated user.
+     *
+     * @return Builder<ReservationRequest>
+     */
+    private function buildQuery(int $restaurantId): Builder
+    {
+        return ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->where('restaurant_id', $restaurantId)
+            ->whereIn('status', [ReservationStatus::New, ReservationStatus::InReview])
+            ->where('desired_at', '>=', Carbon::now()->startOfDay())
+            ->orderByDesc('created_at');
+    }
+
+    /**
+     * @param  list<float>  $samples  Milliseconds.
+     */
+    private function printStats(array $samples): void
+    {
+        sort($samples);
+        $count = count($samples);
+        $sum = array_sum($samples);
+
+        $this->newLine();
+        $this->info(sprintf('Iterations: %d', $count));
+        $this->line(sprintf('  min : %6.2f ms', $samples[0]));
+        $this->line(sprintf('  avg : %6.2f ms', $sum / $count));
+        $this->line(sprintf('  p50 : %6.2f ms', $samples[(int) floor($count * 0.50)] ?? $samples[$count - 1]));
+        $this->line(sprintf('  p95 : %6.2f ms', $samples[(int) floor($count * 0.95)] ?? $samples[$count - 1]));
+        $this->line(sprintf('  max : %6.2f ms', $samples[$count - 1]));
+    }
+
+    private function printExplain(int $restaurantId): void
+    {
+        $query = $this->buildQuery($restaurantId);
+        $sql = $query->toSql();
+        $bindings = $query->getBindings();
+
+        $driver = DB::connection()->getDriverName();
+        $explain = match ($driver) {
+            'sqlite' => 'EXPLAIN QUERY PLAN '.$sql,
+            'mysql', 'mariadb' => 'EXPLAIN '.$sql,
+            'pgsql' => 'EXPLAIN '.$sql,
+            default => null,
+        };
+
+        $this->newLine();
+        $this->info('EXPLAIN');
+
+        if ($explain === null) {
+            $this->warn(sprintf('No EXPLAIN strategy registered for driver "%s".', $driver));
+
+            return;
+        }
+
+        foreach (DB::select($explain, $bindings) as $row) {
+            $this->line('  '.json_encode($row, JSON_UNESCAPED_SLASHES));
+        }
+    }
+}

--- a/database/seeders/PerformanceBenchmarkSeeder.php
+++ b/database/seeders/PerformanceBenchmarkSeeder.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\Restaurant;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class PerformanceBenchmarkSeeder extends Seeder
+{
+    /**
+     * Restaurants over which the requests are distributed. Five tenants give
+     * enough cardinality to verify the composite (restaurant_id, status,
+     * created_at) index is useful while staying realistic for V1.0 (1–5
+     * locations per pilot).
+     */
+    public const int RESTAURANT_COUNT = 5;
+
+    /**
+     * Total number of reservation_requests rows the seeder produces. Matches
+     * the >10k target from issue #61.
+     */
+    public const int RESERVATION_COUNT = 10_000;
+
+    private const int CHUNK_SIZE = 500;
+
+    /**
+     * Override the row count for a single run — used by tests that exercise
+     * the seeder logic without paying the memory cost of inserting 10k rows.
+     */
+    public ?int $count = null;
+
+    /**
+     * Status mix roughly mirroring a mature dashboard: most rows are settled
+     * (replied / confirmed / declined), with a steady backlog of new and
+     * in_review. Numbers are weights, not percentages.
+     *
+     * @var array<string, int>
+     */
+    private const array STATUS_MIX = [
+        ReservationStatus::New->value => 25,
+        ReservationStatus::InReview->value => 15,
+        ReservationStatus::Replied->value => 25,
+        ReservationStatus::Confirmed->value => 25,
+        ReservationStatus::Declined->value => 10,
+    ];
+
+    public function run(): void
+    {
+        $restaurantIds = $this->ensureRestaurants();
+        $statusBag = $this->expandStatusMix();
+
+        $batch = [];
+        $now = Carbon::now();
+        $target = $this->count ?? self::RESERVATION_COUNT;
+
+        for ($i = 0; $i < $target; $i++) {
+            $createdAt = $now->copy()->subMinutes(random_int(0, 90 * 24 * 60));
+            $desiredAt = $createdAt->copy()->addDays(random_int(0, 30))->setTime(
+                random_int(11, 22),
+                random_int(0, 1) === 0 ? 0 : 30,
+            );
+
+            $batch[] = [
+                'restaurant_id' => $restaurantIds[$i % count($restaurantIds)],
+                'source' => $i % 3 === 0 ? ReservationSource::Email->value : ReservationSource::WebForm->value,
+                'status' => $statusBag[$i % count($statusBag)],
+                'guest_name' => 'Benchmark Guest '.$i,
+                'guest_email' => 'guest'.$i.'@benchmark.test',
+                'guest_phone' => null,
+                'party_size' => random_int(1, 8),
+                'desired_at' => $desiredAt->toDateTimeString(),
+                'message' => null,
+                'raw_payload' => null,
+                'needs_manual_review' => $i % 50 === 0,
+                'email_message_id' => null,
+                'created_at' => $createdAt->toDateTimeString(),
+                'updated_at' => $createdAt->toDateTimeString(),
+            ];
+
+            if (count($batch) >= self::CHUNK_SIZE) {
+                DB::table('reservation_requests')->insert($batch);
+                $batch = [];
+            }
+        }
+
+        if ($batch !== []) {
+            DB::table('reservation_requests')->insert($batch);
+        }
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function ensureRestaurants(): array
+    {
+        $existing = Restaurant::query()
+            ->where('slug', 'like', 'benchmark-restaurant-%')
+            ->orderBy('id')
+            ->pluck('id')
+            ->all();
+
+        $needed = self::RESTAURANT_COUNT - count($existing);
+
+        if ($needed <= 0) {
+            return array_slice($existing, 0, self::RESTAURANT_COUNT);
+        }
+
+        $created = Restaurant::factory()
+            ->count($needed)
+            ->sequence(fn ($sequence) => [
+                'slug' => 'benchmark-restaurant-'.($sequence->index + count($existing) + 1).'-'.Str::lower(Str::random(4)),
+            ])
+            ->create()
+            ->pluck('id')
+            ->all();
+
+        return [...$existing, ...$created];
+    }
+
+    /**
+     * Expand the weighted status mix into a flat array used for round-robin
+     * assignment. Cheaper than calling `random_int` per row and produces a
+     * stable distribution across runs.
+     *
+     * @return list<string>
+     */
+    private function expandStatusMix(): array
+    {
+        $bag = [];
+
+        foreach (self::STATUS_MIX as $status => $weight) {
+            for ($i = 0; $i < $weight; $i++) {
+                $bag[] = $status;
+            }
+        }
+
+        shuffle($bag);
+
+        return $bag;
+    }
+}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,113 @@
+# Performance — Dashboard at >10k Reservierungen
+
+Validierung der Annahme aus PRD-004, dass das Dashboard mit 10.000+ `reservation_requests`
+über mehrere Tenants flüssig bleibt, sobald Pagination und der Composite-Index
+`(restaurant_id, status, created_at)` greifen (siehe Migration
+`2026_04_27_172941_add_dashboard_composite_index_to_reservation_requests_table.php`,
+PR #159).
+
+## Geltungsbereich
+
+> **Disclaimer.** Alle Messungen unten wurden gegen **lokales SQLite** auf einem Mac
+> (Apple Silicon, NVMe-SSD) ausgeführt. SQLite ist die V1.0-Default-DB für lokale
+> Entwicklung; die Produktions-DB-Wahl (MySQL vs. Postgres) ist laut PRD-001 noch
+> offen. Sobald die Prod-DB festliegt, müssen diese Zahlen gegen die Prod-Engine
+> (idealerweise mit Prod-ähnlicher Datenmenge und realistischer Latenz) reproduziert
+> werden. Bis dahin sind die Werte ein qualitativer Sanity-Check, kein Performance-SLA.
+
+## Setup reproduzieren
+
+```bash
+# Optional: vorher lokale DB sichern, der Seeder fügt 10k Rows hinzu
+cp database/database.sqlite /tmp/db.sqlite.backup
+
+php artisan migrate --force
+php artisan db:seed --class=Database\\Seeders\\PerformanceBenchmarkSeeder --force
+php artisan dashboard:benchmark --iterations=50 --warmup=5
+
+# Aufräumen
+mv /tmp/db.sqlite.backup database/database.sqlite
+```
+
+Der Seeder erzeugt:
+
+- **5 Restaurants** (`benchmark-restaurant-1` … `-5`) — die V1.0-Pilot-Größenordnung.
+- **10.000 `reservation_requests`** über alle 5 Restaurants (round-robin → ~2.000 pro Tenant).
+- Status-Mix gewichtet: ~25 % `new`, ~15 % `in_review`, ~25 % `replied`, ~25 % `confirmed`, ~10 % `declined`.
+- `created_at` zufällig in den letzten 90 Tagen, `desired_at` 0–30 Tage nach `created_at`.
+
+Der Seeder ist idempotent für Restaurants (re-run legt keine neuen Tenants an), fügt
+beim erneuten Lauf aber jedes Mal weitere 10.000 Rows hinzu — bewusst, damit man die
+Last hochfahren kann.
+
+## Methodik
+
+`php artisan dashboard:benchmark` baut exakt die Default-Query von
+`DashboardController::index` nach (Status ∈ {`new`, `in_review`}, `desired_at >= heute`,
+sortiert nach `created_at DESC`, paginiert auf 25), führt sie nach `--warmup` ungetimten
+Aufrufen `--iterations`-mal mit `hrtime(true)` aus und gibt min / avg / p50 / p95 / max
+in Millisekunden aus. Anschließend dumpt der Command `EXPLAIN QUERY PLAN` (SQLite) bzw.
+`EXPLAIN` (MySQL/Postgres), damit der Index-Plan einsehbar ist.
+
+Die zwei `count()`-Queries für die `stats`-Card laufen separat und werden über
+`php artisan tinker` mit dem gleichen `hrtime`-Schema gemessen.
+
+## Messergebnisse
+
+**Setup**: SQLite, 10.003 Rows insgesamt, 2.000 davon im gemessenen Tenant
+(`benchmark-restaurant-1`), 50 Iterationen, 5 Warmup-Runs.
+
+### Default Dashboard-Query (paginate(25))
+
+| Metrik | Wert |
+|--------|------|
+| min    | 1,34 ms |
+| avg    | 1,50 ms |
+| p50    | 1,37 ms |
+| **p95** | **1,76 ms** |
+| max    | 6,39 ms |
+
+### Stats-Counts (2× `count()` für `new` + `in_review`)
+
+| Metrik | Wert |
+|--------|------|
+| p50    | 0,19 ms |
+| p95    | 0,29 ms |
+| max    | 0,36 ms |
+
+p95-Gesamt-Server-Anteil der Default-Query + Stats: **~2 ms**. Der Inertia-Render-Anteil
+(JSON-Serialisierung der 25 Resources, Eager-Load `latestReply`, Middleware) liegt drüber,
+ist aber nicht Teil dieser Messung.
+
+## Index-Nutzung (EXPLAIN QUERY PLAN)
+
+Listing-Query:
+
+```
+SEARCH reservation_requests USING INDEX reservation_requests_dashboard_index (restaurant_id=? AND status=?)
+USE TEMP B-TREE FOR ORDER BY
+```
+
+Stats-Count-Query:
+
+```
+SEARCH reservation_requests USING INDEX reservation_requests_dashboard_index (restaurant_id=? AND status=?)
+```
+
+**Auswertung:**
+
+- ✅ Der Composite-Index `reservation_requests_dashboard_index (restaurant_id, status, created_at)` wird sowohl für die Listing- als auch für beide Stats-Queries genutzt.
+- ⚠️ Die Listing-Query baut für die Sortierung eine **temporäre B-Tree-Sortierung** auf, statt direkt aus der Index-Reihenfolge zu lesen. Grund: `whereIn('status', ['new', 'in_review'])` erzeugt zwei Index-Ranges; SQLite kann die Index-`created_at`-Sortierung nicht unverändert über zwei Ranges hinweg verwenden. Bei 2.000 Tenant-Rows und Pagination auf 25 ist die Sort-B-Tree-Phase trivial — das ist erst dann ein Thema, wenn ein einzelner Tenant Größenordnungen mehr aktive Anfragen hat als hier modelliert. Bis dahin: kein Handlungsbedarf.
+
+## Was diese Messung *nicht* abdeckt
+
+- **HTTP-Round-Trip**: Inertia-Render, Vite-Middleware, CSRF, Session-Handling laufen drüber.
+- **Concurrency**: alles single-threaded. Bei Polling-Bursts (alle 30 s, mehrere Owner gleichzeitig) müssten WAL-Mode (SQLite) bzw. Connection-Pools (Postgres/MySQL) separat betrachtet werden.
+- **Filter-Kombinationen**: gemessen wurde der Default-Filter. Volltextsuche (`q` in `guest_name`/`guest_email`) ist `LIKE %…%` und nutzt den Index *nicht* — bewusste V1.0-Akzeptanz, siehe PRD-004.
+- **Latenz-Realität**: lokales SQLite hat keinen Netzwerk-Hop. Prod gegen Managed Postgres/MySQL fügt typischerweise 1–3 ms pro Query hinzu.
+
+## Folge-Issues, falls Prod-Zahlen abweichen
+
+- Re-Benchmark gegen die finale Prod-DB nach Entscheidung in PRD-001
+- Falls die Sort-B-Tree-Phase aufgrund vieler aktiver Reservierungen pro Tenant relevant wird: Index-Variante ohne `whereIn`-Spalten oder ein Covering-Index für `created_at` evaluieren
+- Volltextsuche (`q`) in Prod gegen einen FULLTEXT-Index oder `pg_trgm` migrieren, falls die Liste lang wird

--- a/tests/Feature/BenchmarkDashboardCommandTest.php
+++ b/tests/Feature/BenchmarkDashboardCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class BenchmarkDashboardCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_runs_against_seeded_restaurant_and_emits_explain_output(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->count(5)
+            ->state(['status' => ReservationStatus::New, 'desired_at' => now()->addDay()])
+            ->create();
+
+        $this->artisan('dashboard:benchmark', [
+            '--restaurant' => $restaurant->id,
+            '--iterations' => 3,
+            '--warmup' => 0,
+        ])
+            ->expectsOutputToContain('Iterations: 3')
+            ->expectsOutputToContain('p95')
+            ->expectsOutputToContain('EXPLAIN')
+            ->assertSuccessful();
+    }
+
+    public function test_command_fails_gracefully_without_data(): void
+    {
+        $this->artisan('dashboard:benchmark')
+            ->expectsOutputToContain('No restaurant available')
+            ->assertFailed();
+    }
+}

--- a/tests/Feature/PerformanceBenchmarkSeederTest.php
+++ b/tests/Feature/PerformanceBenchmarkSeederTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Models\Restaurant;
+use Database\Seeders\PerformanceBenchmarkSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class PerformanceBenchmarkSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_default_target_count_matches_issue_61_acceptance_criterion(): void
+    {
+        $this->assertSame(10_000, PerformanceBenchmarkSeeder::RESERVATION_COUNT);
+        $this->assertSame(5, PerformanceBenchmarkSeeder::RESTAURANT_COUNT);
+    }
+
+    public function test_seeder_creates_expected_restaurants_and_reservations(): void
+    {
+        $this->runWithCount(120);
+
+        $this->assertSame(
+            PerformanceBenchmarkSeeder::RESTAURANT_COUNT,
+            Restaurant::query()->where('slug', 'like', 'benchmark-restaurant-%')->count(),
+        );
+
+        $this->assertSame(120, DB::table('reservation_requests')->count());
+    }
+
+    public function test_seeder_distributes_reservations_across_all_benchmark_restaurants(): void
+    {
+        $this->runWithCount(120);
+
+        $perRestaurant = DB::table('reservation_requests')
+            ->selectRaw('restaurant_id, COUNT(*) as c')
+            ->groupBy('restaurant_id')
+            ->pluck('c', 'restaurant_id');
+
+        $this->assertCount(PerformanceBenchmarkSeeder::RESTAURANT_COUNT, $perRestaurant);
+
+        foreach ($perRestaurant as $count) {
+            $this->assertGreaterThan(0, $count);
+        }
+    }
+
+    public function test_seeder_is_idempotent_for_restaurant_creation(): void
+    {
+        $this->runWithCount(60);
+        $this->runWithCount(60);
+
+        $this->assertSame(
+            PerformanceBenchmarkSeeder::RESTAURANT_COUNT,
+            Restaurant::query()->where('slug', 'like', 'benchmark-restaurant-%')->count(),
+        );
+
+        $this->assertSame(120, DB::table('reservation_requests')->count());
+    }
+
+    private function runWithCount(int $count): void
+    {
+        $seeder = new PerformanceBenchmarkSeeder;
+        $seeder->count = $count;
+        $seeder->run();
+    }
+}


### PR DESCRIPTION
## Summary

- New `PerformanceBenchmarkSeeder` bulk-inserts 10k `reservation_requests` across 5 benchmark restaurants
- New `php artisan dashboard:benchmark` command times the default dashboard query (`min/avg/p50/p95/max`) and dumps `EXPLAIN QUERY PLAN`
- `docs/performance.md` documents methodology, measured numbers, EXPLAIN output, and an explicit SQLite/local-only disclaimer
- Tests for both seeder (idempotency, distribution) and command (happy path + missing-data fallback)

Acceptance criteria from the issue:

- [x] Seed 10k reservations across several restaurants → `PerformanceBenchmarkSeeder` (5 restaurants × 2k rows each)
- [x] Measure p95 response time of default dashboard load → `dashboard:benchmark` command, **p95 = 1.76 ms** on local SQLite (50 iterations, 5 warmup, 10003 rows)
- [x] Confirm index `(restaurant_id, status, created_at)` is used → EXPLAIN output: `SEARCH ... USING INDEX reservation_requests_dashboard_index (restaurant_id=? AND status=?)`
- [x] Document numbers in `docs/performance.md`

## Why

PRD-004 lists "Dashboard with >10k reservations" as an open risk. PR #159 added the composite index without a benchmark to back it up — this PR closes the loop and makes the assumption auditable. The benchmark also surfaced one finding worth knowing: the `whereIn('status', [...])` filter forces a `USE TEMP B-TREE FOR ORDER BY` step. Trivial at current scale, called out in the docs as a future watch-item.

The benchmark runs against local SQLite, which is the V1.0 dev-default but **not** the production DB (PRD-001 hasn't decided yet). The doc has an explicit disclaimer and a follow-up note to re-benchmark once the prod DB is chosen — Option 1 of the three approaches we discussed.

Closes #61

## Test plan

- [x] `php artisan test` — 405 passed
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Manual: `db:seed --class=PerformanceBenchmarkSeeder` + `dashboard:benchmark --iterations=50 --warmup=5` produces the numbers documented in `docs/performance.md`