### PR TITLE
Add bulk-select checkboxes to dashboard (#147)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,14 +31,18 @@
             },
             "devDependencies": {
                 "@eslint/js": "^9.19.0",
+                "@vitest/coverage-v8": "^4.1.5",
                 "@vue/eslint-config-typescript": "^14.3.0",
+                "@vue/test-utils": "^2.4.9",
                 "eslint": "^9.17.0",
                 "eslint-config-prettier": "^10.0.1",
                 "eslint-plugin-vue": "^9.32.0",
+                "happy-dom": "^20.9.0",
                 "prettier": "^3.4.2",
                 "prettier-plugin-organize-imports": "^4.1.0",
                 "prettier-plugin-tailwindcss": "^0.6.9",
-                "typescript-eslint": "^8.23.0"
+                "typescript-eslint": "^8.23.0",
+                "vitest": "^4.1.5"
             },
             "optionalDependencies": {
                 "@rollup/rollup-linux-x64-gnu": "4.9.5",
@@ -59,30 +63,30 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.26.9",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-            "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+            "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.26.9"
+                "@babel/types": "^7.29.0"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -92,16 +96,26 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.26.9",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-            "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5"
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@bcoe/v8-coverage": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+            "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@esbuild/aix-ppc64": {
@@ -903,15 +917,15 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.25",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+            "version": "0.3.31",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -952,6 +966,13 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/@one-ini/wasm": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@pkgjs/parseargs": {
             "version": "0.11.0",
@@ -1210,6 +1231,13 @@
                 "win32"
             ]
         },
+        "node_modules/@standard-schema/spec": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+            "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@swc/helpers": {
             "version": "0.5.15",
             "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1273,6 +1301,24 @@
                 "vue": "^2.7.0 || ^3.0.0"
             }
         },
+        "node_modules/@types/chai": {
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+            "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/deep-eql": "*",
+                "assertion-error": "^2.0.1"
+            }
+        },
+        "node_modules/@types/deep-eql": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+            "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1312,6 +1358,23 @@
             "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz",
             "integrity": "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow==",
             "license": "MIT"
+        },
+        "node_modules/@types/whatwg-mimetype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+            "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/ws": {
+            "version": "8.18.1",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+            "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            }
         },
         "node_modules/@types/ziggy-js": {
             "version": "1.3.3",
@@ -1528,6 +1591,160 @@
                 "vue": "^3.2.25"
             }
         },
+        "node_modules/@vitest/coverage-v8": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.5.tgz",
+            "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@bcoe/v8-coverage": "^1.0.2",
+                "@vitest/utils": "4.1.5",
+                "ast-v8-to-istanbul": "^1.0.0",
+                "istanbul-lib-coverage": "^3.2.2",
+                "istanbul-lib-report": "^3.0.1",
+                "istanbul-reports": "^3.2.0",
+                "magicast": "^0.5.2",
+                "obug": "^2.1.1",
+                "std-env": "^4.0.0-rc.1",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@vitest/browser": "4.1.5",
+                "vitest": "4.1.5"
+            },
+            "peerDependenciesMeta": {
+                "@vitest/browser": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/expect": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+            "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@standard-schema/spec": "^1.1.0",
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "chai": "^6.2.2",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/mocker": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+            "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "4.1.5",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.21"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@vitest/mocker/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+            "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+            "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "4.1.5",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+            "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "magic-string": "^0.30.21",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+            "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+            "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "4.1.5",
+                "convert-source-map": "^2.0.0",
+                "tinyrainbow": "^3.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@volar/language-core": {
             "version": "2.4.11",
             "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.11.tgz",
@@ -1714,6 +1931,27 @@
             "integrity": "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==",
             "license": "MIT"
         },
+        "node_modules/@vue/test-utils": {
+            "version": "2.4.9",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.9.tgz",
+            "integrity": "sha512-YwgowiO1mPleZqpgAGfxvWu/A5A8nkLrbyH2SqiQRkyzCIaDzzo27/2uS/F1g7fRLvl8BUY0+Sr1eC+6+IHfrw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-beautify": "^1.14.9",
+                "vue-component-type-helpers": "^3.0.0"
+            },
+            "peerDependencies": {
+                "@vue/compiler-dom": "3.x",
+                "@vue/server-renderer": "3.x",
+                "vue": "3.x"
+            },
+            "peerDependenciesMeta": {
+                "@vue/server-renderer": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@vueuse/core": {
             "version": "12.7.0",
             "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.7.0.tgz",
@@ -1748,6 +1986,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/abbrev": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
             }
         },
         "node_modules/acorn": {
@@ -1865,6 +2113,38 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+            "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/trace-mapping": "^0.3.31",
+                "estree-walker": "^3.0.3",
+                "js-tokens": "^10.0.0"
+            }
+        },
+        "node_modules/ast-v8-to-istanbul/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
             }
         },
         "node_modules/asynckit": {
@@ -2066,6 +2346,16 @@
                 }
             ],
             "license": "CC-BY-4.0"
+        },
+        "node_modules/chai": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+            "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/chalk": {
             "version": "4.1.2",
@@ -2295,6 +2585,24 @@
                 "url": "https://github.com/open-cli-tools/concurrently?sponsor=1"
             }
         },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "node_modules/convert-source-map": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+            "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2414,6 +2722,35 @@
             "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
             "license": "MIT"
         },
+        "node_modules/editorconfig": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+            "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@one-ini/wasm": "0.1.1",
+                "commander": "^10.0.0",
+                "minimatch": "^9.0.1",
+                "semver": "^7.5.3"
+            },
+            "bin": {
+                "editorconfig": "bin/editorconfig"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
         "node_modules/electron-to-chromium": {
             "version": "1.5.103",
             "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.103.tgz",
@@ -2455,6 +2792,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/es-module-lexer": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+            "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
@@ -2807,6 +3151,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3124,6 +3478,37 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/happy-dom": {
+            "version": "20.9.0",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+            "integrity": "sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "@types/whatwg-mimetype": "^3.0.2",
+                "@types/ws": "^8.18.1",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.18.3"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/happy-dom/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3181,6 +3566,13 @@
                 "he": "bin/he"
             }
         },
+        "node_modules/html-escaper": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+            "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/ignore": {
             "version": "5.3.2",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3217,6 +3609,13 @@
             "engines": {
                 "node": ">=0.8.19"
             }
+        },
+        "node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/is-binary-path": {
             "version": "2.1.0",
@@ -3290,6 +3689,58 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
+        "node_modules/istanbul-lib-coverage": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-lib-report": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+            "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "istanbul-lib-coverage": "^3.0.0",
+                "make-dir": "^4.0.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/istanbul-lib-report/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/istanbul-reports": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+            "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "html-escaper": "^2.0.0",
+                "istanbul-lib-report": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/jackspeak": {
             "version": "3.4.3",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
@@ -3313,6 +3764,45 @@
             "bin": {
                 "jiti": "bin/jiti.js"
             }
+        },
+        "node_modules/js-beautify": {
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "config-chain": "^1.1.13",
+                "editorconfig": "^1.0.4",
+                "glob": "^10.4.2",
+                "js-cookie": "^3.0.5",
+                "nopt": "^7.2.1"
+            },
+            "bin": {
+                "css-beautify": "js/bin/css-beautify.js",
+                "html-beautify": "js/bin/html-beautify.js",
+                "js-beautify": "js/bin/js-beautify.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
+            "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/js-tokens": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+            "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
@@ -3493,12 +3983,40 @@
             }
         },
         "node_modules/magic-string": {
-            "version": "0.30.17",
-            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
-            "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+            "version": "0.30.21",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+            "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
             "license": "MIT",
             "dependencies": {
-                "@jridgewell/sourcemap-codec": "^1.5.0"
+                "@jridgewell/sourcemap-codec": "^1.5.5"
+            }
+        },
+        "node_modules/magicast": {
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+            "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "source-map-js": "^1.2.1"
+            }
+        },
+        "node_modules/make-dir": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+            "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.5.3"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/math-intrinsics": {
@@ -3641,6 +4159,22 @@
             "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
             "license": "MIT"
         },
+        "node_modules/nopt": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^2.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -3701,6 +4235,17 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/obug": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+            "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+            "dev": true,
+            "funding": [
+                "https://github.com/sponsors/sxzz",
+                "https://opencollective.com/debug"
+            ],
+            "license": "MIT"
         },
         "node_modules/optionator": {
             "version": "0.9.4",
@@ -3817,6 +4362,13 @@
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
+        },
+        "node_modules/pathe": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+            "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/picocolors": {
             "version": "1.1.1",
@@ -4118,6 +4670,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/proxy-from-env": {
             "version": "1.1.0",
@@ -4569,6 +5128,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -4589,6 +5155,20 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/std-env": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+            "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/string-width": {
             "version": "5.1.2",
@@ -4823,6 +5403,81 @@
             },
             "engines": {
                 "node": ">=0.8"
+            }
+        },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+            "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+            "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/to-regex-range": {
@@ -5066,6 +5721,109 @@
                 "picomatch": "^2.3.1"
             }
         },
+        "node_modules/vitest": {
+            "version": "4.1.5",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+            "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "4.1.5",
+                "@vitest/mocker": "4.1.5",
+                "@vitest/pretty-format": "4.1.5",
+                "@vitest/runner": "4.1.5",
+                "@vitest/snapshot": "4.1.5",
+                "@vitest/spy": "4.1.5",
+                "@vitest/utils": "4.1.5",
+                "es-module-lexer": "^2.0.0",
+                "expect-type": "^1.3.0",
+                "magic-string": "^0.30.21",
+                "obug": "^2.1.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "std-env": "^4.0.0-rc.1",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^1.0.2",
+                "tinyglobby": "^0.2.15",
+                "tinyrainbow": "^3.1.0",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@opentelemetry/api": "^1.9.0",
+                "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+                "@vitest/browser-playwright": "4.1.5",
+                "@vitest/browser-preview": "4.1.5",
+                "@vitest/browser-webdriverio": "4.1.5",
+                "@vitest/coverage-istanbul": "4.1.5",
+                "@vitest/coverage-v8": "4.1.5",
+                "@vitest/ui": "4.1.5",
+                "happy-dom": "*",
+                "jsdom": "*",
+                "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser-playwright": {
+                    "optional": true
+                },
+                "@vitest/browser-preview": {
+                    "optional": true
+                },
+                "@vitest/browser-webdriverio": {
+                    "optional": true
+                },
+                "@vitest/coverage-istanbul": {
+                    "optional": true
+                },
+                "@vitest/coverage-v8": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
         "node_modules/vscode-uri": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
@@ -5092,6 +5850,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/vue-component-type-helpers": {
+            "version": "3.2.7",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.2.7.tgz",
+            "integrity": "sha512-+gPp5YGmhfsj1IN+xUo7y0fb4clfnOiiUA39y07yW1VzCRjzVgwLbtmdWlghh7mXrPsEaYc7rrIir/HT6C8vYQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/vue-eslint-parser": {
             "version": "9.4.3",
@@ -5169,6 +5934,16 @@
                 "typescript": ">=5.0.0"
             }
         },
+        "node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5182,6 +5957,23 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/word-wrap": {
@@ -5280,6 +6072,28 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/ws": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+            "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -8,18 +8,24 @@
         "format": "prettier --write resources/",
         "format:check": "prettier --check resources/",
         "lint": "eslint . --fix",
-        "lint:check": "eslint . --max-warnings=0"
+        "lint:check": "eslint . --max-warnings=0",
+        "test": "vitest run",
+        "test:watch": "vitest"
     },
     "devDependencies": {
         "@eslint/js": "^9.19.0",
+        "@vitest/coverage-v8": "^4.1.5",
         "@vue/eslint-config-typescript": "^14.3.0",
+        "@vue/test-utils": "^2.4.9",
         "eslint": "^9.17.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-vue": "^9.32.0",
+        "happy-dom": "^20.9.0",
         "prettier": "^3.4.2",
         "prettier-plugin-organize-imports": "^4.1.0",
         "prettier-plugin-tailwindcss": "^0.6.9",
-        "typescript-eslint": "^8.23.0"
+        "typescript-eslint": "^8.23.0",
+        "vitest": "^4.1.5"
     },
     "dependencies": {
         "@headlessui/vue": "^1.7.23",

--- a/resources/js/composables/useRowSelection.component.test.ts
+++ b/resources/js/composables/useRowSelection.component.test.ts
@@ -1,0 +1,110 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { computed, defineComponent, h } from 'vue';
+import { useRowSelection } from './useRowSelection';
+
+/**
+ * Component-level integration test: mounts a minimal table that wires up
+ * `useRowSelection` exactly the way Dashboard.vue does (header checkbox +
+ * per-row checkboxes + counter). Verifies the user-visible behavior — clicks
+ * flow through the composable and update the rendered state — instead of
+ * pulling in the full Dashboard with Inertia/Ziggy/Layout dependencies.
+ */
+const TestTable = defineComponent({
+    props: {
+        rows: { type: Array as () => Array<{ id: number; name: string }>, required: true },
+    },
+    setup(props) {
+        const selection = useRowSelection();
+        const visibleIds = computed(() => props.rows.map((r) => r.id));
+        const headerState = computed(() => selection.visibleState(visibleIds.value));
+
+        return () =>
+            h('div', [
+                h('span', { 'data-testid': 'count' }, String(selection.count.value)),
+                h('span', { 'data-testid': 'header-state' }, headerState.value),
+                h('table', [
+                    h('thead', [
+                        h('tr', [
+                            h('th', [
+                                h('input', {
+                                    type: 'checkbox',
+                                    'data-testid': 'header',
+                                    checked: selection.isVisibleAllSelected(visibleIds.value),
+                                    onChange: () => selection.toggleAllVisible(visibleIds.value),
+                                }),
+                            ]),
+                        ]),
+                    ]),
+                    h(
+                        'tbody',
+                        props.rows.map((row) =>
+                            h('tr', { key: row.id }, [
+                                h('td', [
+                                    h('input', {
+                                        type: 'checkbox',
+                                        'data-testid': `row-${row.id}`,
+                                        checked: selection.isSelected(row.id),
+                                        onChange: () => selection.toggle(row.id),
+                                    }),
+                                ]),
+                            ]),
+                        ),
+                    ),
+                ]),
+            ]);
+    },
+});
+
+const sampleRows = [
+    { id: 10, name: 'Anna' },
+    { id: 11, name: 'Bob' },
+    { id: 12, name: 'Carla' },
+];
+
+describe('row selection wiring', () => {
+    it('toggles a single row and updates the visible counter', async () => {
+        const wrapper = mount(TestTable, { props: { rows: sampleRows } });
+
+        await wrapper.get('[data-testid="row-11"]').setValue(true);
+
+        expect(wrapper.get('[data-testid="count"]').text()).toBe('1');
+        expect(wrapper.get('[data-testid="header-state"]').text()).toBe('some');
+    });
+
+    it('header click selects every visible row', async () => {
+        const wrapper = mount(TestTable, { props: { rows: sampleRows } });
+
+        await wrapper.get('[data-testid="header"]').trigger('change');
+
+        expect(wrapper.get('[data-testid="count"]').text()).toBe('3');
+        expect(wrapper.get('[data-testid="header-state"]').text()).toBe('all');
+        expect((wrapper.get('[data-testid="row-10"]').element as HTMLInputElement).checked).toBe(true);
+        expect((wrapper.get('[data-testid="row-11"]').element as HTMLInputElement).checked).toBe(true);
+        expect((wrapper.get('[data-testid="row-12"]').element as HTMLInputElement).checked).toBe(true);
+    });
+
+    it('header click in a partially-selected state fills the page (select-first)', async () => {
+        const wrapper = mount(TestTable, { props: { rows: sampleRows } });
+
+        await wrapper.get('[data-testid="row-11"]').trigger('change');
+        expect(wrapper.get('[data-testid="header-state"]').text()).toBe('some');
+
+        await wrapper.get('[data-testid="header"]').trigger('change');
+
+        expect(wrapper.get('[data-testid="count"]').text()).toBe('3');
+        expect(wrapper.get('[data-testid="header-state"]').text()).toBe('all');
+    });
+
+    it('header click while fully selected clears the page', async () => {
+        const wrapper = mount(TestTable, { props: { rows: sampleRows } });
+
+        await wrapper.get('[data-testid="header"]').trigger('change');
+        expect(wrapper.get('[data-testid="header-state"]').text()).toBe('all');
+
+        await wrapper.get('[data-testid="header"]').trigger('change');
+
+        expect(wrapper.get('[data-testid="count"]').text()).toBe('0');
+        expect(wrapper.get('[data-testid="header-state"]').text()).toBe('none');
+    });
+});

--- a/resources/js/composables/useRowSelection.test.ts
+++ b/resources/js/composables/useRowSelection.test.ts
@@ -1,0 +1,151 @@
+import { describe, expect, it } from 'vitest';
+import { useRowSelection } from './useRowSelection';
+
+describe('useRowSelection', () => {
+    it('starts empty', () => {
+        const s = useRowSelection();
+
+        expect(s.count.value).toBe(0);
+        expect(s.selectedIds.value.size).toBe(0);
+    });
+
+    it('tracks individual selection by id', () => {
+        const s = useRowSelection();
+
+        s.toggle(1);
+        s.toggle(42);
+
+        expect(s.isSelected(1)).toBe(true);
+        expect(s.isSelected(42)).toBe(true);
+        expect(s.isSelected(7)).toBe(false);
+        expect(s.count.value).toBe(2);
+    });
+
+    it('toggles an existing id off', () => {
+        const s = useRowSelection();
+
+        s.toggle(5);
+        s.toggle(5);
+
+        expect(s.isSelected(5)).toBe(false);
+        expect(s.count.value).toBe(0);
+    });
+
+    it('reports visibleState as none when no visible rows are selected', () => {
+        const s = useRowSelection();
+
+        s.toggle(99);
+
+        expect(s.visibleState([1, 2, 3])).toBe('none');
+        expect(s.isVisibleAllSelected([1, 2, 3])).toBe(false);
+        expect(s.isVisibleIndeterminate([1, 2, 3])).toBe(false);
+    });
+
+    it('reports visibleState as some when partially selected', () => {
+        const s = useRowSelection();
+
+        s.toggle(2);
+
+        expect(s.visibleState([1, 2, 3])).toBe('some');
+        expect(s.isVisibleIndeterminate([1, 2, 3])).toBe(true);
+        expect(s.isVisibleAllSelected([1, 2, 3])).toBe(false);
+    });
+
+    it('reports visibleState as all when every visible row is selected', () => {
+        const s = useRowSelection();
+
+        s.toggle(1);
+        s.toggle(2);
+        s.toggle(3);
+
+        expect(s.visibleState([1, 2, 3])).toBe('all');
+        expect(s.isVisibleAllSelected([1, 2, 3])).toBe(true);
+        expect(s.isVisibleIndeterminate([1, 2, 3])).toBe(false);
+    });
+
+    it('returns none for an empty visibleIds list', () => {
+        const s = useRowSelection();
+
+        expect(s.visibleState([])).toBe('none');
+    });
+
+    it('toggleAllVisible selects all when none are selected', () => {
+        const s = useRowSelection();
+
+        s.toggleAllVisible([1, 2, 3]);
+
+        expect(s.isSelected(1)).toBe(true);
+        expect(s.isSelected(2)).toBe(true);
+        expect(s.isSelected(3)).toBe(true);
+        expect(s.count.value).toBe(3);
+    });
+
+    it('toggleAllVisible selects the missing rows when some are already selected (select-first)', () => {
+        const s = useRowSelection();
+
+        s.toggle(2);
+        s.toggleAllVisible([1, 2, 3]);
+
+        expect(s.isSelected(1)).toBe(true);
+        expect(s.isSelected(2)).toBe(true);
+        expect(s.isSelected(3)).toBe(true);
+    });
+
+    it('toggleAllVisible clears the visible page when every visible row is already selected', () => {
+        const s = useRowSelection();
+
+        s.toggle(1);
+        s.toggle(2);
+        s.toggle(3);
+        s.toggleAllVisible([1, 2, 3]);
+
+        expect(s.count.value).toBe(0);
+    });
+
+    it('toggleAllVisible only touches ids on the current page (foundation for #84)', () => {
+        const s = useRowSelection();
+
+        // Simulate a previous selection from another page.
+        s.toggle(99);
+
+        s.toggleAllVisible([1, 2]);
+
+        expect(s.isSelected(99)).toBe(true);
+        expect(s.isSelected(1)).toBe(true);
+        expect(s.isSelected(2)).toBe(true);
+        expect(s.count.value).toBe(3);
+
+        // Header-toggle on the current page must not blow away id 99.
+        s.toggleAllVisible([1, 2]);
+
+        expect(s.isSelected(99)).toBe(true);
+        expect(s.isSelected(1)).toBe(false);
+        expect(s.isSelected(2)).toBe(false);
+        expect(s.count.value).toBe(1);
+    });
+
+    it('clear empties the entire set including off-page selections', () => {
+        const s = useRowSelection();
+
+        s.toggle(1);
+        s.toggle(99);
+
+        s.clear();
+
+        expect(s.count.value).toBe(0);
+        expect(s.isSelected(1)).toBe(false);
+        expect(s.isSelected(99)).toBe(false);
+    });
+
+    it('setSelected is idempotent', () => {
+        const s = useRowSelection();
+
+        s.setSelected(7, true);
+        s.setSelected(7, true);
+        expect(s.count.value).toBe(1);
+
+        s.setSelected(7, false);
+        s.setSelected(7, false);
+        expect(s.count.value).toBe(0);
+    });
+});

--- a/resources/js/composables/useRowSelection.ts
+++ b/resources/js/composables/useRowSelection.ts
@@ -1,0 +1,114 @@
+import { computed, ref, type ComputedRef } from 'vue';
+
+export type RowSelectionState = 'none' | 'some' | 'all';
+
+export interface UseRowSelection {
+    selectedIds: ComputedRef<ReadonlySet<number>>;
+    count: ComputedRef<number>;
+    isSelected: (id: number) => boolean;
+    toggle: (id: number) => void;
+    setSelected: (id: number, selected: boolean) => void;
+    visibleState: (visibleIds: readonly number[]) => RowSelectionState;
+    isVisibleAllSelected: (visibleIds: readonly number[]) => boolean;
+    isVisibleIndeterminate: (visibleIds: readonly number[]) => boolean;
+    toggleAllVisible: (visibleIds: readonly number[]) => void;
+    clear: () => void;
+}
+
+/**
+ * Tracks bulk-selection of reservation rows in a `Set<number>` keyed by id.
+ *
+ * The set is component-local and survives pagination because we key by id
+ * rather than visible index — that's the foundation #84 (polling-reload
+ * persistence) builds on.
+ *
+ * Header-checkbox toggle uses the "select-first" convention (Gmail/GitHub):
+ * a click while in any non-fully-selected state selects all visible rows;
+ * a click while fully selected clears them. That keeps a single intuition
+ * for users moving between mixed and clean states.
+ */
+export function useRowSelection(): UseRowSelection {
+    const internal = ref<Set<number>>(new Set());
+
+    const selectedIds = computed<ReadonlySet<number>>(() => internal.value);
+    const count = computed(() => internal.value.size);
+
+    function isSelected(id: number): boolean {
+        return internal.value.has(id);
+    }
+
+    function setSelected(id: number, selected: boolean): void {
+        const next = new Set(internal.value);
+
+        if (selected) {
+            next.add(id);
+        } else {
+            next.delete(id);
+        }
+
+        internal.value = next;
+    }
+
+    function toggle(id: number): void {
+        setSelected(id, !internal.value.has(id));
+    }
+
+    function visibleState(visibleIds: readonly number[]): RowSelectionState {
+        if (visibleIds.length === 0) {
+            return 'none';
+        }
+
+        let selectedCount = 0;
+        for (const id of visibleIds) {
+            if (internal.value.has(id)) {
+                selectedCount++;
+            }
+        }
+
+        if (selectedCount === 0) {
+            return 'none';
+        }
+
+        return selectedCount === visibleIds.length ? 'all' : 'some';
+    }
+
+    function isVisibleAllSelected(visibleIds: readonly number[]): boolean {
+        return visibleState(visibleIds) === 'all';
+    }
+
+    function isVisibleIndeterminate(visibleIds: readonly number[]): boolean {
+        return visibleState(visibleIds) === 'some';
+    }
+
+    function toggleAllVisible(visibleIds: readonly number[]): void {
+        const next = new Set(internal.value);
+        const allSelected = visibleState(visibleIds) === 'all';
+
+        for (const id of visibleIds) {
+            if (allSelected) {
+                next.delete(id);
+            } else {
+                next.add(id);
+            }
+        }
+
+        internal.value = next;
+    }
+
+    function clear(): void {
+        internal.value = new Set();
+    }
+
+    return {
+        selectedIds,
+        count,
+        isSelected,
+        toggle,
+        setSelected,
+        visibleState,
+        isVisibleAllSelected,
+        isVisibleIndeterminate,
+        toggleAllVisible,
+        clear,
+    };
+}

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useRowSelection } from '@/composables/useRowSelection';
 import AppLayout from '@/layouts/AppLayout.vue';
 import {
     type BreadcrumbItem,
@@ -202,6 +204,16 @@ const drawerOpen = computed({
 
 const rawEmailOpen = ref(false);
 
+const selection = useRowSelection();
+const visibleRowIds = computed(() => props.requests.data.map((row) => row.id));
+const headerCheckedModel = computed<boolean | 'indeterminate'>(() => {
+    if (selection.isVisibleIndeterminate(visibleRowIds.value)) {
+        return 'indeterminate';
+    }
+
+    return selection.isVisibleAllSelected(visibleRowIds.value);
+});
+
 watch(
     () => props.selectedRequest?.id,
     () => {
@@ -346,10 +358,31 @@ watch(visibility, (state) => {
                 <p class="mt-1 text-sm text-muted-foreground">Es gibt aktuell keine Anfragen, die zu deinen Filtern passen.</p>
             </section>
 
-            <section v-else class="overflow-x-auto rounded-lg border border-border" data-testid="reservations-table">
+            <section
+                v-if="props.requests.data.length > 0 && selection.count.value > 0"
+                class="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-primary/30 bg-primary/5 px-4 py-2 text-sm"
+                data-testid="bulk-select-toolbar"
+                aria-live="polite"
+            >
+                <span class="font-medium" data-testid="bulk-select-count">Ausgewählt: {{ selection.count.value }}</span>
+                <Button type="button" variant="ghost" size="sm" data-testid="bulk-select-clear" @click="selection.clear()"> Auswahl aufheben </Button>
+            </section>
+
+            <section v-if="props.requests.data.length > 0" class="overflow-x-auto rounded-lg border border-border" data-testid="reservations-table">
                 <table class="w-full text-left text-sm">
+                    <colgroup>
+                        <col class="w-10" />
+                    </colgroup>
                     <thead class="bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
                         <tr>
+                            <th class="px-3 py-2 font-medium">
+                                <Checkbox
+                                    :checked="headerCheckedModel"
+                                    aria-label="Alle sichtbaren Reservierungen auswählen"
+                                    data-testid="bulk-select-header"
+                                    @update:checked="selection.toggleAllVisible(visibleRowIds)"
+                                />
+                            </th>
                             <th class="px-3 py-2 font-medium">Eingegangen</th>
                             <th class="px-3 py-2 font-medium">Wunschzeit</th>
                             <th class="px-3 py-2 font-medium">Personen</th>
@@ -361,6 +394,14 @@ watch(visibility, (state) => {
                     </thead>
                     <tbody class="divide-y divide-border">
                         <tr v-for="row in props.requests.data" :key="row.id" class="hover:bg-muted/30" :data-testid="`reservation-row-${row.id}`">
+                            <td class="px-3 py-2">
+                                <Checkbox
+                                    :checked="selection.isSelected(row.id)"
+                                    :aria-label="`Reservierung ${row.guest_name} auswählen`"
+                                    :data-testid="`bulk-select-row-${row.id}`"
+                                    @update:checked="selection.toggle(row.id)"
+                                />
+                            </td>
                             <td class="whitespace-nowrap px-3 py-2 text-muted-foreground">
                                 {{ formatDateTime(row.created_at) }}
                             </td>

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    plugins: [vue()],
+    resolve: {
+        alias: {
+            '@': path.resolve(__dirname, './resources/js'),
+        },
+    },
+    test: {
+        environment: 'happy-dom',
+        include: ['resources/js/**/*.{test,spec}.ts'],
+        globals: false,
+    },
+});


### PR DESCRIPTION
## Summary

- Per-row + header checkbox column on the dashboard table
- Header indeterminate when some-but-not-all visible rows are selected
- "Ausgewählt: N" toolbar (Gmail-style) appears between filter bar and table once any row is selected; includes "Auswahl aufheben"
- Selection state lives in component-local `ref<Set<number>>` keyed by reservation id (foundation for #84)
- Header uses "select-first" convention: click while indeterminate fills the page; click while fully selected clears it

Acceptance criteria from the issue:

- [x] Per-row checkbox in a leading column (reserved width via `<colgroup>`)
- [x] Header checkbox toggles all visible-on-this-page rows
- [x] Header renders indeterminate (mixed) state when applicable — verified visually via radix `data-state="indeterminate"`
- [x] "Selected: N" indicator near the table — implemented as a sticky toolbar that becomes the natural home for future bulk-action buttons
- [x] Selection set is keyed by id, not by index (foundation for #84)
- [x] Component test asserts header-toggle + per-row toggle interaction — see `useRowSelection.component.test.ts`

## Why

Originally split off from #53 to keep that PR focused on the read-side dashboard. The selection layer is the prerequisite for the future bulk-action endpoint (a separate issue) and for #84 (polling-reload selection persistence).

Decision points worth flagging in review:

- **No JS test infrastructure existed** in the repo (no Vitest, no Jest, no Playwright config). The issue's "Component test" AC was incompatible with existing patterns, so this PR introduces **Vitest + @vue/test-utils + happy-dom** as the project's first JS test runner. `vitest.config.ts` reuses the `@`-alias from `vite.config.ts`. Adds `npm run test` and `npm run test:watch` scripts. Future Vue-side features (#84, the bulk-action UI) can build on this.
- **Selection persists across pages.** The Set is keyed by id, not index — that's what the issue asks for. The header checkbox + toolbar reflect the current page; the underlying Set survives navigation. This sets up #84 cleanly.
- **Toolbar location**: between filter bar and table, only visible when N > 0. This is the Gmail/GitHub pattern and the natural home for the bulk-action buttons that follow in a separate issue.
- **Subtle gotcha**: the project's `Checkbox.vue` (radix-vue wrapper) uses `:checked`/`@update:checked`, NOT the conventional Vue `:model-value` — see existing `Login.vue:74` (`v-model:checked="form.remember"`). Initial implementation hit this; corrected to match the established pattern.

Closes #147

## Test plan

- [x] `npm run test` — 17 passed (13 composable logic + 4 component integration)
- [x] `php artisan test` — 399 passed
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint:check` — clean
- [x] `npm run format:check` — clean
- [x] `npm run build` — clean
- [x] Manual browser test (Playwright MCP): verified per-row toggle, header toggle in three states (none → all, indeterminate → all, all → none), toolbar appearance/clear, indeterminate visual state via `data-state="indeterminate"`