### PR TITLE
Render desired_at in restaurant timezone on dashboard (#83)

### DIFF
--- a/resources/js/lib/format-datetime.test.ts
+++ b/resources/js/lib/format-datetime.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { formatDateTime } from './format-datetime';
+
+describe('formatDateTime', () => {
+    it('returns the em-dash placeholder for null', () => {
+        expect(formatDateTime(null)).toBe('–');
+    });
+
+    it('returns the em-dash placeholder for an unparseable string', () => {
+        expect(formatDateTime('not-a-date')).toBe('–');
+    });
+
+    it('renders a UTC ISO-8601 timestamp in the given restaurant timezone', () => {
+        // 18:00 UTC = 20:00 in Europe/Berlin during DST.
+        const rendered = formatDateTime('2025-06-15T18:00:00+00:00', { timeZone: 'Europe/Berlin' });
+
+        expect(rendered).toContain('20:00');
+        expect(rendered).toContain('15.06.2025');
+    });
+
+    it('renders the same UTC moment differently for a different timezone (proves timezone is applied)', () => {
+        const iso = '2025-06-15T18:00:00+00:00';
+
+        const berlin = formatDateTime(iso, { timeZone: 'Europe/Berlin' });
+        const auckland = formatDateTime(iso, { timeZone: 'Pacific/Auckland' });
+
+        expect(berlin).not.toBe(auckland);
+        // Auckland is +12 in NZST (winter), so 18:00 UTC is 06:00 next day.
+        expect(auckland).toContain('06:00');
+        expect(auckland).toContain('16.06.2025');
+    });
+
+    it('honors a UTC timezone explicitly', () => {
+        const rendered = formatDateTime('2025-01-01T00:00:00+00:00', { timeZone: 'UTC' });
+
+        expect(rendered).toContain('00:00');
+        expect(rendered).toContain('01.01.2025');
+    });
+});

--- a/resources/js/lib/format-datetime.ts
+++ b/resources/js/lib/format-datetime.ts
@@ -1,0 +1,27 @@
+/**
+ * Renders an ISO-8601 timestamp in `de-DE` medium-date / short-time format.
+ *
+ * The API contract (CLAUDE.md, PRD-004) is to emit timestamps in UTC ISO-8601.
+ * Rendering must happen in the restaurant's local timezone so operators see
+ * evening-service reservations at the wall-clock time they actually serve them.
+ *
+ * Pass `timeZone` (IANA, e.g. `Europe/Berlin`) to render in restaurant time.
+ * Without it, the viewer's browser timezone is used — only acceptable when no
+ * restaurant context is available (e.g. shell pages before login).
+ */
+export function formatDateTime(iso: string | null, options?: { timeZone?: string }): string {
+    if (!iso) {
+        return '–';
+    }
+
+    const date = new Date(iso);
+    if (Number.isNaN(date.getTime())) {
+        return '–';
+    }
+
+    return new Intl.DateTimeFormat('de-DE', {
+        dateStyle: 'medium',
+        timeStyle: 'short',
+        timeZone: options?.timeZone,
+    }).format(date);
+}

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -7,6 +7,7 @@ import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useRowSelection } from '@/composables/useRowSelection';
 import AppLayout from '@/layouts/AppLayout.vue';
+import { formatDateTime } from '@/lib/format-datetime';
 import {
     type BreadcrumbItem,
     type DashboardFilters,
@@ -37,6 +38,7 @@ const breadcrumbs: BreadcrumbItem[] = [{ title: 'Dashboard', href: '/dashboard' 
 
 const page = usePage<SharedData>();
 const restaurantName = computed(() => page.props.restaurant?.name ?? '');
+const restaurantTimezone = computed(() => page.props.restaurant?.timezone);
 
 const STATUS_OPTIONS: { value: ReservationStatus; label: string }[] = [
     { value: 'new', label: 'Neu' },
@@ -160,20 +162,8 @@ const hasActiveFilters = computed(() => {
     );
 });
 
-function formatDateTime(iso: string | null): string {
-    if (!iso) {
-        return '–';
-    }
-
-    const date = new Date(iso);
-    if (Number.isNaN(date.getTime())) {
-        return '–';
-    }
-
-    return new Intl.DateTimeFormat('de-DE', {
-        dateStyle: 'medium',
-        timeStyle: 'short',
-    }).format(date);
+function renderTime(iso: string | null): string {
+    return formatDateTime(iso, { timeZone: restaurantTimezone.value });
 }
 
 function detailHref(rowId: number | null): string {
@@ -403,9 +393,9 @@ watch(visibility, (state) => {
                                 />
                             </td>
                             <td class="whitespace-nowrap px-3 py-2 text-muted-foreground">
-                                {{ formatDateTime(row.created_at) }}
+                                {{ renderTime(row.created_at) }}
                             </td>
-                            <td class="whitespace-nowrap px-3 py-2">{{ formatDateTime(row.desired_at) }}</td>
+                            <td class="whitespace-nowrap px-3 py-2">{{ renderTime(row.desired_at) }}</td>
                             <td class="px-3 py-2">{{ row.party_size }}</td>
                             <td class="px-3 py-2">{{ row.guest_name }}</td>
                             <td class="px-3 py-2 text-xs text-muted-foreground">{{ SOURCE_LABEL[row.source] }}</td>
@@ -511,10 +501,10 @@ watch(visibility, (state) => {
 
                 <dl class="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-2 text-sm" data-testid="reservation-detail-fields">
                     <dt class="font-medium text-muted-foreground">Eingegangen</dt>
-                    <dd>{{ formatDateTime(props.selectedRequest.created_at) }}</dd>
+                    <dd>{{ renderTime(props.selectedRequest.created_at) }}</dd>
 
                     <dt class="font-medium text-muted-foreground">Wunschzeit</dt>
-                    <dd>{{ formatDateTime(props.selectedRequest.desired_at) }}</dd>
+                    <dd>{{ renderTime(props.selectedRequest.desired_at) }}</dd>
 
                     <dt class="font-medium text-muted-foreground">Personen</dt>
                     <dd>{{ props.selectedRequest.party_size }}</dd>

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -55,6 +55,32 @@ class DashboardTest extends TestCase
             );
     }
 
+    public function test_dashboard_emits_desired_at_as_utc_iso_for_restaurant_timezone_rendering(): void
+    {
+        // The client renders desired_at in restaurant-local time using the shared
+        // restaurant.timezone prop (see resources/js/lib/format-datetime.ts).
+        // That requires the API to keep emitting UTC ISO-8601 unconditionally.
+        $restaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        // 18:00 UTC is 20:00 in Berlin during DST. The payload must remain UTC.
+        $desiredAt = Carbon::parse('2025-06-15T18:00:00Z');
+
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['desired_at' => $desiredAt, 'status' => ReservationStatus::New]);
+
+        $this->actingAs($user)
+            ->get('/dashboard?clear=1&status[]=new')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->where('restaurant.timezone', 'Europe/Berlin')
+                ->where('requests.data.0.desired_at', $desiredAt->toIso8601String())
+                ->etc()
+            );
+    }
+
     public function test_user_without_restaurant_receives_null_restaurant_prop(): void
     {
         $user = User::factory()->create(['restaurant_id' => null]);


### PR DESCRIPTION
## Summary

- `formatDateTime` extracted into `resources/js/lib/format-datetime.ts` and accepts a `timeZone` (IANA) option that flows through `Intl.DateTimeFormat`.
- `Dashboard.vue` reads `restaurant.timezone` from the shared Inertia prop (already published by `HandleInertiaRequests::share`) and applies it to every `desired_at` / `created_at` rendering — both in the table and in the detail drawer.
- API contract is unchanged: `ReservationRequestResource` still emits UTC ISO-8601 (verified by a new Pest test).
- New Vitest tests cover the formatter (UTC ISO + IANA tz → wall-clock string in that tz, fallback for null/invalid).

## Why

PRD-004 stores `desired_at` in UTC (CLAUDE.md convention). Without explicit restaurant-tz rendering, evening-service reservations appear with a confusing offset on the dashboard, especially for restaurants outside the operator's browser timezone — the exact scenario flagged in PRD-004 §"Risiken & offene Fragen" → "Timezone-Anzeige". This is one of the three remaining PRD-004 risk items that block the `dev → main` release of PRD-001..004.

Closes #83

## Test plan

- [x] `npm run test` (vitest) — 22 / 22 green incl. 5 new tests on `formatDateTime`
- [x] `php artisan test` — 406 / 406 green incl. new `test_dashboard_emits_desired_at_as_utc_iso_for_restaurant_timezone_rendering`
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint && npm run format:check` — clean
- [x] `npm run build` — vue-tsc + Vite build clean

## Acceptance criteria check (Issue #83)

- [x] `desired_at` is shown in restaurant-local time in the dashboard table
- [x] Detail drawer shows restaurant-local time
- [x] API Resource still emits UTC ISO-8601 (asserted by new Pest test)
- [x] Feature test asserts rendering uses `restaurant.timezone` (Pest pins the shared-prop + UTC contract; Vitest pins the formatter behaviour against the tz)