### PR TITLE
Drop off-view dashboard selections after partial reload (#84)

### DIFF
--- a/resources/js/composables/useRowSelection.component.test.ts
+++ b/resources/js/composables/useRowSelection.component.test.ts
@@ -1,14 +1,16 @@
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
-import { computed, defineComponent, h } from 'vue';
+import { computed, defineComponent, h, watch } from 'vue';
 import { useRowSelection } from './useRowSelection';
 
 /**
  * Component-level integration test: mounts a minimal table that wires up
  * `useRowSelection` exactly the way Dashboard.vue does (header checkbox +
- * per-row checkboxes + counter). Verifies the user-visible behavior — clicks
- * flow through the composable and update the rendered state — instead of
- * pulling in the full Dashboard with Inertia/Ziggy/Layout dependencies.
+ * per-row checkboxes + counter, plus a watcher that calls `retainVisible`
+ * after every row-set change to model partial-reload cleanup). Verifies the
+ * user-visible behavior — clicks flow through the composable and update the
+ * rendered state — instead of pulling in the full Dashboard with
+ * Inertia/Ziggy/Layout dependencies.
  */
 const TestTable = defineComponent({
     props: {
@@ -18,6 +20,14 @@ const TestTable = defineComponent({
         const selection = useRowSelection();
         const visibleIds = computed(() => props.rows.map((r) => r.id));
         const headerState = computed(() => selection.visibleState(visibleIds.value));
+
+        // Mirrors Dashboard.vue: every time the row set changes (polling
+        // reload, filter, pagination), drop off-view selections so the bulk
+        // action operates on rows the operator can still see (#84).
+        watch(
+            () => props.rows.map((r) => r.id).join(','),
+            () => selection.retainVisible(visibleIds.value),
+        );
 
         return () =>
             h('div', [
@@ -106,5 +116,60 @@ describe('row selection wiring', () => {
 
         expect(wrapper.get('[data-testid="count"]').text()).toBe('0');
         expect(wrapper.get('[data-testid="header-state"]').text()).toBe('none');
+    });
+
+    describe('reload cleanup (#84)', () => {
+        it('preserves selections of rows that survive a partial reload', async () => {
+            const wrapper = mount(TestTable, { props: { rows: sampleRows } });
+
+            await wrapper.get('[data-testid="row-10"]').trigger('change');
+            await wrapper.get('[data-testid="row-11"]').trigger('change');
+            expect(wrapper.get('[data-testid="count"]').text()).toBe('2');
+
+            // Simulate a polling reload that returns the same rows.
+            await wrapper.setProps({ rows: [...sampleRows] });
+
+            expect(wrapper.get('[data-testid="count"]').text()).toBe('2');
+            expect((wrapper.get('[data-testid="row-10"]').element as HTMLInputElement).checked).toBe(true);
+            expect((wrapper.get('[data-testid="row-11"]').element as HTMLInputElement).checked).toBe(true);
+        });
+
+        it('drops a selected row that left the page after a partial reload', async () => {
+            const wrapper = mount(TestTable, { props: { rows: sampleRows } });
+
+            // Select all three.
+            await wrapper.get('[data-testid="header"]').trigger('change');
+            expect(wrapper.get('[data-testid="count"]').text()).toBe('3');
+
+            // Simulate reload after id 11 was marked declined and dropped from
+            // the active filter — only ids 10 and 12 remain visible.
+            await wrapper.setProps({
+                rows: [
+                    { id: 10, name: 'Anna' },
+                    { id: 12, name: 'Carla' },
+                ],
+            });
+
+            expect(wrapper.get('[data-testid="count"]').text()).toBe('2');
+            expect((wrapper.get('[data-testid="row-10"]').element as HTMLInputElement).checked).toBe(true);
+            expect((wrapper.get('[data-testid="row-12"]').element as HTMLInputElement).checked).toBe(true);
+        });
+
+        it('clears selection when the user navigates to a page with no overlapping ids', async () => {
+            const wrapper = mount(TestTable, { props: { rows: sampleRows } });
+
+            await wrapper.get('[data-testid="row-11"]').trigger('change');
+            expect(wrapper.get('[data-testid="count"]').text()).toBe('1');
+
+            // Page 2 — disjoint id space.
+            await wrapper.setProps({
+                rows: [
+                    { id: 20, name: 'Dora' },
+                    { id: 21, name: 'Eli' },
+                ],
+            });
+
+            expect(wrapper.get('[data-testid="count"]').text()).toBe('0');
+        });
     });
 });

--- a/resources/js/composables/useRowSelection.test.ts
+++ b/resources/js/composables/useRowSelection.test.ts
@@ -148,4 +148,56 @@ describe('useRowSelection', () => {
         s.setSelected(7, false);
         expect(s.count.value).toBe(0);
     });
+
+    describe('retainVisible (#84 polling-reload cleanup)', () => {
+        it('drops ids that are no longer visible', () => {
+            const s = useRowSelection();
+
+            s.toggle(1);
+            s.toggle(2);
+            s.toggle(99);
+
+            s.retainVisible([1, 2, 5]);
+
+            expect(s.isSelected(1)).toBe(true);
+            expect(s.isSelected(2)).toBe(true);
+            expect(s.isSelected(99)).toBe(false);
+            expect(s.count.value).toBe(2);
+        });
+
+        it('keeps every id when all selections remain visible', () => {
+            const s = useRowSelection();
+
+            s.toggle(1);
+            s.toggle(2);
+
+            s.retainVisible([1, 2, 3]);
+
+            expect(s.count.value).toBe(2);
+            expect(s.isSelected(1)).toBe(true);
+            expect(s.isSelected(2)).toBe(true);
+        });
+
+        it('clears the selection when no selected id is visible anymore', () => {
+            const s = useRowSelection();
+
+            s.toggle(7);
+            s.toggle(8);
+
+            s.retainVisible([10, 11]);
+
+            expect(s.count.value).toBe(0);
+        });
+
+        it('is a no-op on an empty selection (does not allocate)', () => {
+            const s = useRowSelection();
+            const before = s.selectedIds.value;
+
+            s.retainVisible([1, 2, 3]);
+
+            expect(s.count.value).toBe(0);
+            // Same Set reference — proves the early return short-circuited.
+            expect(s.selectedIds.value).toBe(before);
+        });
+    });
 });

--- a/resources/js/composables/useRowSelection.ts
+++ b/resources/js/composables/useRowSelection.ts
@@ -12,6 +12,7 @@ export interface UseRowSelection {
     isVisibleAllSelected: (visibleIds: readonly number[]) => boolean;
     isVisibleIndeterminate: (visibleIds: readonly number[]) => boolean;
     toggleAllVisible: (visibleIds: readonly number[]) => void;
+    retainVisible: (visibleIds: readonly number[]) => void;
     clear: () => void;
 }
 
@@ -95,6 +96,34 @@ export function useRowSelection(): UseRowSelection {
         internal.value = next;
     }
 
+    /**
+     * Drops every selected id that is not in `visibleIds`.
+     *
+     * Call this after the dashboard re-renders the row set (polling reload,
+     * filter change, pagination) so the bulk action operates on rows the
+     * operator can still see. Without it, ids that left the view (e.g. a row
+     * that was just marked declined and now no longer matches the active
+     * status filter) would silently linger in the selection.
+     */
+    function retainVisible(visibleIds: readonly number[]): void {
+        if (internal.value.size === 0) {
+            return;
+        }
+
+        const next = new Set<number>();
+        for (const id of visibleIds) {
+            if (internal.value.has(id)) {
+                next.add(id);
+            }
+        }
+
+        if (next.size === internal.value.size) {
+            return;
+        }
+
+        internal.value = next;
+    }
+
     function clear(): void {
         internal.value = new Set();
     }
@@ -109,6 +138,7 @@ export function useRowSelection(): UseRowSelection {
         isVisibleAllSelected,
         isVisibleIndeterminate,
         toggleAllVisible,
+        retainVisible,
         clear,
     };
 }

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -204,6 +204,11 @@ const headerCheckedModel = computed<boolean | 'indeterminate'>(() => {
     return selection.isVisibleAllSelected(visibleRowIds.value);
 });
 
+// After every partial reload (polling, filter change, pagination) drop ids
+// that are no longer in the active row set so a bulk action only ever
+// operates on rows the operator can still see.
+watch(visibleRowIds, (ids) => selection.retainVisible(ids));
+
 watch(
     () => props.selectedRequest?.id,
     () => {


### PR DESCRIPTION
## Summary

- New \`retainVisible(visibleIds)\` method on \`useRowSelection\` intersects the current selection with the given id list, dropping anything else.
- \`Dashboard.vue\` watches \`visibleRowIds\` and calls \`selection.retainVisible()\` after every change so polling reloads, filter changes, and pagination all transparently clean up off-view selections.
- Composable unit tests cover the four branches (drop / keep / clear / no-op early return).
- Component-level integration tests mount a minimal table with the same \`watch → retainVisible\` pattern Dashboard.vue uses, asserting the reload-preserves / reload-drops contract end-to-end.

## Why

PRD-004 §"Risiken & offene Fragen" → "Fluktuation durch Polling": with the previous id-keyed selection, ids could linger after they left the active view (e.g. a request that another operator marked declined and that no longer matches the status filter). A bulk \`POST /reservations/bulk-status\` would then silently operate on invisible rows. This is one of the three remaining PRD-004 risk items that block the \`dev → main\` release of PRD-001..004.

Closes #84

## Test plan

- [x] \`npm run test\` — 29 / 29 green incl. 4 new \`retainVisible\` unit tests + 3 new reload-cleanup component tests
- [x] \`php artisan test\` — 406 / 406 green
- [x] \`./vendor/bin/pint --test\` — pass
- [x] \`npm run lint && npm run format:check\` — clean
- [x] \`npm run build\` — vue-tsc + Vite build clean

## Acceptance criteria check (Issue #84)

- [x] Selecting 3 rows, waiting for a poll, then clicking "Mark as declined" operates on exactly those 3 ids — \`retainVisible\` keeps surviving ids untouched, drops only those that left the view
- [x] Rows that leave the page (filter change, marked status, pagination) are removed from selection
- [x] Component test covers the reload-preserves-selection path (\`useRowSelection.component.test.ts\` § "reload cleanup (#84)")