### PR TITLE
Extract dashboard polling into testable composable (#157)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,6 +130,15 @@ app/
 - **`Mail::fake()`** für Mail-Versand-Tests
 - **Fixture-Mails** für IMAP-Parser-Tests (Klartext, HTML, mit Umlauten, mit/ohne strukturierter Anfrage)
 
+### Frontend Tests (Vitest)
+
+- **Vitest** (Vite-nativ) für Composables, Pure-Helper und Component-Wiring – pendant zu Pest auf der PHP-Seite. Konfiguration in `vitest.config.ts`, Environment `happy-dom`, Aliase identisch zu Vite (`@/` → `resources/js/`).
+- **`@vue/test-utils`** für Component-Tests, die einen Konsumenten-Wrapper mounten, statt die volle Inertia/Ziggy/Layout-Pipeline einzuziehen (siehe `resources/js/composables/useRowSelection.component.test.ts` als Referenz-Pattern).
+- **Fake Timer** (`vi.useFakeTimers()` / `vi.advanceTimersByTimeAsync`) für zeitbasierte Composables wie `usePagePolling` – nie echte Wartezeiten in Tests.
+- **Visibility / Polling**: zeitbasierte Composables nehmen den Visibility-State als optionalen Ref-Parameter, damit Tests deterministisch zwischen `visible`/`hidden` umschalten können, ohne `document` zu mutieren (Beispiel: `usePagePolling`).
+- **CI-Trennung**: `composer test` triggert **kein** Vitest. PHP-Tests laufen über `php artisan test`, JS-Tests über `npm run test`. CI führt beide aus.
+- **Reichweite**: Vitest ersetzt nicht Pest-Feature-Tests für Server-Verhalten – es testet ausschließlich Client-Logik. API-Contracts (Resource-Shape, Shared Props) gehören weiterhin in Pest.
+
 ### Was MUSS getestet werden
 
 **`ReservationContextBuilder`:**

--- a/resources/js/composables/usePagePolling.test.ts
+++ b/resources/js/composables/usePagePolling.test.ts
@@ -1,0 +1,83 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref, type Ref } from 'vue';
+import { usePagePolling } from './usePagePolling';
+
+/**
+ * Reference test that pins the dashboard polling contract: no requests fire
+ * while `document.visibilityState === 'hidden'`, and polling resumes as soon
+ * as the tab returns to `visible`. Originally specified in #55 / #157.
+ */
+describe('usePagePolling', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    function mountPoller(visibility: Ref<DocumentVisibilityState>, callback: () => void) {
+        const Poller = defineComponent({
+            setup() {
+                usePagePolling(callback, 1_000, { visibility });
+                return () => h('div');
+            },
+        });
+        return mount(Poller);
+    }
+
+    it('starts polling on mount when the tab is already visible', async () => {
+        const callback = vi.fn();
+        const visibility = ref<DocumentVisibilityState>('visible');
+
+        mountPoller(visibility, callback);
+
+        await vi.advanceTimersByTimeAsync(2_500);
+
+        expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not poll while the tab is hidden', async () => {
+        const callback = vi.fn();
+        const visibility = ref<DocumentVisibilityState>('hidden');
+
+        mountPoller(visibility, callback);
+
+        await vi.advanceTimersByTimeAsync(5_000);
+
+        expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('pauses when visibility flips to hidden and resumes on visible', async () => {
+        const callback = vi.fn();
+        const visibility = ref<DocumentVisibilityState>('visible');
+
+        mountPoller(visibility, callback);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        visibility.value = 'hidden';
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(callback).toHaveBeenCalledTimes(1);
+
+        visibility.value = 'visible';
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(callback).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not start a backlog of calls when the tab returns from a long hidden period', async () => {
+        const callback = vi.fn();
+        const visibility = ref<DocumentVisibilityState>('hidden');
+
+        mountPoller(visibility, callback);
+
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(callback).not.toHaveBeenCalled();
+
+        visibility.value = 'visible';
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/js/composables/usePagePolling.ts
+++ b/resources/js/composables/usePagePolling.ts
@@ -1,0 +1,50 @@
+import { useDocumentVisibility, useIntervalFn } from '@vueuse/core';
+import { watch, type Ref } from 'vue';
+
+type DocumentVisibility = ReturnType<typeof useDocumentVisibility>;
+
+export interface UsePagePollingOptions {
+    /**
+     * Inject a controlled visibility ref instead of binding to
+     * `document.visibilityState`. Used by the unit tests to drive the
+     * pause/resume behaviour without mutating the real document.
+     */
+    visibility?: DocumentVisibility | Ref<DocumentVisibilityState>;
+}
+
+export interface UsePagePollingHandle {
+    pause: () => void;
+    resume: () => void;
+}
+
+/**
+ * Calls `callback` every `intervalMs` milliseconds while the page is visible.
+ *
+ * Pauses on `document.visibilityState === 'hidden'` and resumes when the tab
+ * is foregrounded again, so a backgrounded dashboard does not hammer the
+ * server with polls nobody is reading.
+ *
+ * The visibility source can be overridden for tests via `options.visibility`.
+ */
+export function usePagePolling(callback: () => void, intervalMs: number, options: UsePagePollingOptions = {}): UsePagePollingHandle {
+    const visibility = options.visibility ?? useDocumentVisibility();
+
+    const { pause, resume } = useIntervalFn(callback, intervalMs, {
+        immediate: false,
+        immediateCallback: false,
+    });
+
+    if (visibility.value === 'visible') {
+        resume();
+    }
+
+    watch(visibility, (state) => {
+        if (state === 'visible') {
+            resume();
+        } else {
+            pause();
+        }
+    });
+
+    return { pause, resume };
+}

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -5,6 +5,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { usePagePolling } from '@/composables/usePagePolling';
 import { useRowSelection } from '@/composables/useRowSelection';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { formatDateTime } from '@/lib/format-datetime';
@@ -19,7 +20,6 @@ import {
     type SharedData,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
-import { useDocumentVisibility, useIntervalFn } from '@vueuse/core';
 import { ChevronDown, Info } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 
@@ -224,25 +224,7 @@ function pollOnly(): string[] {
     return keys;
 }
 
-const visibility = useDocumentVisibility();
-
-const { pause: pausePolling, resume: resumePolling } = useIntervalFn(
-    () => router.reload({ only: pollOnly(), preserveScroll: true, preserveState: true }),
-    POLL_MS,
-    { immediate: false, immediateCallback: false },
-);
-
-if (visibility.value === 'visible') {
-    resumePolling();
-}
-
-watch(visibility, (state) => {
-    if (state === 'visible') {
-        resumePolling();
-    } else {
-        pausePolling();
-    }
-});
+usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, preserveState: true }), POLL_MS);
 </script>
 
 <template>


### PR DESCRIPTION
## Summary

- New \`usePagePolling(callback, intervalMs, { visibility? })\` composable in \`resources/js/composables/\`. Wraps \`useIntervalFn\` + \`useDocumentVisibility\` and exposes the visibility source as an injectable option for tests.
- \`Dashboard.vue\` reduces 19 lines of inline visibility-gating to a single \`usePagePolling(...)\` call. Same 30s contract, no behaviour change.
- New Vitest reference test (\`usePagePolling.test.ts\`) drives a controlled visibility ref with fake timers and asserts:
  1. polling fires while \`visible\`,
  2. no callbacks while \`hidden\`,
  3. resume on return to \`visible\`,
  4. no backlog of catch-up calls after a long hidden period.
- \`CLAUDE.md\` gains a "Frontend Tests (Vitest)" section that documents the JS test layer alongside Pest, including the visibility-injection pattern and the \`composer test\` ⇄ \`npm run test\` separation.

## Why

#157 was carved out of #55 (\"Implement 30s polling honoring document.visibilityState\"). #55 shipped without a JS test because the project had no Vitest infra yet — Vitest was later set up in passing, but the explicit reference test for the polling-visibility contract had never been written. This is the third and final PRD-004 risk-list item that blocks the \`dev → main\` release of PRD-001..004; once it lands, all three open dashboard risks (#83 timezone, #84 selection cleanup, #157 polling test) are closed and the release window opens.

Closes #157

## Test plan

- [x] \`npm run test\` — 33 / 33 green (4 new \`usePagePolling\` tests, all existing tests still passing)
- [x] \`php artisan test\` — 406 / 406 green (Dashboard.vue refactor is behaviour-preserving)
- [x] \`./vendor/bin/pint --test\` — pass
- [x] \`npm run lint && npm run format:check\` — clean
- [x] \`npm run build\` — vue-tsc + Vite build clean

## Acceptance criteria check (Issue #157)

- [x] Vitest installed as dev dependency (already done in passing earlier; verified)
- [x] \`vitest.config.ts\` configured with the same path aliases as Vite (already in place)
- [x] \`happy-dom\` environment so Vue composables that touch \`document\` work
- [x] One reference test exists that asserts dashboard polling pauses while \`document.visibilityState === 'hidden'\` and resumes on \`visible\` (extracted polling code into a composable for cleanliness)
- [x] \`composer test\` does not trigger Vitest — JS tests run via \`npm run test\`
- [x] CLAUDE.md updated with a "Frontend Tests (Vitest)" section