### PR TITLE
#64 Add AI reply assistant config scaffolding

### DIFF
--- a/config/reservations.php
+++ b/config/reservations.php
@@ -19,4 +19,48 @@ return [
             'retention_days' => (int) env('FAILED_EMAIL_IMPORTS_RETENTION_DAYS', 30),
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | AI reply assistant (PRD-005)
+    |--------------------------------------------------------------------------
+    |
+    | Configuration for the OpenAI-powered draft reply generator. Laravel
+    | computes availability deterministically; the AI only formulates the
+    | text. The tonality prompts are placeholders until the pilot restaurant
+    | finalises them (see issue #80).
+    |
+    */
+    'ai' => [
+        'openai_model' => env('OPENAI_MODEL', 'gpt-4o-mini'),
+
+        'tonality_prompts' => [
+            'formal' => 'Du schreibst im Namen eines gehobenen Restaurants. '
+                .'Sprich den Gast in der Sie-Form an, halte die Sprache zurückhaltend, '
+                .'sachlich und respektvoll. Vermeide Umgangssprache. (Platzhalter – '
+                .'finaler Text wird mit Pilot-Restaurant abgestimmt.)',
+            'casual' => 'Du schreibst im Namen eines entspannten Bistros. Sprich den '
+                .'Gast in der Sie-Form an, halte den Ton freundlich und unkompliziert. '
+                .'(Platzhalter – finaler Text wird mit Pilot-Restaurant abgestimmt.)',
+            'family' => 'Du schreibst im Namen eines familienfreundlichen Restaurants. '
+                .'Sprich den Gast in der Sie-Form an, halte die Sprache warm und '
+                .'einladend. (Platzhalter – finaler Text wird mit Pilot-Restaurant '
+                .'abgestimmt.)',
+        ],
+
+        /*
+        | Constant rules appended to every system prompt regardless of
+        | tonality. These guardrails are the single source of truth and are
+        | consumed by OpenAiReplyGenerator. Do not duplicate them elsewhere.
+        */
+        'system_prompt_rules' => [
+            'Antworte ausschließlich auf Deutsch.',
+            'Verwende NUR die im User-JSON enthaltenen Zahlen und Zeiten. Erfinde keine eigenen.',
+            'Wenn `is_open_at_desired_time` = false, biete höflich die `alternative_slots` an oder verweise auf `closed_reason`.',
+            'Wenn `seats_free_at_desired` < `request.party_size`, lehne höflich ab und biete Alternativen an.',
+            'Antworte in maximal 120 Wörtern.',
+            'Keine Emojis, keine Hashtags, keine Marketing-Phrasen.',
+            'Beginne mit Anrede („Guten Tag [Name],"), ende mit Grußformel und Restaurant-Name.',
+        ],
+    ],
 ];

--- a/tests/Unit/Config/ReservationsAiConfigTest.php
+++ b/tests/Unit/Config/ReservationsAiConfigTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Config;
+
+use App\Enums\Tonality;
+use Tests\TestCase;
+
+/**
+ * Guards the AI block in config/reservations.php (Issue #64).
+ *
+ * Acts as the single source of truth for tonality prompts and the
+ * constant system-prompt rules consumed by OpenAiReplyGenerator. If any
+ * tonality enum case has no corresponding non-empty prompt the AI
+ * generator would silently send an unguided system prompt to OpenAI.
+ */
+class ReservationsAiConfigTest extends TestCase
+{
+    public function test_openai_model_falls_back_to_gpt_4o_mini(): void
+    {
+        $this->assertSame('gpt-4o-mini', config('reservations.ai.openai_model'));
+    }
+
+    public function test_every_tonality_case_has_a_non_empty_prompt(): void
+    {
+        $prompts = config('reservations.ai.tonality_prompts');
+
+        $this->assertIsArray($prompts);
+
+        foreach (Tonality::cases() as $tonality) {
+            $this->assertArrayHasKey(
+                $tonality->value,
+                $prompts,
+                "Missing tonality prompt for '{$tonality->value}'."
+            );
+
+            $this->assertIsString($prompts[$tonality->value]);
+            $this->assertNotSame('', trim($prompts[$tonality->value]));
+        }
+    }
+
+    public function test_system_prompt_rules_are_a_non_empty_list_of_strings(): void
+    {
+        $rules = config('reservations.ai.system_prompt_rules');
+
+        $this->assertIsArray($rules);
+        $this->assertNotEmpty($rules);
+
+        foreach ($rules as $rule) {
+            $this->assertIsString($rule);
+            $this->assertNotSame('', trim($rule));
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Extends `config/reservations.php` with an `ai` block: `openai_model` (env-driven), tonality prompt placeholders for the three `Tonality` enum cases, and constant system-prompt rules consumed by the upcoming `OpenAiReplyGenerator`.
- Adds `tests/Unit/Config/ReservationsAiConfigTest.php` to lock the config shape and ensure every Tonality case has a non-empty prompt.

## Why
Foundational config for PRD-005. Centralising tonality prompts and constant rules keeps the AI generator wiring deterministic and replaceable. Placeholder prompt texts are intentional — they will be finalised with the pilot restaurant in #80.

## Decision
Reused the existing `config/reservations.php` (plural) instead of creating a parallel `config/reservation.php` to match the established convention already referenced by `PruneFailedEmailImportsJob`.

## Test plan
- [x] `php artisan test --filter=ReservationsAiConfigTest` (3 passed, 27 assertions)
- [x] Full suite: `php artisan test` (412 passed)
- [x] `./vendor/bin/pint --test`

Closes #64