### PR TITLE
Add ReservationContextBuilder for deterministic AI input (#65)

### DIFF
--- a/app/Services/AI/ReservationContextBuilder.php
+++ b/app/Services/AI/ReservationContextBuilder.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+use App\Models\ReservationRequest;
+use App\Support\OpeningHours;
+
+/**
+ * Deterministic producer of the Context-JSON consumed by the AI reply
+ * generator (PRD-005).
+ *
+ * Every number in the output comes from Laravel — never from the AI. The
+ * builder is intentionally pure (no external IO besides DB reads via the
+ * already-loaded models) so it can be unit-tested without OpenAI.
+ *
+ * Output shape:
+ *
+ *   restaurant   → name, tonality
+ *   request      → guest_name, party_size, desired_at (restaurant local time), message
+ *   availability → is_open_at_desired_time, seats_free_at_desired,
+ *                  alternative_slots, closed_reason
+ */
+final class ReservationContextBuilder
+{
+    /**
+     * @return array{
+     *     restaurant: array{name: string, tonality: string},
+     *     request: array{guest_name: string, party_size: int, desired_at: ?string, message: ?string},
+     *     availability: array{is_open_at_desired_time: bool, seats_free_at_desired: int, alternative_slots: list<string>, closed_reason: ?string}
+     * }
+     */
+    public function build(ReservationRequest $request): array
+    {
+        $restaurant = $request->restaurant;
+        $hours = OpeningHours::fromRestaurant($restaurant);
+        $desiredAt = $request->desired_at;
+
+        $isOpen = $desiredAt !== null && $hours->isOpenAt($desiredAt);
+        $closedReason = $desiredAt !== null ? $hours->closedReasonAt($desiredAt) : null;
+
+        // availableSeatsAt() returns null when the restaurant is closed at
+        // that time. Per PRD-005, we surface 0 to the AI in that case so the
+        // "decline / suggest alternatives" branch triggers naturally.
+        $seatsFree = $desiredAt !== null
+            ? ($restaurant->availableSeatsAt($desiredAt) ?? 0)
+            : 0;
+
+        $localDesiredAt = $desiredAt?->copy()->setTimezone($restaurant->timezone);
+
+        return [
+            'restaurant' => [
+                'name' => $restaurant->name,
+                'tonality' => $restaurant->tonality->value,
+            ],
+            'request' => [
+                'guest_name' => $request->guest_name,
+                'party_size' => $request->party_size,
+                'desired_at' => $localDesiredAt?->format('Y-m-d H:i'),
+                'message' => $request->message,
+            ],
+            'availability' => [
+                'is_open_at_desired_time' => $isOpen,
+                'seats_free_at_desired' => $seatsFree,
+                // Alternative-slot generation is implemented in #67. For #65
+                // the field is present (per the documented shape) but empty.
+                'alternative_slots' => [],
+                'closed_reason' => $closedReason,
+            ],
+        ];
+    }
+}

--- a/app/Support/OpeningHours.php
+++ b/app/Support/OpeningHours.php
@@ -73,6 +73,30 @@ final class OpeningHours
         return false;
     }
 
+    /**
+     * Reason the restaurant is closed at the given moment, or null if it is
+     * open. Discriminates between a Ruhetag (no blocks for the weekday at
+     * all) and a closed time slot on an otherwise opened day.
+     *
+     * Return values match the `closed_reason` enum used in
+     * `ReservationContextBuilder` (PRD-005):
+     *   null                          → open
+     *   'ruhetag'                     → no opening blocks for this weekday
+     *   'ausserhalb_oeffnungszeiten'  → outside the day's opening blocks
+     */
+    public function closedReasonAt(CarbonInterface $time): ?string
+    {
+        if ($this->isOpenAt($time)) {
+            return null;
+        }
+
+        $local = $time->copy()->setTimezone($this->timezone);
+        $dayKey = self::DAY_KEYS[(int) $local->dayOfWeek];
+        $blocks = $this->schedule[$dayKey] ?? [];
+
+        return $blocks === [] ? 'ruhetag' : 'ausserhalb_oeffnungszeiten';
+    }
+
     private function toMinutes(string $hhmm): int
     {
         [$h, $m] = explode(':', $hhmm);

--- a/tests/Unit/Services/AI/ReservationContextBuilderTest.php
+++ b/tests/Unit/Services/AI/ReservationContextBuilderTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Enums\ReservationStatus;
+use App\Enums\Tonality;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\AI\ReservationContextBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class ReservationContextBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ReservationContextBuilder $builder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->builder = new ReservationContextBuilder;
+    }
+
+    public function test_it_returns_full_context_shape_for_an_open_time_window(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'name' => 'La Trattoria',
+            'capacity' => 40,
+            'tonality' => Tonality::Casual,
+            'timezone' => 'Europe/Berlin',
+        ]);
+
+        // Wednesday 19:30 local time → inside the dinner block (18:00-22:30).
+        $desiredAt = Carbon::parse('2026-05-13 19:30', 'Europe/Berlin')->utc();
+
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_name' => 'Anna Müller',
+            'party_size' => 4,
+            'desired_at' => $desiredAt,
+            'message' => 'Möglichst Fensterplatz, danke.',
+        ]);
+
+        $context = $this->builder->build($request);
+
+        $this->assertSame('La Trattoria', $context['restaurant']['name']);
+        $this->assertSame('casual', $context['restaurant']['tonality']);
+
+        $this->assertSame('Anna Müller', $context['request']['guest_name']);
+        $this->assertSame(4, $context['request']['party_size']);
+        $this->assertSame('2026-05-13 19:30', $context['request']['desired_at']);
+        $this->assertSame('Möglichst Fensterplatz, danke.', $context['request']['message']);
+
+        $this->assertTrue($context['availability']['is_open_at_desired_time']);
+        $this->assertSame(40, $context['availability']['seats_free_at_desired']);
+        $this->assertSame([], $context['availability']['alternative_slots']);
+        $this->assertNull($context['availability']['closed_reason']);
+    }
+
+    public function test_it_subtracts_confirmed_party_sizes_from_seats_free(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'capacity' => 40,
+            'timezone' => 'Europe/Berlin',
+        ]);
+
+        $desiredAt = Carbon::parse('2026-05-13 19:30', 'Europe/Berlin')->utc();
+
+        // A confirmed reservation 30min later inside the ±2h window blocks 6 seats.
+        ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'status' => ReservationStatus::Confirmed,
+            'party_size' => 6,
+            'desired_at' => $desiredAt->copy()->addMinutes(30),
+        ]);
+
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'party_size' => 2,
+            'desired_at' => $desiredAt,
+        ]);
+
+        $context = $this->builder->build($request);
+
+        $this->assertSame(34, $context['availability']['seats_free_at_desired']);
+    }
+
+    public function test_it_flags_outside_opening_hours_as_closed_reason(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'timezone' => 'Europe/Berlin',
+        ]);
+
+        // Wednesday 16:00 local — between lunch (until 14:30) and dinner (from 18:00).
+        $desiredAt = Carbon::parse('2026-05-13 16:00', 'Europe/Berlin')->utc();
+
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'desired_at' => $desiredAt,
+        ]);
+
+        $context = $this->builder->build($request);
+
+        $this->assertFalse($context['availability']['is_open_at_desired_time']);
+        $this->assertSame('ausserhalb_oeffnungszeiten', $context['availability']['closed_reason']);
+        $this->assertSame(0, $context['availability']['seats_free_at_desired']);
+    }
+
+    public function test_it_flags_ruhetag_as_closed_reason(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'timezone' => 'Europe/Berlin',
+        ]);
+
+        // Tuesday is the Ruhetag (empty schedule in the factory).
+        $desiredAt = Carbon::parse('2026-05-12 19:30', 'Europe/Berlin')->utc();
+
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'desired_at' => $desiredAt,
+        ]);
+
+        $context = $this->builder->build($request);
+
+        $this->assertFalse($context['availability']['is_open_at_desired_time']);
+        $this->assertSame('ruhetag', $context['availability']['closed_reason']);
+        $this->assertSame([], $context['availability']['alternative_slots']);
+    }
+
+    public function test_desired_at_is_returned_in_restaurant_local_time_even_when_request_is_utc(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'timezone' => 'Europe/Berlin',
+        ]);
+
+        // 17:30 UTC == 19:30 Europe/Berlin (CEST, summer offset).
+        $desiredAtUtc = Carbon::parse('2026-05-13 17:30', 'UTC');
+
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'desired_at' => $desiredAtUtc,
+        ]);
+
+        $context = $this->builder->build($request);
+
+        $this->assertSame('2026-05-13 19:30', $context['request']['desired_at']);
+    }
+}


### PR DESCRIPTION
## Summary

- New `App\Services\AI\ReservationContextBuilder` builds the deterministic context JSON consumed by the OpenAI generator (PRD-005).
- Output keys match the PRD exactly: `restaurant`, `request`, `availability` with `is_open_at_desired_time`, `seats_free_at_desired`, `alternative_slots`, `closed_reason`.
- `OpeningHours` gains a `closedReasonAt()` helper that distinguishes Ruhetag from outside-opening-hours so the builder doesn't duplicate the weekday logic.
- Alternative-slot generation is intentionally stubbed to `[]` here — issue #67 fills it.

## Why

The whole AI guarantee depends on Laravel computing every number that lands in the prompt. This service is the single source of truth for that data so the OpenAI client can stay text-only.

## Test plan

- [x] `php artisan test tests/Unit/Services/AI/ReservationContextBuilderTest.php` — 5 cases: full shape, capacity subtraction, outside opening hours, Ruhetag, timezone correctness
- [x] `php artisan test` — full suite green (417 passed)
- [x] `./vendor/bin/pint --test` — clean
- [x] `npm run lint` / `npm run format:check` — clean

Closes #65