### PR TITLE
Generate alternative_slots in AI context builder (#67)

### DIFF
--- a/app/Services/AI/ReservationContextBuilder.php
+++ b/app/Services/AI/ReservationContextBuilder.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Services\AI;
 
 use App\Models\ReservationRequest;
+use App\Models\Restaurant;
 use App\Support\OpeningHours;
+use Carbon\CarbonInterface;
 
 /**
  * Deterministic producer of the Context-JSON consumed by the AI reply
@@ -24,6 +26,12 @@ use App\Support\OpeningHours;
  */
 final class ReservationContextBuilder
 {
+    /** Spacing between candidate alternative slots, in minutes (PRD-005). */
+    private const int SLOT_STEP_MINUTES = 30;
+
+    /** Maximum number of alternative slots returned to the AI prompt. */
+    private const int MAX_ALTERNATIVE_SLOTS = 3;
+
     /**
      * @return array{
      *     restaurant: array{name: string, tonality: string},
@@ -63,11 +71,66 @@ final class ReservationContextBuilder
             'availability' => [
                 'is_open_at_desired_time' => $isOpen,
                 'seats_free_at_desired' => $seatsFree,
-                // Alternative-slot generation is implemented in #67. For #65
-                // the field is present (per the documented shape) but empty.
-                'alternative_slots' => [],
+                'alternative_slots' => $desiredAt === null
+                    ? []
+                    : $this->alternativeSlots($restaurant, $desiredAt, $request->party_size),
                 'closed_reason' => $closedReason,
             ],
         ];
+    }
+
+    /**
+     * Up to MAX_ALTERNATIVE_SLOTS candidate slots on the same restaurant-local
+     * day, spaced SLOT_STEP_MINUTES apart, that:
+     *   - lie inside an opening block,
+     *   - have at least $partySize seats free,
+     *   - are not the exact desired time.
+     *
+     * Sorted by absolute distance to the desired time (closest first).
+     * Returns `[]` when the day has no opening blocks (Ruhetag).
+     *
+     * @return list<string> Carbon `Y-m-d H:i` formatted strings in restaurant local time.
+     */
+    private function alternativeSlots(Restaurant $restaurant, CarbonInterface $desiredAt, int $partySize): array
+    {
+        $hours = OpeningHours::fromRestaurant($restaurant);
+        $blocks = $hours->blocksAt($desiredAt);
+
+        if ($blocks === []) {
+            return [];
+        }
+
+        $local = $desiredAt->copy()->setTimezone($restaurant->timezone);
+        $desiredKey = $local->format('Y-m-d H:i');
+
+        $eligible = [];
+        foreach ($blocks as $block) {
+            $start = $local->copy()->setTimeFromTimeString($block['from']);
+            $end = $local->copy()->setTimeFromTimeString($block['to']);
+
+            for ($cursor = $start->copy(); $cursor->lt($end); $cursor->addMinutes(self::SLOT_STEP_MINUTES)) {
+                if ($cursor->format('Y-m-d H:i') === $desiredKey) {
+                    continue;
+                }
+
+                $seats = $restaurant->availableSeatsAt($cursor);
+                if ($seats === null || $seats < $partySize) {
+                    continue;
+                }
+
+                $eligible[] = $cursor->copy();
+            }
+        }
+
+        usort(
+            $eligible,
+            fn (CarbonInterface $a, CarbonInterface $b): int => abs($a->diffInSeconds($local))
+                <=> abs($b->diffInSeconds($local))
+        );
+
+        return array_map(
+            fn (CarbonInterface $slot): string => $slot->format('Y-m-d H:i'),
+            array_slice($eligible, 0, self::MAX_ALTERNATIVE_SLOTS)
+        );
     }
 }

--- a/app/Support/OpeningHours.php
+++ b/app/Support/OpeningHours.php
@@ -84,6 +84,20 @@ final class OpeningHours
      *   'ruhetag'                     → no opening blocks for this weekday
      *   'ausserhalb_oeffnungszeiten'  → outside the day's opening blocks
      */
+    /**
+     * Opening blocks for the restaurant-local day that contains $time.
+     * Returns an empty array on a Ruhetag.
+     *
+     * @return array<int, array{from: string, to: string}>
+     */
+    public function blocksAt(CarbonInterface $time): array
+    {
+        $local = $time->copy()->setTimezone($this->timezone);
+        $dayKey = self::DAY_KEYS[(int) $local->dayOfWeek];
+
+        return $this->schedule[$dayKey] ?? [];
+    }
+
     public function closedReasonAt(CarbonInterface $time): ?string
     {
         if ($this->isOpenAt($time)) {

--- a/tests/Unit/Services/AI/ReservationContextBuilderAlternativeSlotsTest.php
+++ b/tests/Unit/Services/AI/ReservationContextBuilderAlternativeSlotsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\AI\ReservationContextBuilder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+/**
+ * Coverage for the `alternative_slots` field of the AI context (PRD-005 /
+ * issue #67). The builder must offer up to three free 30-min-spaced slots
+ * inside the day's opening hours, sorted closest-first to the desired
+ * time, excluding the desired time itself, and `[]` on a Ruhetag.
+ */
+class ReservationContextBuilderAlternativeSlotsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private ReservationContextBuilder $builder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->builder = new ReservationContextBuilder;
+    }
+
+    private function makeRestaurant(int $capacity = 40): Restaurant
+    {
+        return Restaurant::factory()->create([
+            'capacity' => $capacity,
+            'timezone' => 'Europe/Berlin',
+        ]);
+    }
+
+    /** Build for a Berlin-local desired time (passed as UTC for cast safety). */
+    private function buildFor(Restaurant $restaurant, Carbon $desiredAtUtc, int $partySize = 4): array
+    {
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'desired_at' => $desiredAtUtc,
+            'party_size' => $partySize,
+        ]);
+
+        return $this->builder->build($request);
+    }
+
+    public function test_returns_three_closest_free_slots_on_an_empty_evening(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // 19:00 Berlin == 17:00 UTC on Wednesday — dinner block 18:00–22:30.
+        $context = $this->buildFor($restaurant, Carbon::create(2026, 5, 13, 17, 0, 0, 'UTC'));
+
+        $slots = $context['availability']['alternative_slots'];
+
+        $this->assertCount(3, $slots);
+        // Closest 30-min slots to 19:00 in [18:00, 22:30): 18:30, 19:30, 18:00.
+        $this->assertSame(['2026-05-13 18:30', '2026-05-13 19:30', '2026-05-13 18:00'], $slots);
+    }
+
+    public function test_excludes_the_exact_desired_time(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // 18:30 Berlin (16:30 UTC) is itself a 30-min slot — must not appear.
+        $context = $this->buildFor($restaurant, Carbon::create(2026, 5, 13, 16, 30, 0, 'UTC'));
+
+        $slots = $context['availability']['alternative_slots'];
+
+        $this->assertNotContains('2026-05-13 18:30', $slots);
+    }
+
+    public function test_returns_empty_on_ruhetag(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // Tuesday 2026-05-12 is the factory's Ruhetag.
+        $context = $this->buildFor($restaurant, Carbon::create(2026, 5, 12, 17, 30, 0, 'UTC'));
+
+        $this->assertSame([], $context['availability']['alternative_slots']);
+    }
+
+    public function test_skips_slots_where_party_does_not_fit(): void
+    {
+        $restaurant = $this->makeRestaurant(capacity: 10);
+
+        // Block 18:30 Berlin (16:30 UTC) by confirming an 8-seat party there.
+        // For a party of 4, that slot has only 2 free → not eligible.
+        ReservationRequest::factory()->confirmed()->forRestaurant($restaurant)->create([
+            'desired_at' => Carbon::create(2026, 5, 13, 16, 30, 0, 'UTC'),
+            'party_size' => 8,
+        ]);
+
+        // Desired 19:00 Berlin (17:00 UTC), party of 4.
+        $context = $this->buildFor($restaurant, Carbon::create(2026, 5, 13, 17, 0, 0, 'UTC'), partySize: 4);
+
+        $slots = $context['availability']['alternative_slots'];
+
+        $this->assertNotContains('2026-05-13 18:30', $slots);
+    }
+
+    public function test_each_returned_slot_is_inside_an_opening_block(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        $context = $this->buildFor($restaurant, Carbon::create(2026, 5, 13, 17, 0, 0, 'UTC'));
+
+        // Wed dinner block: 18:00–22:30 inclusive of from, exclusive of to.
+        foreach ($context['availability']['alternative_slots'] as $slot) {
+            $time = Carbon::createFromFormat('Y-m-d H:i', $slot, 'Europe/Berlin');
+            $this->assertNotNull($time);
+
+            $minutes = $time->hour * 60 + $time->minute;
+            $insideLunch = $minutes >= 11 * 60 + 30 && $minutes < 14 * 60 + 30;
+            $insideDinner = $minutes >= 18 * 60 && $minutes < 22 * 60 + 30;
+
+            $this->assertTrue(
+                $insideLunch || $insideDinner,
+                "Slot {$slot} is outside Wednesday's opening blocks."
+            );
+        }
+    }
+
+    public function test_slots_are_ordered_closest_first(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // Desired 20:00 Berlin (18:00 UTC) — closest 3 free 30-min slots in
+        // [18:00, 22:30) excluding 20:00 itself: 19:30, 20:30, 19:00.
+        $context = $this->buildFor($restaurant, Carbon::create(2026, 5, 13, 18, 0, 0, 'UTC'));
+
+        $this->assertSame(
+            ['2026-05-13 19:30', '2026-05-13 20:30', '2026-05-13 19:00'],
+            $context['availability']['alternative_slots']
+        );
+    }
+
+    public function test_returns_at_most_three_slots_even_when_many_are_eligible(): void
+    {
+        $restaurant = $this->makeRestaurant();
+
+        // Wednesday 19:00 — the Wed schedule has lunch 11:30–14:30 and
+        // dinner 18:00–22:30, so plenty of free 30-min slots exist.
+        $context = $this->buildFor($restaurant, Carbon::create(2026, 5, 13, 17, 0, 0, 'UTC'));
+
+        $this->assertLessThanOrEqual(3, count($context['availability']['alternative_slots']));
+    }
+}

--- a/tests/Unit/Services/AI/ReservationContextBuilderTest.php
+++ b/tests/Unit/Services/AI/ReservationContextBuilderTest.php
@@ -58,7 +58,7 @@ class ReservationContextBuilderTest extends TestCase
 
         $this->assertTrue($context['availability']['is_open_at_desired_time']);
         $this->assertSame(40, $context['availability']['seats_free_at_desired']);
-        $this->assertSame([], $context['availability']['alternative_slots']);
+        $this->assertIsArray($context['availability']['alternative_slots']);
         $this->assertNull($context['availability']['closed_reason']);
     }
 


### PR DESCRIPTION
## Summary

- Implements `alternativeSlots()` in `ReservationContextBuilder`: up to 3 free 30-min-spaced candidate slots inside the same restaurant-local day, sorted closest-first, excluding the desired time itself.
- Returns `[]` on Ruhetag.
- New `OpeningHours::blocksAt()` helper exposes the day's opening blocks so the builder can iterate without duplicating the weekday-key logic.
- The #65 happy-path test now asserts the field is an array (the feature populates it on a free evening).

## Why

PRD-005 lists `alternative_slots` as a required acceptance criterion. The earlier stub (`[]`) would have left the AI prompt unable to suggest alternatives when the desired time isn't available. This closes that gap with deterministic Laravel-side generation — the AI never invents times.

## Test plan

- [x] `php artisan test tests/Unit/Services/AI/` — 20 cases (5 + 8 + 7) green
- [x] `php artisan test` — full suite green (432 passed)
- [x] `./vendor/bin/pint --test` — clean

Closes #67