### PR TITLE
Add OpenAiReplyGenerator with safe fallback (#68)

### DIFF
--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+use OpenAI\Contracts\ClientContract;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Stateless service that turns a deterministic Context-JSON (produced by
+ * `ReservationContextBuilder`) into a German reply text via OpenAI Chat
+ * Completions.
+ *
+ * On ANY error path — empty completion, network failure, 401, 429, 5xx,
+ * timeout, malformed payload — the generator returns the same neutral
+ * fallback so the caller never raises and the AI prompt branch always
+ * yields a string. The granular error matrix (admin notification on 401,
+ * one retry on 429) lives outside this service in #71.
+ *
+ * Logging hygiene: only `$e->getMessage()` is logged. No API key, no
+ * Authorization header, no full context payload, no guest data.
+ */
+final class OpenAiReplyGenerator
+{
+    public const string FALLBACK_TEXT = 'Vielen Dank für Ihre Anfrage. Wir melden uns in Kürze persönlich bei Ihnen.';
+
+    private const float TEMPERATURE = 0.4;
+
+    public function __construct(
+        private readonly ClientContract $client,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $context  the JSON produced by
+     *                                         ReservationContextBuilder::build()
+     */
+    public function generate(array $context): string
+    {
+        try {
+            $tonality = $this->extractTonality($context);
+
+            $response = $this->client->chat()->create([
+                'model' => config('reservations.ai.openai_model', 'gpt-4o-mini'),
+                'temperature' => self::TEMPERATURE,
+                'messages' => [
+                    ['role' => 'system', 'content' => $this->systemPrompt($tonality)],
+                    ['role' => 'user', 'content' => json_encode($context, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)],
+                ],
+            ]);
+
+            $content = trim((string) ($response->choices[0]->message->content ?? ''));
+
+            return $content !== '' ? $content : self::FALLBACK_TEXT;
+        } catch (Throwable $e) {
+            $this->logger->warning('openai reply generation failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return self::FALLBACK_TEXT;
+        }
+    }
+
+    /**
+     * Build the system prompt from the tonality block plus the constant
+     * rules that apply regardless of tonality (German-only, no invented
+     * numbers, salutation/sign-off, etc.).
+     */
+    private function systemPrompt(string $tonality): string
+    {
+        /** @var array<string, string> $tonalityPrompts */
+        $tonalityPrompts = config('reservations.ai.tonality_prompts', []);
+        /** @var list<string> $rules */
+        $rules = config('reservations.ai.system_prompt_rules', []);
+
+        $tonalityBlock = $tonalityPrompts[$tonality] ?? '';
+        $rulesBlock = implode("\n", array_map(static fn (string $rule): string => '- '.$rule, $rules));
+
+        return trim($tonalityBlock."\n\n".$rulesBlock);
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function extractTonality(array $context): string
+    {
+        $tonality = $context['restaurant']['tonality'] ?? null;
+
+        return is_string($tonality) ? $tonality : 'casual';
+    }
+}

--- a/tests/Unit/Services/AI/OpenAiReplyGeneratorTest.php
+++ b/tests/Unit/Services/AI/OpenAiReplyGeneratorTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Services\AI\OpenAiReplyGenerator;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Resources\Chat;
+use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Testing\ClientFake;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Tests\TestCase;
+
+class OpenAiReplyGeneratorTest extends TestCase
+{
+    /**
+     * Sentinel API key value used to verify the key never leaks into log
+     * lines or exception messages, even on the error path.
+     */
+    private const string LEAK_SENTINEL = 'sk-test-LEAK-CHECK-12345';
+
+    private function makeContext(string $tonality = 'casual'): array
+    {
+        return [
+            'restaurant' => [
+                'name' => 'La Trattoria',
+                'tonality' => $tonality,
+            ],
+            'request' => [
+                'guest_name' => 'Anna Müller',
+                'party_size' => 4,
+                'desired_at' => '2026-05-13 19:30',
+                'message' => 'Möglichst Fensterplatz, danke.',
+            ],
+            'availability' => [
+                'is_open_at_desired_time' => true,
+                'seats_free_at_desired' => 12,
+                'alternative_slots' => [],
+                'closed_reason' => null,
+            ],
+        ];
+    }
+
+    private function makeGenerator(ClientFake $fake): OpenAiReplyGenerator
+    {
+        return new OpenAiReplyGenerator($fake, new NullLogger);
+    }
+
+    public function test_it_returns_the_trimmed_assistant_content(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    [
+                        'index' => 0,
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => "  Guten Tag Anna,\n\nwir haben um 19:30 einen Tisch frei.\n\nViele Grüße  ",
+                        ],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $reply = $this->makeGenerator($fake)->generate($this->makeContext());
+
+        $this->assertSame(
+            "Guten Tag Anna,\n\nwir haben um 19:30 einen Tisch frei.\n\nViele Grüße",
+            $reply
+        );
+    }
+
+    public function test_it_sends_the_context_json_as_the_user_message_and_a_system_prompt(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        $context = $this->makeContext('formal');
+
+        $this->makeGenerator($fake)->generate($context);
+
+        $fake->assertSent(Chat::class, function (string $method, array $params) use ($context): bool {
+            if ($method !== 'create') {
+                return false;
+            }
+
+            $messages = $params['messages'] ?? [];
+            if (count($messages) !== 2) {
+                return false;
+            }
+
+            // System message MUST contain the formal tonality prompt and at least
+            // one of the constant rules from config.
+            $system = $messages[0]['content'] ?? '';
+            $expectedTonality = config('reservations.ai.tonality_prompts.formal');
+            if (! str_contains($system, $expectedTonality) || ! str_contains($system, 'Antworte ausschließlich auf Deutsch.')) {
+                return false;
+            }
+
+            // User message MUST be the context JSON byte-for-byte.
+            $expectedJson = json_encode($context, JSON_UNESCAPED_UNICODE);
+            if (($messages[1]['content'] ?? null) !== $expectedJson) {
+                return false;
+            }
+
+            return ($params['temperature'] ?? null) === 0.4;
+        });
+    }
+
+    public function test_it_falls_back_when_the_response_content_is_empty(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => '   '], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        $reply = $this->makeGenerator($fake)->generate($this->makeContext());
+
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply);
+    }
+
+    public function test_it_falls_back_when_the_client_throws(): void
+    {
+        $fake = OpenAI::fake([
+            new RuntimeException('connection refused'),
+        ]);
+
+        $reply = $this->makeGenerator($fake)->generate($this->makeContext());
+
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply);
+    }
+
+    public function test_the_api_key_never_appears_in_log_output(): void
+    {
+        config()->set('openai.api_key', self::LEAK_SENTINEL);
+
+        $captured = [];
+        Log::shouldReceive('warning')->andReturnUsing(function (string $message, array $context) use (&$captured): void {
+            $captured[] = ['message' => $message, 'context' => $context];
+        });
+        Log::shouldReceive('debug')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+
+        $fake = OpenAI::fake([
+            new RuntimeException('boom — no key here either'),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, Log::getFacadeRoot());
+
+        $generator->generate($this->makeContext());
+
+        $serialized = json_encode($captured, JSON_UNESCAPED_UNICODE);
+        $this->assertNotFalse($serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $serialized);
+    }
+}


### PR DESCRIPTION
## Summary

- New \`App\Services\AI\OpenAiReplyGenerator\` (stateless, final, ClientContract + LoggerInterface DI).
- \`generate(array \$context): string\` calls Chat Completions with model from config, temperature 0.4, system+user message pair.
- Uniform fallback (\`FALLBACK_TEXT\`) on any \`Throwable\`, on empty/whitespace-only content, and on JSON encoding failures.
- Logs \`\$e->getMessage()\` only — no key, no headers, no context payload — and a sentinel-key test verifies the key never leaks.
- System prompt assembled from \`reservations.ai.tonality_prompts\` + \`reservations.ai.system_prompt_rules\` (both wired in #64).

## Why

PRD-005's \"Laravel decides, AI formulates\" guarantee depends on this service never propagating an exception. Whatever OpenAI does, the caller gets a string; the granular error matrix (401 admin notice, 429 retry) is layered on top in #71.

## Test plan

- [x] \`php artisan test tests/Unit/Services/AI/OpenAiReplyGeneratorTest.php\` — 5 cases: trim, payload assertion, empty-content fallback, throwable fallback, sentinel-key leak check
- [x] \`php artisan test\` — full suite green (437 passed)
- [x] \`./vendor/bin/pint --test\` — clean

Closes #68