### PR TITLE
Wire ReservationRequestReceived to AI draft generation (#70)

### DIFF
--- a/app/Jobs/GenerateReservationReplyJob.php
+++ b/app/Jobs/GenerateReservationReplyJob.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\ReservationReplyStatus;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Services\AI\Contracts\ReplyGenerator;
+use App\Services\AI\OpenAiReplyGenerator;
+use App\Services\AI\ReservationContextBuilder;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Builds the deterministic Context-JSON for a reservation request and
+ * persists the AI-drafted reply (PRD-005).
+ *
+ * On the happy path: the OpenAI generator returns a string, the reply is
+ * saved as `draft`, the snapshot retains the exact JSON sent to OpenAI.
+ *
+ * On any failure inside this job — dependency resolution, context build,
+ * generator call, persistence — the request is flagged
+ * `needs_manual_review = true` AND a draft reply with the fallback text is
+ * still stored. This guarantees that the dashboard always has something
+ * to show next to a request, and a human is paged via the manual-review
+ * flag.
+ *
+ * Dependencies are resolved inside `handle()` (rather than via parameter
+ * injection on the job's `handle` signature) so a missing OPENAI_API_KEY
+ * is caught by this job's try-block and turned into a manual-review row,
+ * instead of bubbling out of the worker as an uncaught exception during
+ * sync-queue execution.
+ */
+final class GenerateReservationReplyJob implements ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 1;
+
+    public int $timeout = 30;
+
+    public function __construct(public int $reservationRequestId) {}
+
+    public function handle(): void
+    {
+        /** @var LoggerInterface $logger */
+        $logger = app(LoggerInterface::class);
+
+        $request = ReservationRequest::withoutGlobalScopes()->find($this->reservationRequestId);
+        if ($request === null) {
+            return;
+        }
+
+        $context = null;
+        try {
+            $builder = app(ReservationContextBuilder::class);
+            $generator = app(ReplyGenerator::class);
+
+            $context = $builder->build($request);
+            $body = $generator->generate($context);
+
+            ReservationReply::create([
+                'reservation_request_id' => $request->id,
+                'status' => ReservationReplyStatus::Draft,
+                'body' => $body,
+                'ai_prompt_snapshot' => $context,
+            ]);
+        } catch (Throwable $e) {
+            // Log without leaking the context payload — only the error
+            // message and the request id end up in the log line.
+            $logger->warning('reservation.reply.generate_failed', [
+                'reservation_request_id' => $request->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            $request->forceFill(['needs_manual_review' => true])->save();
+
+            ReservationReply::create([
+                'reservation_request_id' => $request->id,
+                'status' => ReservationReplyStatus::Draft,
+                'body' => OpenAiReplyGenerator::FALLBACK_TEXT,
+                'ai_prompt_snapshot' => $context,
+            ]);
+        }
+    }
+}

--- a/app/Listeners/GenerateReservationReplyListener.php
+++ b/app/Listeners/GenerateReservationReplyListener.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\ReservationRequestReceived;
+use App\Jobs\GenerateReservationReplyJob;
+
+/**
+ * Bridges the domain event `ReservationRequestReceived` to the queued
+ * draft-generation job. Lives in its own class (not a closure listener)
+ * so the wiring can be auto-discovered and unit-tested without booting
+ * the queue.
+ */
+final class GenerateReservationReplyListener
+{
+    public function handle(ReservationRequestReceived $event): void
+    {
+        GenerateReservationReplyJob::dispatch($event->request->id);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Services\AI\Contracts\ReplyGenerator;
+use App\Services\AI\OpenAiReplyGenerator;
 use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\WebklexImapMailboxFactory;
 use Illuminate\Support\ServiceProvider;
@@ -14,6 +16,7 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(ImapMailboxFactory::class, WebklexImapMailboxFactory::class);
+        $this->app->bind(ReplyGenerator::class, OpenAiReplyGenerator::class);
     }
 
     /**

--- a/app/Services/AI/Contracts/ReplyGenerator.php
+++ b/app/Services/AI/Contracts/ReplyGenerator.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI\Contracts;
+
+/**
+ * Producer of a German reply text from a deterministic Context-JSON.
+ *
+ * Implementations MUST never throw; on every error path they return the
+ * neutral fallback string. This contract is the seam used by the job
+ * layer (and tests) to substitute in a real OpenAI client, a stub, or a
+ * future provider (Azure / Anthropic) without changing call sites.
+ */
+interface ReplyGenerator
+{
+    /**
+     * @param  array<string, mixed>  $context  the JSON produced by
+     *                                         ReservationContextBuilder::build()
+     */
+    public function generate(array $context): string;
+}

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\AI;
 
+use App\Services\AI\Contracts\ReplyGenerator;
 use OpenAI\Contracts\ClientContract;
 use Psr\Log\LoggerInterface;
 use Throwable;
@@ -22,7 +23,7 @@ use Throwable;
  * Logging hygiene: only `$e->getMessage()` is logged. No API key, no
  * Authorization header, no full context payload, no guest data.
  */
-final class OpenAiReplyGenerator
+final class OpenAiReplyGenerator implements ReplyGenerator
 {
     public const string FALLBACK_TEXT = 'Vielen Dank für Ihre Anfrage. Wir melden uns in Kürze persönlich bei Ihnen.';
 

--- a/tests/Feature/Jobs/GenerateReservationReplyJobTest.php
+++ b/tests/Feature/Jobs/GenerateReservationReplyJobTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\ReservationReplyStatus;
+use App\Events\ReservationRequestReceived;
+use App\Jobs\GenerateReservationReplyJob;
+use App\Listeners\GenerateReservationReplyListener;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\AI\Contracts\ReplyGenerator;
+use App\Services\AI\OpenAiReplyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use RuntimeException;
+use Tests\TestCase;
+
+class GenerateReservationReplyJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeRequest(): ReservationRequest
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+
+        return ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'desired_at' => Carbon::create(2026, 5, 13, 17, 0, 0, 'UTC'),
+            'party_size' => 4,
+        ]);
+    }
+
+    /**
+     * Bind a fake ReplyGenerator that returns the given body (or throws).
+     */
+    private function bindGenerator(string|RuntimeException $bodyOrError): void
+    {
+        $this->app->bind(ReplyGenerator::class, fn () => new class($bodyOrError) implements ReplyGenerator
+        {
+            public function __construct(private readonly string|RuntimeException $bodyOrError) {}
+
+            public function generate(array $context): string
+            {
+                if ($this->bodyOrError instanceof RuntimeException) {
+                    throw $this->bodyOrError;
+                }
+
+                return $this->bodyOrError;
+            }
+        });
+    }
+
+    public function test_listener_dispatches_the_job_when_event_is_received(): void
+    {
+        Queue::fake();
+
+        $request = $this->makeRequest();
+
+        (new GenerateReservationReplyListener)->handle(new ReservationRequestReceived($request));
+
+        Queue::assertPushed(GenerateReservationReplyJob::class, fn (GenerateReservationReplyJob $job): bool => $job->reservationRequestId === $request->id);
+    }
+
+    public function test_event_dispatch_routes_through_the_listener(): void
+    {
+        Queue::fake();
+
+        $request = $this->makeRequest();
+
+        ReservationRequestReceived::dispatch($request);
+
+        Queue::assertPushed(GenerateReservationReplyJob::class);
+    }
+
+    public function test_job_persists_a_draft_reply_with_the_context_snapshot(): void
+    {
+        $request = $this->makeRequest();
+        $this->bindGenerator('Guten Tag, gerne!');
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        /** @var ReservationReply $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
+
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+        $this->assertSame('Guten Tag, gerne!', $reply->body);
+        $this->assertIsArray($reply->ai_prompt_snapshot);
+        $this->assertSame($request->guest_name, $reply->ai_prompt_snapshot['request']['guest_name']);
+        $this->assertFalse($request->fresh()->needs_manual_review);
+    }
+
+    public function test_throwable_during_generation_flags_manual_review_and_stores_fallback_draft(): void
+    {
+        $request = $this->makeRequest();
+        $this->bindGenerator(new RuntimeException('boom'));
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $this->assertTrue($request->fresh()->needs_manual_review);
+
+        /** @var ReservationReply $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+    }
+
+    public function test_job_is_a_no_op_for_a_missing_request(): void
+    {
+        $this->bindGenerator('should-not-be-called');
+
+        (new GenerateReservationReplyJob(999_999))->handle();
+
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+    }
+
+    public function test_job_falls_back_when_openai_key_is_missing(): void
+    {
+        // No generator bound and no API key → app(ReplyGenerator::class) throws.
+        // The job must still leave a usable draft and flag manual review.
+        config()->set('openai.api_key', null);
+        $request = $this->makeRequest();
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $this->assertTrue($request->fresh()->needs_manual_review);
+
+        /** @var ReservationReply $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+    }
+}


### PR DESCRIPTION
## Summary

- New \`GenerateReservationReplyListener\` (auto-discovered) subscribes to \`ReservationRequestReceived\` and dispatches the job.
- New queued \`GenerateReservationReplyJob\` runs \`ReservationContextBuilder\` + \`ReplyGenerator\` and persists a \`draft\` \`ReservationReply\` with the full \`ai_prompt_snapshot\`.
- Any throwable — including a missing \`OPENAI_API_KEY\` raised during DI — is caught: the request is flagged \`needs_manual_review = true\` and a fallback-text draft is stored, so the dashboard always has something to show.
- Introduces \`App\Services\AI\Contracts\ReplyGenerator\` (implemented by \`OpenAiReplyGenerator\`) so the job depends on a contract; a future provider (Azure / Anthropic) is one container binding away, and tests can swap in a fake without touching final classes.

## Why

PRD-005 requires that every new request produces a draft within 60 s, with the snapshot retained for reproducibility. The error path must never silently drop a request — \`needs_manual_review\` is the safety net so the human-in-the-loop guarantee still holds even if OpenAI is unreachable.

Resolving dependencies inside \`handle()\` (rather than via parameter injection) is intentional: under sync queue, an unset API key would otherwise raise during DI resolution and fail the upstream HTTP request that fired the event.

## Test plan

- [x] \`php artisan test tests/Feature/Jobs/GenerateReservationReplyJobTest.php\` — 6 cases: listener-dispatches-job, event-routing, draft persistence with snapshot, throwable→manual-review fallback, missing-request no-op, missing-API-key fallback
- [x] \`php artisan test\` — full suite green (445 passed)
- [x] \`./vendor/bin/pint --test\` — clean
- [x] Verified \`php artisan event:list\` shows the listener auto-registered

Closes #70