### PR TITLE
Implement OpenAI error matrix (#71)

### DIFF
--- a/app/Events/OpenAiAuthenticationFailed.php
+++ b/app/Events/OpenAiAuthenticationFailed.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Domain event emitted when the configured OpenAI API key is rejected
+ * (HTTP 401). The dashboard admin notification (issue #76) listens for
+ * this event to surface "OpenAI key check" to operators.
+ */
+final class OpenAiAuthenticationFailed
+{
+    use Dispatchable;
+}

--- a/app/Exceptions/AI/OpenAiAuthenticationException.php
+++ b/app/Exceptions/AI/OpenAiAuthenticationException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\AI;
+
+use RuntimeException;
+
+/**
+ * Signals that OpenAI rejected the API key (HTTP 401). The job MUST NOT
+ * retry — the only resolution is operator action — and SHOULD surface a
+ * dashboard notification (see #76).
+ */
+final class OpenAiAuthenticationException extends RuntimeException
+{
+    public function __construct(string $message = 'OpenAI rejected the API key (HTTP 401).')
+    {
+        parent::__construct($message);
+    }
+}

--- a/app/Exceptions/AI/OpenAiRateLimitException.php
+++ b/app/Exceptions/AI/OpenAiRateLimitException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\AI;
+
+use RuntimeException;
+
+/**
+ * Signals that OpenAI returned HTTP 429. The job retries exactly once
+ * after a 60-second delay; if the second attempt is also rate-limited,
+ * the job falls back as for any other failure.
+ */
+final class OpenAiRateLimitException extends RuntimeException
+{
+    public function __construct(string $message = 'OpenAI rate limit hit (HTTP 429).')
+    {
+        parent::__construct($message);
+    }
+}

--- a/app/Jobs/GenerateReservationReplyJob.php
+++ b/app/Jobs/GenerateReservationReplyJob.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Enums\ReservationReplyStatus;
+use App\Events\OpenAiAuthenticationFailed;
+use App\Exceptions\AI\OpenAiAuthenticationException;
+use App\Exceptions\AI\OpenAiRateLimitException;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Services\AI\Contracts\ReplyGenerator;
@@ -35,13 +38,16 @@ use Throwable;
  * instead of bubbling out of the worker as an uncaught exception during
  * sync-queue execution.
  */
-final class GenerateReservationReplyJob implements ShouldQueue
+class GenerateReservationReplyJob implements ShouldQueue
 {
     use Queueable;
 
-    public int $tries = 1;
+    public int $tries = 2;
 
     public int $timeout = 30;
+
+    /** Delay before re-attempting after a 429 (PRD-005). */
+    public const int RATE_LIMIT_RETRY_DELAY_SECONDS = 60;
 
     public function __construct(public int $reservationRequestId) {}
 
@@ -69,22 +75,55 @@ final class GenerateReservationReplyJob implements ShouldQueue
                 'body' => $body,
                 'ai_prompt_snapshot' => $context,
             ]);
+        } catch (OpenAiRateLimitException $e) {
+            // First 429 → release back to queue with the configured delay.
+            // Second 429 falls through to the generic-fallback path.
+            if ($this->attempts() < $this->tries) {
+                $this->release(self::RATE_LIMIT_RETRY_DELAY_SECONDS);
+
+                return;
+            }
+
+            $this->storeFallbackDraft($request, $context, $logger, '429 rate-limit after retry');
+        } catch (OpenAiAuthenticationException $e) {
+            // 401 → admin notification, no retry. Always fall straight
+            // through to the fallback path so the dashboard still has
+            // something to show.
+            OpenAiAuthenticationFailed::dispatch();
+
+            $this->storeFallbackDraft($request, $context, $logger, '401 authentication failed');
         } catch (Throwable $e) {
-            // Log without leaking the context payload — only the error
-            // message and the request id end up in the log line.
-            $logger->warning('reservation.reply.generate_failed', [
-                'reservation_request_id' => $request->id,
-                'error' => $e->getMessage(),
-            ]);
-
-            $request->forceFill(['needs_manual_review' => true])->save();
-
-            ReservationReply::create([
-                'reservation_request_id' => $request->id,
-                'status' => ReservationReplyStatus::Draft,
-                'body' => OpenAiReplyGenerator::FALLBACK_TEXT,
-                'ai_prompt_snapshot' => $context,
-            ]);
+            // 5xx, timeouts, network, builder/persistence errors,
+            // missing API key at DI time → immediate fallback. No retry.
+            $this->storeFallbackDraft($request, $context, $logger, $e->getMessage());
         }
+    }
+
+    /**
+     * Persist the fallback draft and flag the request for manual review.
+     * Always called from inside a handled-exception branch — never from
+     * the happy path.
+     *
+     * @param  array<string, mixed>|null  $context
+     */
+    private function storeFallbackDraft(
+        ReservationRequest $request,
+        ?array $context,
+        LoggerInterface $logger,
+        string $reason,
+    ): void {
+        $logger->warning('reservation.reply.generate_failed', [
+            'reservation_request_id' => $request->id,
+            'reason' => $reason,
+        ]);
+
+        $request->forceFill(['needs_manual_review' => true])->save();
+
+        ReservationReply::create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Draft,
+            'body' => OpenAiReplyGenerator::FALLBACK_TEXT,
+            'ai_prompt_snapshot' => $context,
+        ]);
     }
 }

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Services\AI;
 
+use App\Exceptions\AI\OpenAiAuthenticationException;
+use App\Exceptions\AI\OpenAiRateLimitException;
 use App\Services\AI\Contracts\ReplyGenerator;
 use OpenAI\Contracts\ClientContract;
+use OpenAI\Exceptions\ErrorException;
+use OpenAI\Exceptions\RateLimitException;
 use Psr\Log\LoggerInterface;
 use Throwable;
 
@@ -14,11 +18,14 @@ use Throwable;
  * `ReservationContextBuilder`) into a German reply text via OpenAI Chat
  * Completions.
  *
- * On ANY error path — empty completion, network failure, 401, 429, 5xx,
- * timeout, malformed payload — the generator returns the same neutral
- * fallback so the caller never raises and the AI prompt branch always
- * yields a string. The granular error matrix (admin notification on 401,
- * one retry on 429) lives outside this service in #71.
+ * Error matrix (PRD-005 / #71):
+ *   - HTTP 401 or RateLimit/Server errors are classified as
+ *     `OpenAiAuthenticationException` / `OpenAiRateLimitException` and
+ *     RETHROWN so the job layer can drive the admin notification (#76)
+ *     and the one-retry policy.
+ *   - Every other error path — empty completion, network failure, 5xx,
+ *     timeout, malformed payload — returns the neutral fallback so the
+ *     caller never raises.
  *
  * Logging hygiene: only `$e->getMessage()` is logged. No API key, no
  * Authorization header, no full context payload, no guest data.
@@ -55,6 +62,23 @@ final class OpenAiReplyGenerator implements ReplyGenerator
             $content = trim((string) ($response->choices[0]->message->content ?? ''));
 
             return $content !== '' ? $content : self::FALLBACK_TEXT;
+        } catch (ErrorException $e) {
+            $this->logger->warning('openai reply generation failed', [
+                'status' => $e->getStatusCode(),
+                'error' => $e->getErrorMessage(),
+            ]);
+
+            if ($e->getStatusCode() === 401) {
+                throw new OpenAiAuthenticationException;
+            }
+
+            return self::FALLBACK_TEXT;
+        } catch (RateLimitException $e) {
+            $this->logger->warning('openai reply generation rate-limited', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new OpenAiRateLimitException;
         } catch (Throwable $e) {
             $this->logger->warning('openai reply generation failed', [
                 'error' => $e->getMessage(),

--- a/tests/Feature/Jobs/GenerateReservationReplyJobErrorMatrixTest.php
+++ b/tests/Feature/Jobs/GenerateReservationReplyJobErrorMatrixTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Jobs;
+
+use App\Enums\ReservationReplyStatus;
+use App\Events\OpenAiAuthenticationFailed;
+use App\Exceptions\AI\OpenAiAuthenticationException;
+use App\Exceptions\AI\OpenAiRateLimitException;
+use App\Jobs\GenerateReservationReplyJob;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\AI\Contracts\ReplyGenerator;
+use App\Services\AI\OpenAiReplyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * Verifies the full PRD-005 OpenAI error matrix at the job layer:
+ *   - HTTP 401 → admin event dispatched, fallback stored, no retry
+ *   - HTTP 429 → release once with 60s delay, then fallback on second pass
+ *   - HTTP 5xx / timeout / unknown → immediate fallback, no retry
+ *   - Every fallback path leaves needs_manual_review = true
+ *
+ * Tests use a controllable test-double for `attempts()` and `release()` so
+ * the retry behaviour is exercised without booting a real queue worker.
+ */
+class GenerateReservationReplyJobErrorMatrixTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeRequest(): ReservationRequest
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+
+        return ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'desired_at' => Carbon::create(2026, 5, 13, 17, 0, 0, 'UTC'),
+            'party_size' => 4,
+        ]);
+    }
+
+    private function bindGenerator(\Throwable $error): void
+    {
+        $this->app->bind(ReplyGenerator::class, fn () => new class($error) implements ReplyGenerator
+        {
+            public function __construct(private readonly \Throwable $error) {}
+
+            public function generate(array $context): string
+            {
+                throw $this->error;
+            }
+        });
+    }
+
+    /**
+     * Build a job whose `attempts()` and `release()` we can drive from the test.
+     */
+    private function makeJob(int $reservationRequestId, int $attempts = 1): GenerateReservationReplyJob
+    {
+        return new class($reservationRequestId, $attempts) extends GenerateReservationReplyJob
+        {
+            public int $releasedWithDelay = -1;
+
+            public function __construct(int $id, public int $stubbedAttempts)
+            {
+                parent::__construct($id);
+            }
+
+            public function attempts(): int
+            {
+                return $this->stubbedAttempts;
+            }
+
+            public function release($delay = 0): mixed
+            {
+                $this->releasedWithDelay = (int) $delay;
+
+                return null;
+            }
+        };
+    }
+
+    public function test_http_401_dispatches_admin_event_stores_fallback_and_does_not_release(): void
+    {
+        Event::fake([OpenAiAuthenticationFailed::class]);
+
+        $request = $this->makeRequest();
+        $this->bindGenerator(new OpenAiAuthenticationException);
+
+        $job = $this->makeJob($request->id, attempts: 1);
+        $job->handle();
+
+        Event::assertDispatched(OpenAiAuthenticationFailed::class);
+        $this->assertSame(-1, $job->releasedWithDelay, '401 must not release for retry.');
+
+        $this->assertTrue($request->fresh()->needs_manual_review);
+        /** @var ReservationReply $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+    }
+
+    public function test_http_429_first_attempt_releases_with_60_seconds_and_writes_no_draft(): void
+    {
+        $request = $this->makeRequest();
+        $this->bindGenerator(new OpenAiRateLimitException);
+
+        $job = $this->makeJob($request->id, attempts: 1);
+        $job->handle();
+
+        $this->assertSame(GenerateReservationReplyJob::RATE_LIMIT_RETRY_DELAY_SECONDS, $job->releasedWithDelay);
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+        $this->assertFalse($request->fresh()->needs_manual_review);
+    }
+
+    public function test_http_429_second_attempt_stores_fallback_and_marks_manual_review(): void
+    {
+        $request = $this->makeRequest();
+        $this->bindGenerator(new OpenAiRateLimitException);
+
+        $job = $this->makeJob($request->id, attempts: 2);
+        $job->handle();
+
+        $this->assertSame(-1, $job->releasedWithDelay, 'Second 429 must not re-release.');
+        $this->assertTrue($request->fresh()->needs_manual_review);
+
+        /** @var ReservationReply $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+    }
+
+    public function test_5xx_or_timeout_falls_back_immediately_with_no_retry(): void
+    {
+        Event::fake([OpenAiAuthenticationFailed::class]);
+
+        $request = $this->makeRequest();
+        $this->bindGenerator(new RuntimeException('upstream timeout'));
+
+        $job = $this->makeJob($request->id, attempts: 1);
+        $job->handle();
+
+        Event::assertNotDispatched(OpenAiAuthenticationFailed::class);
+        $this->assertSame(-1, $job->releasedWithDelay);
+        $this->assertTrue($request->fresh()->needs_manual_review);
+
+        /** @var ReservationReply $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+    }
+}

--- a/tests/Unit/Services/AI/OpenAiReplyGeneratorErrorClassificationTest.php
+++ b/tests/Unit/Services/AI/OpenAiReplyGeneratorErrorClassificationTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Exceptions\AI\OpenAiAuthenticationException;
+use App\Exceptions\AI\OpenAiRateLimitException;
+use App\Services\AI\OpenAiReplyGenerator;
+use GuzzleHttp\Psr7\Response;
+use OpenAI\Exceptions\ErrorException;
+use OpenAI\Exceptions\RateLimitException;
+use OpenAI\Exceptions\ServerException;
+use OpenAI\Laravel\Facades\OpenAI;
+use Psr\Log\NullLogger;
+use Tests\TestCase;
+
+/**
+ * The generator must classify the OpenAI exception types so the job
+ * layer can drive the PRD-005 error matrix:
+ *   - 401 ErrorException  → OpenAiAuthenticationException (rethrown)
+ *   - RateLimitException  → OpenAiRateLimitException (rethrown)
+ *   - ServerException     → fallback (handled in-place)
+ *   - Anything else       → fallback (handled in-place)
+ *
+ * The sentinel-key leak guard is also exercised here on the throw paths
+ * so a future change cannot start logging the API key alongside the
+ * status code.
+ */
+class OpenAiReplyGeneratorErrorClassificationTest extends TestCase
+{
+    private const string LEAK_SENTINEL = 'sk-test-LEAK-CHECK-12345';
+
+    private function makeContext(): array
+    {
+        return [
+            'restaurant' => ['name' => 'X', 'tonality' => 'casual'],
+            'request' => ['guest_name' => 'X', 'party_size' => 2, 'desired_at' => '2026-05-13 19:00', 'message' => null],
+            'availability' => [
+                'is_open_at_desired_time' => true,
+                'seats_free_at_desired' => 10,
+                'alternative_slots' => [],
+                'closed_reason' => null,
+            ],
+        ];
+    }
+
+    public function test_401_response_is_classified_as_authentication_exception(): void
+    {
+        $fake = OpenAI::fake([
+            new ErrorException(
+                ['message' => 'invalid api key', 'type' => 'invalid_request_error'],
+                new Response(401),
+            ),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, new NullLogger);
+
+        $this->expectException(OpenAiAuthenticationException::class);
+        $generator->generate($this->makeContext());
+    }
+
+    public function test_rate_limit_response_is_classified_as_rate_limit_exception(): void
+    {
+        $fake = OpenAI::fake([
+            new RateLimitException(new Response(429)),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, new NullLogger);
+
+        $this->expectException(OpenAiRateLimitException::class);
+        $generator->generate($this->makeContext());
+    }
+
+    public function test_500_server_error_falls_back_silently(): void
+    {
+        $fake = OpenAI::fake([
+            new ServerException(new Response(500)),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, new NullLogger);
+
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $generator->generate($this->makeContext()));
+    }
+
+    public function test_non_401_error_response_falls_back_silently(): void
+    {
+        $fake = OpenAI::fake([
+            new ErrorException(
+                ['message' => 'bad request', 'type' => 'invalid_request_error'],
+                new Response(400),
+            ),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, new NullLogger);
+
+        $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $generator->generate($this->makeContext()));
+    }
+
+    public function test_api_key_does_not_leak_when_classified_exceptions_are_thrown(): void
+    {
+        config()->set('openai.api_key', self::LEAK_SENTINEL);
+
+        $captured = [];
+        $logger = new class($captured) extends NullLogger
+        {
+            public function __construct(private array &$captured) {}
+
+            public function warning($message, array $context = []): void
+            {
+                $this->captured[] = ['msg' => $message, 'ctx' => $context];
+            }
+        };
+
+        $fake = OpenAI::fake([
+            new ErrorException(
+                ['message' => 'unauthorised'],
+                new Response(401),
+            ),
+        ]);
+
+        try {
+            (new OpenAiReplyGenerator($fake, $logger))->generate($this->makeContext());
+        } catch (OpenAiAuthenticationException) {
+            // expected
+        }
+
+        $serialized = (string) json_encode($captured, JSON_UNESCAPED_UNICODE);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $serialized);
+    }
+}


### PR DESCRIPTION
## Summary

PRD-005 error matrix implemented end-to-end:

| HTTP | Action | Retry | Manual review |
|------|--------|-------|---------------|
| 401  | dispatch \`OpenAiAuthenticationFailed\` event + fallback draft | no | yes |
| 429  | release with 60s delay; on the retry, fallback draft | one | yes (after retry) |
| 5xx  | fallback draft | no | yes |
| any other Throwable (timeout, missing key, etc.) | fallback draft | no | yes |

- Two new domain exceptions (\`OpenAiAuthenticationException\`, \`OpenAiRateLimitException\`) classify the OpenAI client's typed exceptions so the job layer can route by error class instead of inspecting status codes itself.
- New domain event \`OpenAiAuthenticationFailed\` — consumed by the dashboard admin notification in #76.
- Job's \`tries = 2\` so the 429 release counts toward Laravel's retry policy without spamming attempts.
- Sentinel-key leak guard now covers the throw paths too — a future change cannot start logging the key alongside the status code.

## Test plan

- [x] 5 new unit tests classify the OpenAI exceptions (\`OpenAiReplyGeneratorErrorClassificationTest\`)
- [x] 4 new feature tests cover the matrix at the job layer (\`GenerateReservationReplyJobErrorMatrixTest\`) using a controllable test-double for \`attempts()\` and \`release()\`
- [x] \`php artisan test\` — full suite green (454 passed)
- [x] \`./vendor/bin/pint --test\` — clean

Closes #71