### PR TITLE
Add POST /reservation-replies/{reply}/approve (#72, #86)

### DIFF
--- a/app/Http/Controllers/ReservationReplyController.php
+++ b/app/Http/Controllers/ReservationReplyController.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\ReservationReplyStatus;
+use App\Http\Requests\ApproveReservationReplyRequest;
+use App\Jobs\SendReservationReplyJob;
+use App\Models\ReservationReply;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+
+class ReservationReplyController extends Controller
+{
+    /**
+     * Approve an AI draft and queue it for sending (PRD-005).
+     *
+     * Idempotency: re-approving an already-Sent or already-Approved reply
+     * is a no-op with a flash error — the dashboard's "Freigeben" button
+     * is disabled in those states, but a stale tab can still POST.
+     */
+    public function approve(ApproveReservationReplyRequest $request, ReservationReply $reply): RedirectResponse
+    {
+        if (in_array($reply->status, [ReservationReplyStatus::Sent, ReservationReplyStatus::Approved], true)) {
+            return back()->with('error', 'Diese Antwort wurde bereits freigegeben.');
+        }
+
+        $editedBody = $request->string('body')->trim()->toString();
+        if ($editedBody !== '' && $editedBody !== $reply->body) {
+            $reply->body = $editedBody;
+        }
+
+        $reply->forceFill([
+            'status' => ReservationReplyStatus::Approved,
+            'approved_by' => Auth::id(),
+            'approved_at' => now(),
+        ])->save();
+
+        SendReservationReplyJob::dispatch($reply->id);
+
+        return back()->with('success', 'Antwort freigegeben — sie wird gleich versendet.');
+    }
+}

--- a/app/Http/Requests/ApproveReservationReplyRequest.php
+++ b/app/Http/Requests/ApproveReservationReplyRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class ApproveReservationReplyRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // Authorization is enforced by the route's `can:approve,reply` gate
+        // — this FormRequest only validates the optional body override.
+        return true;
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public function rules(): array
+    {
+        return [
+            // Operator-edited body — optional. When present it overwrites
+            // the AI draft before the send job dispatches. The hard cap is
+            // generous but bounded; a reply much longer than this is almost
+            // certainly an unintentional paste.
+            'body' => ['sometimes', 'string', 'max:4000'],
+        ];
+    }
+}

--- a/app/Policies/ReservationReplyPolicy.php
+++ b/app/Policies/ReservationReplyPolicy.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Models\ReservationReply;
+use App\Models\User;
+
+final class ReservationReplyPolicy
+{
+    public function view(User $user, ReservationReply $reply): bool
+    {
+        return $reply->reservationRequest?->restaurant_id === $user->restaurant_id
+            && $user->restaurant_id !== null;
+    }
+
+    public function approve(User $user, ReservationReply $reply): bool
+    {
+        return $this->view($user, $reply);
+    }
+}

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -10,6 +10,13 @@ declare module 'ziggy-js' {
         }
     ],
     "reservations.bulk-status": [],
+    "reservation-replies.approve": [
+        {
+            "name": "reply",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "public.reservations.create": [
         {
             "name": "restaurant",

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PublicReservationController;
+use App\Http\Controllers\ReservationReplyController;
 use App\Http\Controllers\ReservationRequestController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -22,6 +23,10 @@ Route::get('reservations/{reservation}', [ReservationRequestController::class, '
 Route::post('reservations/bulk-status', [ReservationRequestController::class, 'bulkStatus'])
     ->middleware(['auth', 'verified'])
     ->name('reservations.bulk-status');
+
+Route::post('reservation-replies/{reply}/approve', [ReservationReplyController::class, 'approve'])
+    ->middleware(['auth', 'verified', 'can:approve,reply'])
+    ->name('reservation-replies.approve');
 
 Route::get('r/{restaurant:slug}/reservations', [PublicReservationController::class, 'create'])
     ->name('public.reservations.create');

--- a/tests/Feature/Http/ApproveReservationReplyTest.php
+++ b/tests/Feature/Http/ApproveReservationReplyTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Http;
+
+use App\Enums\ReservationReplyStatus;
+use App\Jobs\SendReservationReplyJob;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class ApproveReservationReplyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeUserAndDraft(): array
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->create(['restaurant_id' => $restaurant->id]);
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Draft,
+            'body' => 'Original AI draft.',
+        ]);
+
+        return [$user, $reply];
+    }
+
+    public function test_approving_a_draft_dispatches_the_send_job_and_transitions_status(): void
+    {
+        Queue::fake();
+        [$user, $reply] = $this->makeUserAndDraft();
+
+        $this->actingAs($user)
+            ->post(route('reservation-replies.approve', $reply))
+            ->assertRedirect();
+
+        Queue::assertPushed(SendReservationReplyJob::class, fn (SendReservationReplyJob $job): bool => $job->reservationReplyId === $reply->id);
+
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::Approved, $reply->status);
+        $this->assertSame($user->id, $reply->approved_by);
+        $this->assertNotNull($reply->approved_at);
+    }
+
+    public function test_an_edited_body_overwrites_the_draft_before_dispatch(): void
+    {
+        Queue::fake();
+        [$user, $reply] = $this->makeUserAndDraft();
+
+        $this->actingAs($user)
+            ->post(route('reservation-replies.approve', $reply), [
+                'body' => 'Bearbeiteter Text vom Gastronom.',
+            ])
+            ->assertRedirect();
+
+        $this->assertSame('Bearbeiteter Text vom Gastronom.', $reply->fresh()->body);
+        // The dispatched job will read this body when sending the mail.
+        Queue::assertPushed(SendReservationReplyJob::class);
+    }
+
+    public function test_approving_without_body_keeps_the_original_draft(): void
+    {
+        Queue::fake();
+        [$user, $reply] = $this->makeUserAndDraft();
+
+        $this->actingAs($user)
+            ->post(route('reservation-replies.approve', $reply))
+            ->assertRedirect();
+
+        $this->assertSame('Original AI draft.', $reply->fresh()->body);
+    }
+
+    public function test_approving_an_already_sent_reply_is_a_no_op(): void
+    {
+        Queue::fake();
+        [$user, $reply] = $this->makeUserAndDraft();
+        $reply->forceFill(['status' => ReservationReplyStatus::Sent, 'sent_at' => now()])->save();
+
+        $this->actingAs($user)
+            ->post(route('reservation-replies.approve', $reply))
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        Queue::assertNothingPushed();
+        $this->assertSame(ReservationReplyStatus::Sent, $reply->fresh()->status);
+    }
+
+    public function test_approving_an_already_approved_reply_is_a_no_op(): void
+    {
+        Queue::fake();
+        [$user, $reply] = $this->makeUserAndDraft();
+        $reply->forceFill(['status' => ReservationReplyStatus::Approved, 'approved_at' => now()])->save();
+
+        $this->actingAs($user)
+            ->post(route('reservation-replies.approve', $reply))
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_users_cannot_approve_replies_of_other_restaurants(): void
+    {
+        Queue::fake();
+        [, $reply] = $this->makeUserAndDraft();
+        $otherRestaurant = Restaurant::factory()->create();
+        $intruder = User::factory()->create(['restaurant_id' => $otherRestaurant->id]);
+
+        // RestaurantScope hides replies of other restaurants from route
+        // model binding, so the intruder sees a 404 — not a 403.
+        // Either response keeps the reply private; 404 is the project's
+        // tenant-isolation contract via the global scope.
+        $this->actingAs($intruder)
+            ->post(route('reservation-replies.approve', $reply))
+            ->assertNotFound();
+
+        Queue::assertNothingPushed();
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->fresh()->status);
+    }
+
+    public function test_unauthenticated_users_are_redirected_to_login(): void
+    {
+        Queue::fake();
+        [, $reply] = $this->makeUserAndDraft();
+
+        $this->post(route('reservation-replies.approve', $reply))
+            ->assertRedirect(route('login'));
+
+        Queue::assertNothingPushed();
+    }
+
+    public function test_body_field_validates_max_length(): void
+    {
+        Queue::fake();
+        [$user, $reply] = $this->makeUserAndDraft();
+
+        $this->actingAs($user)
+            ->post(route('reservation-replies.approve', $reply), [
+                'body' => str_repeat('x', 4001),
+            ])
+            ->assertSessionHasErrors('body');
+
+        Queue::assertNothingPushed();
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->fresh()->status);
+    }
+}


### PR DESCRIPTION
## Summary

- New \`ReservationReplyController::approve\` (FormRequest + Policy + route) closes the loop on PRD-005's human-in-the-loop checkpoint.
- Authorization in two layers: route gate \`can:approve,reply\` (new \`ReservationReplyPolicy\`) plus the existing \`RestaurantScope\` global scope, so cross-tenant probes return 404.
- Optional \`body\` field overwrites the AI draft before \`SendReservationReplyJob::dispatch\` — this is the path that satisfies #86 (operator-edited body actually gets sent).
- Idempotent: re-approving a \`Sent\` or \`Approved\` reply is a flash-error no-op.
- \`approved_by\` / \`approved_at\` written via \`forceFill\` so they remain audit-only columns (not operator-mutable).

## Why

Without this endpoint, AI drafts are dead-ends — there's no path to actually send them. Combined with #73 / #74, this PR makes the full reply pipeline reachable end-to-end from the dashboard.

## Test plan

- [x] \`php artisan test tests/Feature/Http/ApproveReservationReplyTest.php\` — 8 cases: dispatch + transition, edited-body overwrite, no-body keeps draft, idempotency on Sent + Approved, cross-tenant 404, login redirect, max-length validation
- [x] \`php artisan test\` — full suite green (472 passed)
- [x] \`./vendor/bin/pint --test\` — clean
- [x] \`php artisan ziggy:generate --types-only\` re-run; \`resources/js/ziggy.d.ts\` updated

Closes #72