### PR TITLE
Surface AI draft + approval UI in the dashboard drawer (#75)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -57,6 +57,7 @@ final class DashboardController extends Controller
 
         $reservation = ReservationRequest::query()
             ->withoutGlobalScopes()
+            ->with(['latestReply'])
             ->find($id);
 
         if ($reservation === null || ! Gate::forUser($request->user())->allows('view', $reservation)) {

--- a/app/Http/Resources/ReservationRequestDetailResource.php
+++ b/app/Http/Resources/ReservationRequestDetailResource.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Http\Resources;
 
 use App\Enums\ReservationSource;
+use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -41,6 +42,31 @@ final class ReservationRequestDetailResource extends JsonResource
             'raw_email_body' => $isEmail && is_array($rawPayload)
                 ? ($rawPayload['body'] ?? null)
                 : null,
+            'latest_reply' => $this->serializeReply($this->resource->latestReply),
+        ];
+    }
+
+    /**
+     * Surface the AI draft / approved reply to the dashboard drawer.
+     * `ai_prompt_snapshot` is intentionally NOT exposed — it is an
+     * internal debugging field (issue #85) and would leak the full
+     * Context-JSON to the browser otherwise.
+     *
+     * @return array<string, mixed>|null
+     */
+    private function serializeReply(?ReservationReply $reply): ?array
+    {
+        if ($reply === null) {
+            return null;
+        }
+
+        return [
+            'id' => $reply->id,
+            'status' => $reply->status->value,
+            'body' => $reply->body,
+            'approved_at' => $reply->approved_at?->toISOString(),
+            'sent_at' => $reply->sent_at?->toISOString(),
+            'error_message' => $reply->error_message,
         ];
     }
 }

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -211,15 +211,34 @@ const REPLY_STATUS_BADGE: Record<'draft' | 'approved' | 'sent' | 'failed', strin
 const replyBody = ref('');
 const approving = ref(false);
 
+// Per-reply scratchpad. Switching rows must NOT silently lose an
+// in-progress edit, so unsaved bodies are stashed by reply.id and
+// restored when the operator comes back. Polling that re-broadcasts
+// the same reply.id is also a no-op against this cache.
+const replyEditCache = ref<Record<number, string>>({});
+
+const currentReplyId = computed(() => props.selectedRequest?.latest_reply?.id ?? null);
+
 const isReplyEditable = computed(() => {
     const reply = props.selectedRequest?.latest_reply;
     return reply !== null && reply !== undefined && reply.status === 'draft';
 });
 
 watch(
-    () => props.selectedRequest?.latest_reply?.body,
-    (body) => {
-        replyBody.value = body ?? '';
+    currentReplyId,
+    (id, prevId) => {
+        // Stash the body the operator was editing before we switch.
+        if (typeof prevId === 'number') {
+            replyEditCache.value[prevId] = replyBody.value;
+        }
+
+        if (typeof id !== 'number') {
+            replyBody.value = '';
+            return;
+        }
+
+        const cached = replyEditCache.value[id];
+        replyBody.value = cached ?? props.selectedRequest?.latest_reply?.body ?? '';
     },
     { immediate: true },
 );
@@ -237,6 +256,11 @@ function submitApproval(): void {
     approving.value = true;
     router.post(route('reservation-replies.approve', { reply: reply.id }), payload, {
         preserveScroll: true,
+        onSuccess: () => {
+            // The reply has been dispatched — drop the scratchpad so a
+            // subsequent re-open shows the canonical server-side body.
+            delete replyEditCache.value[reply.id];
+        },
         onFinish: () => {
             approving.value = false;
         },

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -194,6 +194,55 @@ const drawerOpen = computed({
 
 const rawEmailOpen = ref(false);
 
+const REPLY_STATUS_LABEL: Record<'draft' | 'approved' | 'sent' | 'failed', string> = {
+    draft: 'KI-Vorschlag verfügbar',
+    approved: 'Wird versendet',
+    sent: 'Versendet',
+    failed: 'Versand fehlgeschlagen',
+};
+
+const REPLY_STATUS_BADGE: Record<'draft' | 'approved' | 'sent' | 'failed', string> = {
+    draft: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200',
+    approved: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-200',
+    sent: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200',
+    failed: 'bg-red-100 text-red-900 dark:bg-red-900/40 dark:text-red-200',
+};
+
+const replyBody = ref('');
+const approving = ref(false);
+
+const isReplyEditable = computed(() => {
+    const reply = props.selectedRequest?.latest_reply;
+    return reply !== null && reply !== undefined && reply.status === 'draft';
+});
+
+watch(
+    () => props.selectedRequest?.latest_reply?.body,
+    (body) => {
+        replyBody.value = body ?? '';
+    },
+    { immediate: true },
+);
+
+function submitApproval(): void {
+    const reply = props.selectedRequest?.latest_reply;
+    if (!reply || reply.status !== 'draft') {
+        return;
+    }
+
+    const original = reply.body;
+    const edited = replyBody.value.trim();
+    const payload = edited !== '' && edited !== original ? { body: edited } : {};
+
+    approving.value = true;
+    router.post(route('reservation-replies.approve', { reply: reply.id }), payload, {
+        preserveScroll: true,
+        onFinish: () => {
+            approving.value = false;
+        },
+    });
+}
+
 const selection = useRowSelection();
 const visibleRowIds = computed(() => props.requests.data.map((row) => row.id));
 const headerCheckedModel = computed<boolean | 'indeterminate'>(() => {
@@ -530,6 +579,43 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                         >
                     </CollapsibleContent>
                 </Collapsible>
+
+                <section v-if="props.selectedRequest.latest_reply" class="space-y-2 border-t border-border pt-4" data-testid="ai-reply-section">
+                    <div class="flex items-center justify-between">
+                        <h3 class="text-sm font-medium">KI-Antwortvorschlag</h3>
+                        <span
+                            class="rounded-full px-2 py-0.5 text-xs font-medium"
+                            :class="REPLY_STATUS_BADGE[props.selectedRequest.latest_reply.status]"
+                            data-testid="ai-reply-status"
+                        >
+                            {{ REPLY_STATUS_LABEL[props.selectedRequest.latest_reply.status] }}
+                        </span>
+                    </div>
+
+                    <textarea
+                        v-model="replyBody"
+                        :disabled="!isReplyEditable"
+                        rows="8"
+                        class="w-full resize-y rounded-md border border-border bg-background p-3 text-sm leading-relaxed disabled:cursor-not-allowed disabled:opacity-60"
+                        data-testid="ai-reply-textarea"
+                    ></textarea>
+
+                    <p
+                        v-if="props.selectedRequest.latest_reply.status === 'failed' && props.selectedRequest.latest_reply.error_message"
+                        class="text-xs text-red-600 dark:text-red-400"
+                        data-testid="ai-reply-error"
+                    >
+                        Versand fehlgeschlagen: {{ props.selectedRequest.latest_reply.error_message }}
+                    </p>
+
+                    <p v-if="props.selectedRequest.latest_reply.sent_at" class="text-xs text-muted-foreground" data-testid="ai-reply-sent-at">
+                        Versendet: {{ renderTime(props.selectedRequest.latest_reply.sent_at) }}
+                    </p>
+
+                    <Button v-if="isReplyEditable" :disabled="approving" class="w-full" data-testid="ai-reply-approve" @click="submitApproval">
+                        Freigeben &amp; Versenden
+                    </Button>
+                </section>
             </SheetContent>
         </Sheet>
     </AppLayout>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -104,8 +104,20 @@ export interface DashboardStats {
     in_review: number;
 }
 
+export type ReservationReplyStatus = 'draft' | 'approved' | 'sent' | 'failed';
+
+export interface ReservationReplySummary {
+    id: number;
+    status: ReservationReplyStatus;
+    body: string;
+    approved_at: string | null;
+    sent_at: string | null;
+    error_message: string | null;
+}
+
 export interface ReservationRequestDetail extends ReservationRequestRow {
     message: string | null;
     raw_payload: Record<string, unknown> | null;
     raw_email_body: string | null;
+    latest_reply: ReservationReplySummary | null;
 }

--- a/tests/Feature/DashboardDrawerAiTest.php
+++ b/tests/Feature/DashboardDrawerAiTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\ReservationReplyStatus;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+/**
+ * Pins the contract surface that the dashboard drawer (issue #75)
+ * relies on: every selected reservation that has an AI draft reply
+ * carries `latest_reply` with the operator-visible fields, AND the
+ * internal `ai_prompt_snapshot` is NEVER exposed to the browser.
+ */
+class DashboardDrawerAiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeUserAndDraft(): array
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->create(['restaurant_id' => $restaurant->id]);
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Draft,
+            'body' => 'Original AI draft.',
+            'ai_prompt_snapshot' => ['restaurant' => ['name' => 'X', 'tonality' => 'casual']],
+        ]);
+
+        return [$user, $request, $reply];
+    }
+
+    public function test_selected_request_carries_latest_reply_summary(): void
+    {
+        [$user, $request, $reply] = $this->makeUserAndDraft();
+
+        $response = $this->actingAs($user)->get(route('dashboard', ['selected' => $request->id]));
+
+        $response->assertOk()
+            ->assertInertia(function ($page) use ($reply) {
+                $page->where('selectedRequest.latest_reply.id', $reply->id)
+                    ->where('selectedRequest.latest_reply.status', 'draft')
+                    ->where('selectedRequest.latest_reply.body', 'Original AI draft.')
+                    ->where('selectedRequest.latest_reply.error_message', null)
+                    ->where('selectedRequest.latest_reply.sent_at', null);
+            });
+    }
+
+    public function test_ai_prompt_snapshot_is_not_exposed_to_the_browser(): void
+    {
+        [$user, $request] = $this->makeUserAndDraft();
+
+        $this->actingAs($user)
+            ->get(route('dashboard', ['selected' => $request->id]))
+            ->assertInertia(function ($page) {
+                $page->missing('selectedRequest.latest_reply.ai_prompt_snapshot');
+            });
+    }
+
+    public function test_selected_request_without_a_reply_has_null_latest_reply(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->create(['restaurant_id' => $restaurant->id]);
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($user)
+            ->get(route('dashboard', ['selected' => $request->id]))
+            ->assertOk()
+            ->assertInertia(function ($page) {
+                $page->where('selectedRequest.latest_reply', null);
+            });
+    }
+}

--- a/tests/Feature/Http/Resources/ReservationRequestDetailResourceTest.php
+++ b/tests/Feature/Http/Resources/ReservationRequestDetailResourceTest.php
@@ -50,6 +50,7 @@ class ReservationRequestDetailResourceTest extends TestCase
             'message',
             'raw_payload',
             'raw_email_body',
+            'latest_reply',
         ], array_keys($payload));
 
         $this->assertSame('Allergie: Nüsse', $payload['message']);


### PR DESCRIPTION
## Summary

- \`ReservationRequestDetailResource\` carries \`latest_reply\` (id, status, body, approved_at, sent_at, error_message). \`ai_prompt_snapshot\` is intentionally NOT exposed (#85 calls it internal debugging state).
- \`DashboardController\` eager-loads \`latestReply\` so the drawer doesn't trigger an N+1.
- Drawer adds a status badge, prefilled textarea, and \"Freigeben & Versenden\" button POSTing the optional edited body to \`reservation-replies.approve\`.
- Textarea is read-only after the reply leaves Draft; Sent surfaces \`sent_at\`; Failed surfaces \`error_message\`.

## Why

Without this, AI drafts have no operator-visible surface — the approve endpoint (#72) and SendJob (#73) had no UI entry point. With this PR the chain is reachable end-to-end from the dashboard.

## Notes

- Visual diff between original draft and edited body (placebo-click mitigation from PRD-005 Risiken) is the next-step UX covered by issue #82.
- TypeScript types extended in \`resources/js/types/index.ts\` (\`ReservationReplyStatus\`, \`ReservationReplySummary\`, \`latest_reply\` on \`ReservationRequestDetail\`).

## Test plan

- [x] \`php artisan test tests/Feature/DashboardDrawerAiTest.php\` — 3 cases pin the surface (latest_reply on select, snapshot NOT leaked, null when no draft)
- [x] \`php artisan test\` — full suite green (498 passed)
- [x] \`./vendor/bin/pint --test\` — clean
- [x] \`npm run lint\` / \`npm run format:check\` — clean
- [x] \`npm run build\` — TS / Vite green
- [x] \`php artisan ziggy:generate --types-only\` re-run

Closes #75