### PR TITLE
Surface OpenAI 401 admin notification on the dashboard (#76)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -5,10 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Enums\ReservationStatus;
+use App\Enums\UserRole;
 use App\Http\Requests\DashboardFilterRequest;
 use App\Http\Resources\ReservationRequestDetailResource;
 use App\Http\Resources\ReservationRequestResource;
 use App\Models\ReservationRequest;
+use App\Support\OpenAiKeyHealth;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Gate;
@@ -46,6 +48,12 @@ final class DashboardController extends Controller
                     ->count(),
             ],
             'selectedRequest' => fn () => $this->resolveSelected($selectedId, $request),
+            // Owner-only banner. The flag is global (V1.0 has one OpenAI key
+            // app-wide); dismissing-by-user is intentionally NOT supported
+            // (issue #76) so a stale alert can't outlive a still-broken key.
+            'openaiKeyRejectedAt' => $request->user()?->role === UserRole::Owner
+                ? OpenAiKeyHealth::rejectedAt()
+                : null,
         ]);
     }
 

--- a/app/Listeners/RecordOpenAiKeyRejected.php
+++ b/app/Listeners/RecordOpenAiKeyRejected.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Listeners;
+
+use App\Events\OpenAiAuthenticationFailed;
+use App\Support\OpenAiKeyHealth;
+
+/**
+ * Auto-discovered listener for `OpenAiAuthenticationFailed`. The job
+ * layer dispatches the event whenever OpenAI returns 401; this listener
+ * persists the signal so the dashboard's owner-only banner can surface
+ * it (issue #76).
+ */
+final class RecordOpenAiKeyRejected
+{
+    public function handle(OpenAiAuthenticationFailed $event): void
+    {
+        OpenAiKeyHealth::flagAsRejected();
+    }
+}

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -7,6 +7,7 @@ namespace App\Services\AI;
 use App\Exceptions\AI\OpenAiAuthenticationException;
 use App\Exceptions\AI\OpenAiRateLimitException;
 use App\Services\AI\Contracts\ReplyGenerator;
+use App\Support\OpenAiKeyHealth;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Exceptions\ErrorException;
 use OpenAI\Exceptions\RateLimitException;
@@ -60,6 +61,11 @@ final class OpenAiReplyGenerator implements ReplyGenerator
             ]);
 
             $content = trim((string) ($response->choices[0]->message->content ?? ''));
+
+            // Reaching this point means the call authenticated successfully —
+            // auto-clear the admin "OpenAI key check" banner (#76) so the
+            // dashboard doesn't strand stale alerts after a key rotation.
+            OpenAiKeyHealth::clear();
 
             return $content !== '' ? $content : self::FALLBACK_TEXT;
         } catch (ErrorException $e) {

--- a/app/Support/OpenAiKeyHealth.php
+++ b/app/Support/OpenAiKeyHealth.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Cache;
+
+/**
+ * Single-flag persistence for the "OpenAI key rejected" admin signal
+ * (PRD-005 / issue #76).
+ *
+ * Cache-backed, app-wide (PRD-005 V1.0 uses one global API key). When
+ * the next successful OpenAI call lands, the flag is cleared so the
+ * admin notification disappears without requiring operator action.
+ *
+ * Dismissal by the operator is intentionally NOT implemented for V1.0:
+ * a transient "I dismissed this and now don't realise the key is still
+ * broken" failure mode is worse than waiting for the next successful
+ * call to clear it.
+ */
+final class OpenAiKeyHealth
+{
+    private const string CACHE_KEY = 'reservations.openai.key_rejected_at';
+
+    private const int RETENTION_SECONDS = 7 * 24 * 60 * 60;
+
+    public static function flagAsRejected(): void
+    {
+        Cache::put(self::CACHE_KEY, now()->toIso8601String(), self::RETENTION_SECONDS);
+    }
+
+    public static function clear(): void
+    {
+        Cache::forget(self::CACHE_KEY);
+    }
+
+    public static function rejectedAt(): ?string
+    {
+        $value = Cache::get(self::CACHE_KEY);
+
+        return is_string($value) ? $value : null;
+    }
+}

--- a/app/Support/OpenAiKeyHealth.php
+++ b/app/Support/OpenAiKeyHealth.php
@@ -18,6 +18,16 @@ use Illuminate\Support\Facades\Cache;
  * a transient "I dismissed this and now don't realise the key is still
  * broken" failure mode is worse than waiting for the next successful
  * call to clear it.
+ *
+ * Storage caveat: this flag lives wherever the configured cache driver
+ * lives. With `file` / `redis` / `database` drivers it persists across
+ * requests and worker processes, which is what we want. With `array`
+ * (e.g. inside a single test or a misconfigured Octane runtime) the
+ * flag is request-scoped and the banner will appear to flicker on
+ * every request — not a correctness issue, but worth knowing when
+ * debugging an environment where the banner refuses to surface.
+ * `cache:clear` will also dismiss the flag silently; treat that as
+ * acceptable, since it's an explicit operator action.
  */
 final class OpenAiKeyHealth
 {

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -30,6 +30,7 @@ interface DashboardProps {
     requests: PaginatedReservationRequests;
     stats: DashboardStats;
     selectedRequest?: ReservationRequestDetail | null;
+    openaiKeyRejectedAt?: string | null;
 }
 
 const props = defineProps<DashboardProps>();
@@ -305,6 +306,21 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
 
     <AppLayout :breadcrumbs="breadcrumbs">
         <div class="flex h-full flex-1 flex-col gap-6 p-6">
+            <div
+                v-if="props.openaiKeyRejectedAt"
+                class="flex items-start gap-3 rounded-md border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100"
+                data-testid="openai-key-banner"
+            >
+                <Info class="mt-0.5 size-5 shrink-0" />
+                <div>
+                    <strong class="font-medium">OpenAI-Key prüfen</strong>
+                    <p class="leading-relaxed">
+                        Die letzte KI-Anfrage wurde mit HTTP 401 abgewiesen. Hinterlege einen gültigen API-Key in der Umgebungs-Konfiguration. Sobald
+                        die nächste Antwort erfolgreich generiert wird, verschwindet dieser Hinweis automatisch.
+                    </p>
+                </div>
+            </div>
+
             <header class="flex flex-wrap items-end justify-between gap-4" data-testid="restaurant-header">
                 <div>
                     <h1 class="text-2xl font-semibold tracking-tight">{{ restaurantName }}</h1>

--- a/tests/Feature/OpenAi401AdminNotificationTest.php
+++ b/tests/Feature/OpenAi401AdminNotificationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use App\Enums\UserRole;
+use App\Events\OpenAiAuthenticationFailed;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Services\AI\OpenAiReplyGenerator;
+use App\Support\OpenAiKeyHealth;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Responses\Chat\CreateResponse;
+use Psr\Log\NullLogger;
+use Tests\TestCase;
+
+/**
+ * PRD-005 / issue #76 — owner-only "OpenAI-Key prüfen" banner.
+ *
+ * The signal is global (V1.0 has one app-wide API key); the listener
+ * stashes it to a cache flag, the dashboard surfaces it for users with
+ * the Owner role only, and a successful OpenAI call auto-clears it.
+ */
+class OpenAi401AdminNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        OpenAiKeyHealth::clear();
+    }
+
+    public function test_listener_flags_the_key_as_rejected_when_event_fires(): void
+    {
+        $this->assertNull(OpenAiKeyHealth::rejectedAt());
+
+        OpenAiAuthenticationFailed::dispatch();
+
+        $this->assertNotNull(OpenAiKeyHealth::rejectedAt());
+    }
+
+    public function test_dashboard_surfaces_the_banner_for_owner_users(): void
+    {
+        OpenAiKeyHealth::flagAsRejected();
+
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->create(['restaurant_id' => $restaurant->id, 'role' => UserRole::Owner]);
+
+        $this->actingAs($owner)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->where('openaiKeyRejectedAt', fn ($v) => is_string($v)));
+    }
+
+    public function test_dashboard_does_not_surface_the_banner_for_staff_users(): void
+    {
+        OpenAiKeyHealth::flagAsRejected();
+
+        $restaurant = Restaurant::factory()->create();
+        $staff = User::factory()->create(['restaurant_id' => $restaurant->id, 'role' => UserRole::Staff]);
+
+        $this->actingAs($staff)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page->where('openaiKeyRejectedAt', null));
+    }
+
+    public function test_successful_generator_call_clears_the_flag(): void
+    {
+        OpenAiKeyHealth::flagAsRejected();
+        $this->assertNotNull(OpenAiKeyHealth::rejectedAt());
+
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        (new OpenAiReplyGenerator($fake, new NullLogger))->generate([
+            'restaurant' => ['name' => 'X', 'tonality' => 'casual'],
+            'request' => ['guest_name' => 'X', 'party_size' => 2, 'desired_at' => '2026-05-13 19:00', 'message' => null],
+            'availability' => [
+                'is_open_at_desired_time' => true,
+                'seats_free_at_desired' => 4,
+                'alternative_slots' => [],
+                'closed_reason' => null,
+            ],
+        ]);
+
+        $this->assertNull(OpenAiKeyHealth::rejectedAt());
+    }
+}


### PR DESCRIPTION
## Summary

- New \`App\Support\OpenAiKeyHealth\` cache helper holds a single global flag with 7-day TTL.
- New \`RecordOpenAiKeyRejected\` listener (auto-discovered) persists the flag whenever \`OpenAiAuthenticationFailed\` (dispatched from PR #176) fires.
- \`OpenAiReplyGenerator\` clears the flag the moment a chat call authenticates — auto-heal after key rotation, no dismissal needed.
- \`DashboardController\` exposes \`openaiKeyRejectedAt\` only for users with role Owner; staff see \`null\`.
- Dashboard renders an amber \"OpenAI-Key prüfen\" banner above the page header when the prop is non-null.

## Why

PRD-005 mandates a visible signal so a customer with a rotated/disabled OpenAI key isn't silently producing fallback drafts. Owner-role gating prevents the alert leaking to staff who can't fix it. No-dismissal is intentional: a \"dismissed but still broken\" failure mode is worse than waiting for the next successful call to self-heal.

## Test plan

- [x] \`php artisan test tests/Feature/OpenAi401AdminNotificationTest.php\` — 4 cases: listener flags, banner visible to Owner, hidden from Staff, success-clears
- [x] \`php artisan test\` — full suite green (502 passed)
- [x] \`./vendor/bin/pint --test\` — clean
- [x] \`npm run build\` — TS / Vite green
- [x] \`npm run format:check\` — clean

Closes #76