### PR TITLE
Highlight operator edits vs AI draft in approval drawer (#82)

### DIFF
--- a/resources/js/lib/line-diff.test.ts
+++ b/resources/js/lib/line-diff.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { lineDiff } from './line-diff';
+
+describe('lineDiff', () => {
+    it('returns all-context when the two strings are identical', () => {
+        const lines = lineDiff('A\nB\nC', 'A\nB\nC');
+        expect(lines.map((l) => l.kind)).toEqual(['context', 'context', 'context']);
+    });
+
+    it('marks an inserted middle line as added', () => {
+        const lines = lineDiff('A\nC', 'A\nB\nC');
+        expect(lines).toEqual([
+            { kind: 'context', text: 'A' },
+            { kind: 'added', text: 'B' },
+            { kind: 'context', text: 'C' },
+        ]);
+    });
+
+    it('marks a removed middle line', () => {
+        const lines = lineDiff('A\nB\nC', 'A\nC');
+        expect(lines).toEqual([
+            { kind: 'context', text: 'A' },
+            { kind: 'removed', text: 'B' },
+            { kind: 'context', text: 'C' },
+        ]);
+    });
+
+    it('handles a replacement as removal-then-addition', () => {
+        const lines = lineDiff('A\nB\nC', 'A\nX\nC');
+        expect(lines).toEqual([
+            { kind: 'context', text: 'A' },
+            { kind: 'removed', text: 'B' },
+            { kind: 'added', text: 'X' },
+            { kind: 'context', text: 'C' },
+        ]);
+    });
+
+    it('treats a fully rewritten body as removal of all old + addition of all new', () => {
+        const lines = lineDiff('A\nB', 'X\nY');
+        expect(lines.filter((l) => l.kind === 'removed').map((l) => l.text)).toEqual(['A', 'B']);
+        expect(lines.filter((l) => l.kind === 'added').map((l) => l.text)).toEqual(['X', 'Y']);
+    });
+
+    it('preserves blank lines as context', () => {
+        const lines = lineDiff('A\n\nB', 'A\n\nB');
+        expect(lines).toEqual([
+            { kind: 'context', text: 'A' },
+            { kind: 'context', text: '' },
+            { kind: 'context', text: 'B' },
+        ]);
+    });
+
+    it('handles an empty original (everything is added)', () => {
+        const lines = lineDiff('', 'X');
+        expect(lines).toEqual([
+            { kind: 'removed', text: '' },
+            { kind: 'added', text: 'X' },
+        ]);
+    });
+
+    it('handles an empty edit (everything is removed)', () => {
+        const lines = lineDiff('A\nB', '');
+        const removals = lines.filter((l) => l.kind === 'removed').map((l) => l.text);
+        expect(removals).toEqual(['A', 'B']);
+    });
+});

--- a/resources/js/lib/line-diff.ts
+++ b/resources/js/lib/line-diff.ts
@@ -1,0 +1,57 @@
+/**
+ * Line-level diff between an original string and an edited one. Walks
+ * both arrays once with two cursors and a small look-ahead so that
+ * inserted-only / deleted-only / replaced lines render correctly without
+ * the cost of pulling in a full LCS dependency.
+ *
+ * Surfaced in the dashboard drawer (PRD-005 / issue #82) so the
+ * operator can see what they changed against the AI draft before
+ * approving — the placebo-click mitigation called out in PRD-005's
+ * "Risiken" section.
+ */
+export type DiffLineKind = 'added' | 'removed' | 'context';
+
+export interface DiffLine {
+    kind: DiffLineKind;
+    text: string;
+}
+
+export function lineDiff(original: string, edited: string): DiffLine[] {
+    const oldLines = original.split('\n');
+    const newLines = edited.split('\n');
+    const out: DiffLine[] = [];
+
+    let i = 0;
+    let j = 0;
+    while (i < oldLines.length || j < newLines.length) {
+        if (i < oldLines.length && j < newLines.length && oldLines[i] === newLines[j]) {
+            out.push({ kind: 'context', text: oldLines[i] });
+            i++;
+            j++;
+            continue;
+        }
+
+        // Look ahead in newLines for the next reappearance of the
+        // current oldLine — everything in between is an insertion.
+        const nextMatchInNew = i < oldLines.length ? newLines.indexOf(oldLines[i], j) : -1;
+        if (nextMatchInNew !== -1) {
+            while (j < nextMatchInNew) {
+                out.push({ kind: 'added', text: newLines[j] });
+                j++;
+            }
+            continue;
+        }
+
+        // Otherwise the current oldLine has no future match — removal.
+        // Mirror remaining newLines as additions when oldLines is exhausted.
+        if (i < oldLines.length) {
+            out.push({ kind: 'removed', text: oldLines[i] });
+            i++;
+        } else if (j < newLines.length) {
+            out.push({ kind: 'added', text: newLines[j] });
+            j++;
+        }
+    }
+
+    return out;
+}

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -274,7 +274,12 @@ function submitApproval(): void {
         return;
     }
 
-    const original = reply.body;
+    // Trim both sides so a whitespace-only "edit" doesn't get persisted
+    // as a real operator edit. `isEdited` and the diff panel use the
+    // same convention; mismatching here would let the button relabel
+    // itself to "Bearbeitete Version senden" yet still send the
+    // original body, or vice versa.
+    const original = reply.body.trim();
     const edited = replyBody.value.trim();
     const payload = edited !== '' && edited !== original ? { body: edited } : {};
 

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -9,6 +9,7 @@ import { usePagePolling } from '@/composables/usePagePolling';
 import { useRowSelection } from '@/composables/useRowSelection';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { formatDateTime } from '@/lib/format-datetime';
+import { type DiffLine, lineDiff } from '@/lib/line-diff';
 import {
     type BreadcrumbItem,
     type DashboardFilters,
@@ -211,6 +212,13 @@ const REPLY_STATUS_BADGE: Record<'draft' | 'approved' | 'sent' | 'failed', strin
 
 const replyBody = ref('');
 const approving = ref(false);
+const diffOpen = ref(false);
+
+const DIFF_PREFIX: Record<'added' | 'removed' | 'context', string> = {
+    added: '+',
+    removed: '−',
+    context: ' ',
+};
 
 // Per-reply scratchpad. Switching rows must NOT silently lose an
 // in-progress edit, so unsaved bodies are stashed by reply.id and
@@ -223,6 +231,22 @@ const currentReplyId = computed(() => props.selectedRequest?.latest_reply?.id ??
 const isReplyEditable = computed(() => {
     const reply = props.selectedRequest?.latest_reply;
     return reply !== null && reply !== undefined && reply.status === 'draft';
+});
+
+const isEdited = computed(() => {
+    const reply = props.selectedRequest?.latest_reply;
+    if (!reply) {
+        return false;
+    }
+    return replyBody.value.trim() !== reply.body.trim();
+});
+
+const replyDiff = computed<DiffLine[]>(() => {
+    const reply = props.selectedRequest?.latest_reply;
+    if (!reply) {
+        return [];
+    }
+    return lineDiff(reply.body, replyBody.value);
 });
 
 watch(
@@ -640,6 +664,31 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                         data-testid="ai-reply-textarea"
                     ></textarea>
 
+                    <Collapsible v-if="isReplyEditable && isEdited" v-model:open="diffOpen" class="space-y-2" data-testid="ai-reply-diff-collapsible">
+                        <CollapsibleTrigger as-child>
+                            <Button variant="outline" size="sm" class="w-full justify-between" data-testid="ai-reply-diff-toggle">
+                                <span>Änderungen gegenüber dem KI-Vorschlag anzeigen</span>
+                                <ChevronDown class="size-4 transition-transform" :class="diffOpen ? 'rotate-180' : ''" />
+                            </Button>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent>
+                            <ol class="space-y-1 rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed" data-testid="ai-reply-diff">
+                                <li
+                                    v-for="(line, idx) in replyDiff"
+                                    :key="idx"
+                                    :class="{
+                                        'text-emerald-700 dark:text-emerald-400': line.kind === 'added',
+                                        'text-red-700 line-through dark:text-red-400': line.kind === 'removed',
+                                        'text-muted-foreground': line.kind === 'context',
+                                    }"
+                                >
+                                    <span class="select-none pr-2 font-mono">{{ DIFF_PREFIX[line.kind] }}</span>
+                                    <span class="whitespace-pre-wrap">{{ line.text || ' ' }}</span>
+                                </li>
+                            </ol>
+                        </CollapsibleContent>
+                    </Collapsible>
+
                     <p
                         v-if="props.selectedRequest.latest_reply.status === 'failed' && props.selectedRequest.latest_reply.error_message"
                         class="text-xs text-red-600 dark:text-red-400"
@@ -653,7 +702,7 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                     </p>
 
                     <Button v-if="isReplyEditable" :disabled="approving" class="w-full" data-testid="ai-reply-approve" @click="submitApproval">
-                        Freigeben &amp; Versenden
+                        {{ isEdited ? 'Bearbeitete Version senden' : 'Freigeben & Versenden' }}
                     </Button>
                 </section>
             </SheetContent>


### PR DESCRIPTION
## Summary

Closes the placebo-click loophole called out in PRD-005 \"Risiken\": without a visible diff, the operator's \"Freigeben\" click is at risk of becoming reflexive.

- Approve button label flips between \"Freigeben & Versenden\" and \"Bearbeitete Version senden\" — one-glance signal that the edited body will actually go out.
- New collapsed \"Änderungen gegenüber dem KI-Vorschlag anzeigen\" panel (only when editable AND edited) shows a line-level diff: \`+\` additions in green, \`−\` removals in red strike, blank context in muted grey.
- Diff computed by \`resources/js/lib/line-diff.ts\` — small two-cursor walker, no LCS dependency.

## Why

Per PRD-005's Risiken section, the freigabe step risks becoming a placebo if the operator can't see what they changed. Surfacing the diff gives the click meaning. Keeping it collapsed-by-default keeps the drawer compact when nothing has been edited.

## Test plan

- [x] \`npm run test\` — 8 new vitest cases for \`lineDiff\` (identical / insert / remove / replace / rewrite / blank-line context / empty original / empty edit)
- [x] \`php artisan test\` — full suite green (502 passed)
- [x] \`./vendor/bin/pint --test\` — clean
- [x] \`npm run build\` — TS / Vite green
- [x] \`npm run format:check\` — clean

Closes #82