### PR TITLE
docs: V2.0 PRDs (006-010) and post-V1 roadmap mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,20 +143,28 @@ reservation-agent/
 
 ---
 
-## Bewusst NICHT in V1.0
+## Roadmap nach V1.0
 
-| Feature                                 | Version |
-|-----------------------------------------|---------|
-| OpenTable / TheFork / Quandoo Anbindung | V2.0    |
-| Google Reserve / Google Business        | V2.0    |
-| Automatischer Mailversand ohne Freigabe | V2.0    |
-| Tischplan / grafische Sitzordnung       | V2.0    |
-| Zahlungs-Hinterlegung / No-Show-Gebühr  | V2.0    |
-| Mehrsprachige Antworten                 | V2.0    |
-| Analytics / Reporting                   | V2.0    |
-| Multi-Standort-Verwaltung > 5 Standorte | V3.0    |
-| Mobile App                              | V3.0    |
-| Lokale KI (Ollama/Llama)                | V3.0    |
+| Feature                                          | Version | Status                                                              |
+|--------------------------------------------------|---------|---------------------------------------------------------------------|
+| Mail-Threading                                   | V2.0    | scoped → [PRD-006](docs/PRD-006-mail-threading.md)                  |
+| Automatischer Mailversand (opt-in mit Hard-Gates)| V2.0    | scoped → [PRD-007](docs/PRD-007-auto-send-trust-modes.md)           |
+| Analytics / Reporting                            | V2.0    | scoped → [PRD-008](docs/PRD-008-dashboard-analytics.md)             |
+| Export CSV/PDF                                   | V2.0    | scoped → [PRD-009](docs/PRD-009-export-csv-pdf.md)                  |
+| Push / Sound-Alerts / Daily Digest               | V2.0    | scoped → [PRD-010](docs/PRD-010-push-and-sound-alerts.md)           |
+| Tischplan / grafische Sitzordnung                | V3.0    | (Robustheit + Tischplan)                                            |
+| WebSockets via Laravel Reverb                    | V3.0    | siehe [decision](docs/decisions/polling-vs-websockets-v1.md)        |
+| DSGVO-UI für Betroffenen-Löschanträge            | V3.0    | siehe [decision](docs/decisions/failed-email-imports-retention.md)  |
+| Multi-Standort-Verwaltung > 5 Standorte          | V3.0    |                                                                     |
+| KI lernt aus manuellen Edits (RAG)               | V4.0    | (KI-Differenzierung)                                                |
+| Tonalität pro Restaurant statt global            | V4.0    | siehe [decision](docs/decisions/ai-tonality-prompts.md)             |
+| Mehrsprachige Antworten                          | V4.0    |                                                                     |
+| Lokale KI (Ollama / vLLM)                        | V4.0+   | siehe [decision](docs/decisions/openai-data-protection.md)          |
+| Embeddable Widget / iframe-Variante              | V5.0    | (Reichweite)                                                        |
+| OpenTable / TheFork / Quandoo Anbindung          | V5.0    | (Reichweite)                                                        |
+| Google Reserve / Google Business                 | V5.0    | (Reichweite)                                                        |
+| Mobile App                                       | V5.0+   | eigene Produkt-Linie                                                |
+| Zahlungs-Hinterlegung / No-Show-Gebühr           | offen   | nicht versionsgebunden                                              |
 
 ---
 

--- a/docs/PRD-006-mail-threading.md
+++ b/docs/PRD-006-mail-threading.md
@@ -1,0 +1,296 @@
+# PRD-006: Mail-Threading
+
+**Produkt:** reservation-agent
+**Version:** V2.0
+**Priorität:** P0 – Voraussetzung für PRD-007 (Auto-Versand)
+**Entwicklungsphase:** V2-Phase 1
+
+---
+
+## Problem
+
+In V1.0 erkennt PRD-003 jede eingehende Mail als neue Reservierungsanfrage. Wenn ein Gast auf eine vom System versendete Bestätigungsmail antwortet (z. B. *„Vielen Dank, sehen uns Freitag!"* oder *„Können wir doch noch auf 19:30 verschieben?"*), entsteht eine **zweite** Reservierung im Dashboard – obwohl es ein Folgekommentar zur ersten ist.
+
+Das hat drei Folgen:
+
+1. **Dubletten** – der Gastronom muss manuell mergen, was zeitintensiv und fehleranfällig ist.
+2. **Falsche Statistiken** – jede Reply zählt als neue Anfrage in PRD-008-Reports.
+3. **Auto-Versand wäre gefährlich** – ohne Threading würde PRD-007 im `auto`-Modus auf eine Reply wie *„Danke!"* mit einer kompletten Reservierungsbestätigung antworten. Das ist peinlich und kostet Vertrauen.
+
+PRD-003 hat dieses Problem explizit nach V2.0 verschoben (siehe [`docs/PRD-003-email-ingestion.md`](PRD-003-email-ingestion.md) Zeile 39 und 151).
+
+## Ziel
+
+Eingehende Mails werden anhand der RFC-2822-Threading-Header (`Message-ID`, `In-Reply-To`, `References`) und einer Subject-Marker-Heuristik einer bereits existierenden `ReservationRequest` zugeordnet. Treffer landen als `ReservationMessage` an der bestehenden Reservierung – kein neuer Request entsteht. Outbound-Mails (von PRD-005 und PRD-007) tragen ihrerseits eine stabile Message-ID und einen Subject-Marker, damit Replies sauber zuordenbar sind.
+
+Wo Threading nicht eindeutig auflösbar ist, fällt das System auf das V1.0-Verhalten zurück: neuer `ReservationRequest` mit `needs_manual_review = true`. Niemals wird eine Reply einer *falschen* Reservierung zugeordnet (Spoofing-Sicherheit).
+
+---
+
+## Scope V2.0
+
+### In Scope
+
+- Neue Tabelle `reservation_messages` für die Thread-Historie pro Reservierung (in- und outbound)
+- Erweiterung `reservation_replies.outbound_message_id` (eindeutige RFC-2822-Message-ID jeder versendeten Mail)
+- Service `ThreadResolver` mit vier Resolution-Strategien (`In-Reply-To`, `References`, Subject-Marker, Heuristik)
+- Cross-Check Absender-Adresse vs. `guest_email` der Ziel-Reservierung (Anti-Spoofing)
+- Automatisches Einfügen des Subject-Markers `[Res #<id>]` in jede outbound Mail (PRD-005-Mailable + PRD-007-Mailable)
+- Stabile Message-ID-Generation in `ReservationReplyMail` via `withSymfonyMessage`
+- Erweiterung des Dashboard-Detail-Drawers um eine Thread-Ansicht (chronologisch: Original-Anfrage → ausgehende Antworten → eingehende Replies)
+- Erweiterung von `EmailReservationParser` und `FetchReservationEmailsJob` um den `ThreadResolver`-Schritt **vor** der Anlage einer neuen Reservierung
+- Idempotenz: gleiche `Message-ID` wird nie doppelt importiert (egal ob als neue Reservation oder als Thread-Message)
+
+### Out of Scope
+
+- Forwarding-Heuristik (Gast leitet Bestätigung an seinen Partner weiter, der antwortet aus anderer Adresse) – V3.0
+- Conversational Auto-Reply (KI antwortet automatisch auf eine Gast-Reply) – V4.0
+- Inhaltsbasierte Status-Übergänge aus Replies (*„Ich storniere"* → `cancelled`) – V4.0
+- Threading für Web-Form-Anfragen (Web-Anfragen sind atomar, kein Thread-Konzept)
+
+---
+
+## Technische Anforderungen
+
+### Datenmodell
+
+**Neue Tabelle `reservation_messages`** (Migration additiv, kein Schema-Bruch):
+
+| Spalte                  | Typ            | Notiz                                                  |
+|-------------------------|----------------|--------------------------------------------------------|
+| id                      | bigint PK      |                                                        |
+| reservation_request_id  | bigint FK      | indexiert                                              |
+| direction               | string         | `in` \| `out`                                          |
+| message_id              | string unique  | RFC-2822-Message-ID, eindeutig über alle Restaurants   |
+| in_reply_to             | string null    | aus Header                                             |
+| references              | text null      | gesamte References-Kette (Whitespace-separated)        |
+| subject                 | string         |                                                        |
+| from_address            | string         | Absender (Outbound: System-Mail, Inbound: Gast)        |
+| to_address              | string         | Empfänger                                              |
+| body_plain              | text           | Plaintext-Repräsentation                               |
+| raw_headers             | text           | komplette Headers (für Audit + spätere Heuristiken)    |
+| sent_at                 | datetime null  | bei `direction = out`                                  |
+| received_at             | datetime null  | bei `direction = in`                                   |
+| created_at, updated_at  | timestamps     |                                                        |
+
+Index: `(reservation_request_id, created_at)` für Drawer-Query.
+Unique: `message_id` (verhindert doppelten Import).
+
+**Erweiterung `reservation_replies`:**
+
+| Spalte                | Typ           | Notiz                                                  |
+|-----------------------|---------------|--------------------------------------------------------|
+| outbound_message_id   | string null   | RFC-2822-Message-ID der versendeten Mail; FK-loose zu `reservation_messages.message_id` |
+
+`outbound_message_id` ist `null` solange `status = draft`, wird beim Versand gesetzt.
+
+### ThreadResolver
+
+`app/Services/Email/ThreadResolver.php` – ein zustandsloser Service mit nur einer öffentlichen Methode:
+
+```php
+final class ThreadResolver
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Versucht, eine eingehende Mail einer existierenden Reservierung zuzuordnen.
+     * Liefert null, wenn keine eindeutige Zuordnung möglich ist.
+     */
+    public function resolveForIncoming(\Webklex\PHPIMAP\Message $message, int $restaurantId): ?ReservationRequest
+    {
+        // Strategie 1: In-Reply-To → bekannte outbound Message-ID
+        if ($id = $this->byInReplyTo($message, $restaurantId)) {
+            return $this->verifySender($id, $message);
+        }
+
+        // Strategie 2: References → eine bekannte Message-ID in der Kette
+        if ($id = $this->byReferences($message, $restaurantId)) {
+            return $this->verifySender($id, $message);
+        }
+
+        // Strategie 3: Subject-Marker [Res #<id>]
+        if ($id = $this->bySubjectMarker($message, $restaurantId)) {
+            return $this->verifySender($id, $message);
+        }
+
+        // Strategie 4: Heuristik: Subject "Re: <bekanntes Subject>" + gleicher Absender + < 30 Tage
+        if ($id = $this->byHeuristic($message, $restaurantId)) {
+            return $this->verifySender($id, $message);
+        }
+
+        return null;
+    }
+
+    private function verifySender(ReservationRequest $request, \Webklex\PHPIMAP\Message $message): ?ReservationRequest
+    {
+        $from = strtolower(trim((string) $message->getFrom()[0]?->mail ?? ''));
+        $expected = strtolower(trim((string) $request->guest_email));
+
+        if ($from === '' || $expected === '' || $from !== $expected) {
+            $this->logger->warning('thread resolver: sender mismatch, falling back to new reservation', [
+                'reservation_id' => $request->id,
+                'message_id'     => (string) $message->getMessageId(),
+                // Adressen werden NICHT geloggt
+            ]);
+            return null;
+        }
+
+        return $request;
+    }
+}
+```
+
+**Strategie-Details:**
+
+- **`byInReplyTo`** – sucht in `reservation_messages.message_id` (direction = out) nach dem Wert von `In-Reply-To`. Bei Treffer wird die zugehörige `ReservationRequest` geladen, eingeschränkt auf das Restaurant.
+- **`byReferences`** – splittet den `References`-Header an Whitespace, sucht für jede ID nach einer outbound Message. Erste Übereinstimmung gewinnt.
+- **`bySubjectMarker`** – Regex `/\[Res #(\d+)\]/` im Subject. Falls die ID zu einer Reservation des Restaurants gehört: Treffer.
+- **`byHeuristic`** – nur als Fallback: Subject beginnt mit `Re: `, Rest des Subjects matcht das Subject einer outbound Mail dieser Reservation aus den letzten 30 Tagen, **und** die Absender-Adresse entspricht `guest_email`. Diese Strategie ist die schwächste und wird bewusst nur als letzter Versuch eingesetzt.
+
+`verifySender` ist nicht-verhandelbar: jede positive Resolution wird zusätzlich gegen die Gast-Mail geprüft. Spoofing eines `In-Reply-To` auf fremde Reservierungen wird so abgewehrt.
+
+### Integration in den Fetch-Job
+
+`FetchReservationEmailsJob` aus PRD-003 wird angepasst (additiv, kein Patternbruch):
+
+```php
+foreach ($messages as $message) {
+    if ($this->alreadyImported($message->getMessageId())) {
+        continue;
+    }
+
+    if ($threadParent = $this->threadResolver->resolveForIncoming($message, $this->restaurantId)) {
+        $this->appendAsThreadMessage($threadParent, $message);
+        $message->setFlag('Seen');
+        continue;
+    }
+
+    // V1.0-Pfad: neue Reservation anlegen
+    $parsed = $this->parser->parse($message);
+    // ... unverändert
+}
+```
+
+`alreadyImported` prüft `reservation_messages.message_id` UND `reservation_requests.email_message_id` (PRD-003-Spalte). Damit ist Idempotenz auch über den Modus-Wechsel hinweg garantiert.
+
+### Outbound-Pfad
+
+`app/Mail/ReservationReplyMail.php` (aus PRD-005) wird erweitert:
+
+```php
+public function build(): self
+{
+    return $this
+        ->subject($this->buildSubjectWithMarker())
+        ->view('mail.reservation-reply')
+        ->with(['reply' => $this->reply])
+        ->withSymfonyMessage(function (Email $email) {
+            $messageId = $this->generateMessageId();
+            $email->getHeaders()->addIdHeader('Message-ID', $messageId);
+
+            // Falls bereits frühere Outbound-Mails existieren: References-Kette setzen
+            if ($previous = $this->previousMessageIds()) {
+                $email->getHeaders()->addTextHeader('References', implode(' ', $previous));
+                $email->getHeaders()->addTextHeader('In-Reply-To', end($previous));
+            }
+
+            $this->reply->update(['outbound_message_id' => $messageId]);
+        });
+}
+
+private function buildSubjectWithMarker(): string
+{
+    $marker = sprintf('[Res #%d]', $this->reply->reservation_request_id);
+    $subject = $this->originalSubject ?? sprintf('Reservierung bei %s', $this->restaurant->name);
+
+    return str_contains($subject, $marker) ? $subject : "{$subject} {$marker}";
+}
+
+private function generateMessageId(): string
+{
+    return sprintf('<reservation-%d-%s@%s>',
+        $this->reply->id,
+        bin2hex(random_bytes(8)),
+        config('mail.from.address') ? parse_url('mailto:'.config('mail.from.address'))['path'] ?? 'localhost' : 'localhost'
+    );
+}
+```
+
+**Wichtig:** `generateMessageId` nutzt `random_bytes` (vgl. CLAUDE.md-Verbote: keine eigene Krypto, aber `random_bytes` ist Laravel-Standard).
+
+Nach erfolgreichem Versand (`SendReservationReplyJob`) wird zusätzlich ein `ReservationMessage` mit `direction = out` angelegt, damit der Thread auch im Detail-Drawer vollständig sichtbar ist.
+
+### Dashboard-Erweiterung
+
+`resources/js/pages/Dashboard.vue` Detail-Drawer:
+
+- Neuer Tab/Abschnitt „Verlauf"
+- Lädt `reservation_messages` der Reservation chronologisch (separater Endpoint `GET /reservations/{id}/messages`, Resource-basiert)
+- Pro Eintrag: Richtung-Icon (↑ outbound, ↓ inbound), Datum, Subject, Body (Plaintext), Absender
+- Outbound-Mails zeigen zusätzlich den User, der die Antwort freigegeben hat (PRD-005)
+
+API-Resource `ReservationMessageResource` mappt nur die Felder, die das UI braucht – `raw_headers` bleibt server-seitig.
+
+---
+
+## Akzeptanzkriterien
+
+- [ ] Outbound-Mail enthält stabile, eindeutige `Message-ID` (`<reservation-{id}-{random}@{domain}>`)
+- [ ] Outbound-Subject enthält automatisch den `[Res #<id>]`-Marker
+- [ ] Zweite Outbound-Mail an dieselbe Reservation setzt korrekten `References`-Header und `In-Reply-To`
+- [ ] Inbound-Reply mit passender `In-Reply-To` wird als `reservation_message` an existierende Reservation gehängt – **kein neuer Request**
+- [ ] Inbound-Reply ohne Threading-Header, aber mit `[Res #<id>]` im Subject und passender Absender-Adresse wird zugeordnet
+- [ ] Inbound-Reply mit gespooftem `In-Reply-To` (Absender ≠ `guest_email`) → Sender-Mismatch greift, Resolution liefert null, Fallback auf neuer Request mit `needs_manual_review = true`
+- [ ] Idempotenz: gleiche `Message-ID` (in- oder outbound) wird nie zweimal in die DB aufgenommen
+- [ ] Detail-Drawer zeigt Thread chronologisch
+- [ ] Bestehende V1.0-Tests aus PRD-003 bleiben grün
+- [ ] Alle neuen Tests grün
+- [ ] `./vendor/bin/pint --test` ohne Findings, `npm run lint` und `npm run format:check` ohne Findings
+
+---
+
+## Tests
+
+**Unit (`tests/Unit/Email/ThreadResolverTest.php`)**
+
+- `it resolves by in-reply-to header` – Outbound-Message in DB, Inbound mit passendem `In-Reply-To` → Treffer
+- `it resolves by references chain` – `In-Reply-To` unbekannt, aber `References`-Kette enthält bekannte ID
+- `it resolves by subject marker` – nur `[Res #42]` im Subject, keine Header → Treffer
+- `it resolves by heuristic when within 30 days`
+- `it does NOT resolve by heuristic when older than 30 days`
+- `it rejects spoofed in-reply-to (sender mismatch)` – Treffer wird durch Sender-Check verworfen
+- `it returns null when no strategy matches`
+- `it does not match across restaurants` – outbound Message gehört zu Restaurant A, Inbound trifft Restaurant B → keine Resolution
+
+**Feature (`tests/Feature/Email/ThreadingFlowTest.php`)**
+
+- `it appends reply as thread message instead of creating new reservation`
+- `it falls back to new reservation when sender does not match`
+- `it generates stable message id for outbound mail` (mit `Mail::fake()` und Header-Inspection)
+- `it inserts subject marker for outbound mail`
+- `it builds references chain on second outbound mail`
+- `it dedupes by message id even with thread fallback`
+- `it lists thread messages in detail drawer chronologically`
+
+**Fixtures**
+
+`tests/Fixtures/emails/threading/`:
+- `reply-with-in-reply-to.eml`
+- `reply-with-references-only.eml`
+- `reply-with-subject-marker-only.eml`
+- `reply-spoofed-in-reply-to.eml` (`In-Reply-To` zeigt auf bekannte ID, aber Absender weicht ab)
+- `reply-heuristic-match.eml`
+- `reply-no-match.eml`
+
+---
+
+## Risiken & offene Fragen
+
+- **Spoofing über gefälschte Absender** – wenn ein Angreifer sowohl `In-Reply-To` als auch die `From`-Adresse fälscht, würde die Reply einer fremden Reservation zugeordnet. Das ist kein Threading-Problem, sondern ein Mail-Authentizitäts-Problem (DKIM/SPF). V2.0 löst es nicht; V3.0 sollte DKIM-Validierung erwägen.
+- **Mailclients normalisieren Subjects unterschiedlich** – `Re:`, `RE:`, `AW:`, `Antw:`, `Re[2]:`. Die Heuristik nimmt das in Kauf und vergleicht Subjects nach Strip-Pattern (`/^(re|aw|antw)(\[\d+\])?:\s*/i`).
+- **References-Header kann lang werden** – RFC empfiehlt Trimming auf ~1000 Zeichen. Wir behalten die DB-Spalte als `text`, aber outbound trimmen wir auf die letzten 10 Message-IDs der Kette.
+- **Thread-Drift** – wenn ein Gast in einer Reply ein völlig neues Anliegen schreibt („Ach übrigens, übermorgen 6 Personen?"), wird das aktuell als Thread-Message und nicht als neue Reservation gespeichert. Das ist akzeptabler V2.0-Tradeoff – PRD-007-Auto-Send schaltet sich bei diesem Pattern ohnehin nicht ein, weil keine neue `ReservationRequest` entsteht und damit keine `desired_at` zur Auto-Send-Entscheidung vorliegt. PRD-008-Analytics zeigt aber Thread-Volumen, sodass Drift erkennbar wird.
+- **DSGVO** – `reservation_messages.body_plain` und `raw_headers` enthalten personenbezogene Daten. Sie unterliegen derselben Aufbewahrungsfrist wie `ReservationRequest` (siehe Decision in [`docs/decisions/failed-email-imports-retention.md`](decisions/failed-email-imports-retention.md)).

--- a/docs/PRD-007-auto-send-trust-modes.md
+++ b/docs/PRD-007-auto-send-trust-modes.md
@@ -1,0 +1,508 @@
+# PRD-007: Auto-Versand mit Vertrauensstufen
+
+**Produkt:** reservation-agent
+**Version:** V2.0
+**Priorität:** P0 – das zentrale V2.0-Feature
+**Entwicklungsphase:** V2-Phase 2 (nach PRD-006)
+
+---
+
+## Problem
+
+In V1.0 ist die manuelle Freigabe jeder KI-Antwort architektonisches Prinzip:
+
+> *„Kein KI-generierter Text erreicht ohne menschliche Bestätigung einen Kunden."*
+> ([CLAUDE.md](../CLAUDE.md), Kernprinzip)
+
+Dieses Prinzip ist bewusst gewählt – V1.0 baut Vertrauen erst auf. Aber bei produktiv laufenden Restaurants wird die Freigabe-Pflicht zur **operativen Engstelle**:
+
+- Stoßzeiten erzeugen viele Anfragen gleichzeitig
+- Nachts oder am Ruhetag ist niemand am Dashboard – Anfragen warten Stunden
+- Bei wiederholt unveränderten Freigaben („alles freigeben"-Klick) wird die manuelle Stufe zur Placebo-Sicherheit
+
+Gleichzeitig: **blindes Auto-Send wäre fahrlässig**. Eine einzige halluzinierte Bestätigung an einen Gast, dessen Tisch nicht existiert, schadet dem Restaurant nachhaltiger als jede gesparte Minute.
+
+Es braucht einen Pfad, der **Vertrauen messbar aufbaut, bevor er versendet** – und der harte Sicherheitsnetze auch dann beibehält, wenn der Owner Auto-Send aktiviert.
+
+## Ziel
+
+Pro Restaurant kann der Owner einen Versandmodus wählen: `manual` (V1.0-Verhalten, Default), `shadow` (KI generiert + markiert „wäre versendet worden", versendet aber nicht), `auto` (versendet automatisch nach Sicherheits-Cooldown). Bestimmte Anfrage-Konstellationen erzwingen unabhängig vom Modus immer manuelle Freigabe.
+
+Der Wechsel `manual → shadow → auto` läuft als bewusster Vertrauensaufbau: im Shadow-Modus sammelt das System Daten über die Übernahme-Rate des Owners, der Wechsel auf `auto` zeigt diese Statistik im Confirmation-Dialog. Ein **Killswitch** schaltet jederzeit auf `manual` zurück und stoppt alle eingeplanten, aber noch nicht versendeten Auto-Sends.
+
+---
+
+## Scope V2.0
+
+### In Scope
+
+- Migration: `restaurants.send_mode` (Enum `SendMode`: `manual` | `shadow` | `auto`, Default `manual`)
+- Migration: `restaurants.auto_send_party_size_max` (int, Default 10)
+- Migration: `restaurants.auto_send_min_lead_time_minutes` (int, Default 90)
+- Migration: `reservation_replies.send_mode_at_creation` (Enum-Snapshot zum Generierzeitpunkt)
+- Migration: `reservation_replies.shadow_compared_at`, `shadow_was_modified` (boolean) für Übernahme-Statistik
+- Migration: neue Status-Werte in `ReservationReplyStatus` Enum: `shadow`, `scheduled_auto_send`, `cancelled_auto`
+- Service `AutoSendDecider` mit Hard-Gate-Cascade
+- Wert-Objekt `AutoSendDecision` (Status `manual` | `shadow` | `auto_send`, plus `reason`)
+- Job `ScheduledAutoSendJob` mit 60-Sekunden-Delay (Cancel-Window)
+- Killswitch-Action: `Restaurant::killswitchAutoSend()` – setzt Mode zurück und cancelt alle laufenden Auto-Send-Jobs
+- Audit-Tabelle `auto_send_audits` für nachvollziehbare Entscheidungen
+- Settings-UI `resources/js/pages/Settings/SendMode.vue` mit Drei-Karten-Layout, Confirmation-Dialogs und Killswitch
+- Dashboard-Banner zeigt aktiven Mode
+- Detail-Drawer-Erweiterung: Shadow-Replies mit Vergleichs-Block + „Doch manuell freigeben"-Button
+- Anpassung `CLAUDE.md` Kernprinzip-Block (V1.0-Verbot wird zu opt-in-Erlaubnis mit Sicherheitsnetzen)
+- Anpassung Datenschutzhinweis: Auto-Versand muss in Datenschutzerklärung erwähnt werden
+
+### Out of Scope
+
+- Granulare Toggles pro Antworttyp (Bestätigung/Ablehnung/Alternative) – V2.1 (eigenes Issue, falls erste Pilot-Daten Bedarf zeigen)
+- Confidence-basierte Auto-Send-Schwellen (über Hard-Gates hinaus) – V4.0 (gehört zur KI-Lernschleife)
+- Time-of-day-Regeln („nicht zwischen 22 und 8 Uhr autosenden") – V2.1
+- Auto-Versand für eingehende Replies (PRD-006-Thread-Messages) – V4.0 (Conversational AI)
+- A/B-Vergleich KI-Draft vs. Owner-Edit zur Lernsignalisierung – V4.0
+
+---
+
+## Technische Anforderungen
+
+### Enum
+
+`app/Enums/SendMode.php`:
+
+```php
+enum SendMode: string
+{
+    case Manual = 'manual';
+    case Shadow = 'shadow';
+    case Auto   = 'auto';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Manual => 'Manuelle Freigabe',
+            self::Shadow => 'Shadow-Modus (Test)',
+            self::Auto   => 'Automatischer Versand',
+        };
+    }
+}
+```
+
+`ReservationReplyStatus` aus PRD-001 wird erweitert:
+
+```php
+case Shadow             = 'shadow';              // Draft, der NICHT versendet wird, aber als „wäre versendet" markiert ist
+case ScheduledAutoSend  = 'scheduled_auto_send'; // Draft im 60s-Cancel-Window
+case CancelledAuto      = 'cancelled_auto';      // Auto-Send durch Owner oder Killswitch abgebrochen
+```
+
+Status-Übergänge in `ReservationReplyStatus::canTransitionTo()`:
+
+```
+draft → shadow                     (Shadow-Modus aktiv, Generierung fertig)
+draft → scheduled_auto_send        (Auto-Modus aktiv, Generierung fertig, 60s warten)
+draft → approved                   (V1.0: manuelle Freigabe)
+shadow → approved                  („Doch manuell freigeben"-Button)
+shadow → draft                     (Owner editiert Shadow-Reply → wird zum Draft mit modified=true)
+scheduled_auto_send → sent         (60s vorbei, Mailversand erfolgreich)
+scheduled_auto_send → cancelled_auto (Owner klickt „Abbrechen" oder Killswitch)
+scheduled_auto_send → approved     (Owner überholt das Cancel-Window mit manueller Freigabe)
+```
+
+### Datenmodell-Erweiterungen
+
+**`restaurants`:**
+
+| Spalte                            | Typ                | Default     |
+|-----------------------------------|--------------------|-------------|
+| send_mode                         | string (SendMode)  | `manual`    |
+| auto_send_party_size_max          | int                | 10          |
+| auto_send_min_lead_time_minutes   | int                | 90          |
+| send_mode_changed_at              | datetime null      | null        |
+| send_mode_changed_by              | bigint FK null     | null        |
+
+**`reservation_replies`:**
+
+| Spalte                  | Typ                | Notiz                                              |
+|-------------------------|--------------------|----------------------------------------------------|
+| send_mode_at_creation   | string (SendMode)  | Snapshot, NICHT mit Restaurant-Setting joinen      |
+| shadow_compared_at      | datetime null      | wann der Owner die Shadow-Reply angesehen hat      |
+| shadow_was_modified     | boolean            | true, wenn Owner den Body editiert hat             |
+| auto_send_decision      | json null          | serialisierter `AutoSendDecision` (für Audit)      |
+| auto_send_scheduled_for | datetime null      | gesetzt im `scheduled_auto_send`-Status            |
+
+**Neue Tabelle `auto_send_audits`** (append-only):
+
+| Spalte                   | Typ        |
+|--------------------------|------------|
+| id                       | bigint PK  |
+| reservation_reply_id     | bigint FK  |
+| restaurant_id            | bigint FK  |
+| send_mode                | string     |
+| decision                 | string     | `manual` \| `shadow` \| `auto_send` \| `cancelled_auto` |
+| reason                   | string     | siehe AutoSendDecider-Reason-Codes                  |
+| triggered_by_user_id     | bigint FK null | null = System (Auto-Send), gesetzt bei Killswitch/Cancel |
+| created_at               | timestamp  |
+
+Index: `(restaurant_id, created_at)` für PRD-008-Analytics.
+
+### AutoSendDecider
+
+`app/Services/AI/AutoSendDecider.php` – zentraler Service, der zur **einzig autoritativen Quelle** für die Entscheidung wird, ob/wie versendet wird.
+
+```php
+final class AutoSendDecider
+{
+    public function decide(ReservationReply $reply): AutoSendDecision
+    {
+        $request = $reply->reservationRequest;
+        $restaurant = $request->restaurant;
+
+        if ($gate = $this->blockedByHardGate($request, $reply)) {
+            return AutoSendDecision::manual($gate);
+        }
+
+        return match ($restaurant->send_mode) {
+            SendMode::Manual => AutoSendDecision::manual('mode_manual'),
+            SendMode::Shadow => AutoSendDecision::shadow('mode_shadow'),
+            SendMode::Auto   => AutoSendDecision::autoSend('mode_auto'),
+        };
+    }
+
+    private function blockedByHardGate(ReservationRequest $request, ReservationReply $reply): ?string
+    {
+        $restaurant = $request->restaurant;
+
+        // 1. Manuelle Review explizit angefragt (PRD-003: confidence < 1.0 oder Parser-Unklarheit)
+        if ($request->needs_manual_review) {
+            return 'needs_manual_review';
+        }
+
+        // 2. Reply ist Fallback-Text (OpenAI-Fehler)
+        if ($this->isFallbackText($reply)) {
+            return 'fallback_text';
+        }
+
+        // 3. Gruppengröße über dem Restaurant-Limit
+        if ($request->party_size > $restaurant->auto_send_party_size_max) {
+            return 'party_size_over_limit';
+        }
+
+        // 4. Kurzfristige Anfrage – Owner soll persönlich entscheiden
+        if ($request->desired_at !== null
+            && $request->desired_at->diffInMinutes(now(), false) > -$restaurant->auto_send_min_lead_time_minutes) {
+            return 'short_notice';
+        }
+
+        // 5. Erstanfrage von dieser E-Mail-Adresse an dieses Restaurant
+        if ($this->isFirstTimeGuest($request)) {
+            return 'first_time_guest';
+        }
+
+        // 6. Email-Quelle mit niedriger Parser-Confidence
+        if ($request->source === ReservationSource::Email
+            && ($request->raw_payload['confidence'] ?? 0) < 0.9) {
+            return 'low_confidence_email';
+        }
+
+        return null;
+    }
+
+    private function isFallbackText(ReservationReply $reply): bool
+    {
+        // OpenAiReplyGenerator-Fallback-Text aus PRD-005 ist konstant – exakter Match
+        return $reply->body === config('reservation.fallback_reply_text');
+    }
+
+    private function isFirstTimeGuest(ReservationRequest $request): bool
+    {
+        if ($request->guest_email === null) {
+            return true;
+        }
+
+        return ReservationRequest::query()
+            ->where('restaurant_id', $request->restaurant_id)
+            ->where('guest_email', $request->guest_email)
+            ->where('id', '!=', $request->id)
+            ->where('status', ReservationStatus::Confirmed)
+            ->doesntExist();
+    }
+}
+```
+
+`AutoSendDecision` ist ein readonly Value-Object:
+
+```php
+final readonly class AutoSendDecision
+{
+    public function __construct(
+        public string $decision, // 'manual' | 'shadow' | 'auto_send'
+        public string $reason,
+    ) {}
+
+    public static function manual(string $reason): self  { return new self('manual', $reason); }
+    public static function shadow(string $reason): self  { return new self('shadow', $reason); }
+    public static function autoSend(string $reason): self{ return new self('auto_send', $reason); }
+}
+```
+
+**Reason-Codes (vollständige Liste, dokumentationspflichtig):**
+
+| Code                    | Auslöser                                                |
+|-------------------------|---------------------------------------------------------|
+| `mode_manual`           | Restaurant.send_mode = manual                           |
+| `mode_shadow`           | Restaurant.send_mode = shadow                           |
+| `mode_auto`             | Restaurant.send_mode = auto, kein Hard-Gate aktiv       |
+| `needs_manual_review`   | PRD-003 hat Parser-Unsicherheit markiert                |
+| `fallback_text`         | OpenAI-Generation auf Fallback gefallen (401/429/5xx)   |
+| `party_size_over_limit` | `party_size > restaurant.auto_send_party_size_max`      |
+| `short_notice`          | `desired_at` < `now() + min_lead_time_minutes`          |
+| `first_time_guest`      | Keine vorherige `confirmed`-Reservation dieser Adresse  |
+| `low_confidence_email`  | Email-Source, Parser-Confidence < 0.9                   |
+
+### Trigger-Kette (Erweiterung von PRD-005)
+
+```
+ReservationRequestReceived
+        │
+        ▼
+GenerateReservationReplyJob (PRD-005)
+        │
+        ├─► ReservationContextBuilder::build()
+        ├─► OpenAiReplyGenerator::generate()
+        ├─► ReservationReply::create([... 'status' => 'draft' ...])
+        ├─► AutoSendDecider::decide() ◄── neu in PRD-007
+        ├─► AutoSendAudit-Eintrag schreiben
+        │
+        ├─► decision = 'manual'    → Status bleibt 'draft' (V1.0-Pfad)
+        ├─► decision = 'shadow'    → Status 'shadow', kein Mailversand, Banner im UI
+        └─► decision = 'auto_send' → Status 'scheduled_auto_send',
+                                      ScheduledAutoSendJob::dispatch()->delay(60s)
+```
+
+`ScheduledAutoSendJob` prüft beim Ausführen:
+
+```php
+public function handle(AutoSendDecider $decider): void
+{
+    $reply = ReservationReply::find($this->replyId);
+
+    // Race-Condition-sicher: Status muss noch scheduled sein
+    if ($reply === null || $reply->status !== ReservationReplyStatus::ScheduledAutoSend) {
+        return; // Owner hat im Cancel-Window gestoppt
+    }
+
+    // Restaurant kann zwischenzeitlich Killswitch ausgelöst haben
+    if ($reply->reservationRequest->restaurant->send_mode !== SendMode::Auto) {
+        $reply->update(['status' => ReservationReplyStatus::CancelledAuto]);
+        $this->writeAudit($reply, 'cancelled_auto', 'killswitch_during_window');
+        return;
+    }
+
+    // Re-evaluieren der Hard-Gates – State könnte sich geändert haben
+    $decision = $decider->decide($reply);
+    if ($decision->decision !== 'auto_send') {
+        $reply->update(['status' => ReservationReplyStatus::Draft]);
+        $this->writeAudit($reply, 'cancelled_auto', "hard_gate_late:{$decision->reason}");
+        return;
+    }
+
+    SendReservationReplyJob::dispatchSync($reply);
+}
+```
+
+**Wichtig:** Hard-Gates werden **zweimal** evaluiert – einmal bei Generierung, einmal vor dem tatsächlichen Versand. Zwischenzeitlich kann sich der Zustand ändern (z. B. `desired_at` rutscht durch Wartezeit unter `min_lead_time` → Hard-Gate `short_notice` greift jetzt).
+
+### Killswitch
+
+`POST /restaurants/{id}/send-mode/killswitch`:
+
+```php
+public function killswitch(Restaurant $restaurant): RedirectResponse
+{
+    $this->authorize('manageSendMode', $restaurant);
+
+    DB::transaction(function () use ($restaurant) {
+        $restaurant->update([
+            'send_mode' => SendMode::Manual,
+            'send_mode_changed_at' => now(),
+            'send_mode_changed_by' => auth()->id(),
+        ]);
+
+        // Alle Replies im Cancel-Window sofort canceln
+        $restaurant->reservationReplies()
+            ->where('status', ReservationReplyStatus::ScheduledAutoSend)
+            ->each(function (ReservationReply $reply) {
+                $reply->update(['status' => ReservationReplyStatus::CancelledAuto]);
+                AutoSendAudit::write($reply, 'cancelled_auto', 'killswitch');
+            });
+    });
+
+    return back()->with('flash', 'Auto-Versand sofort gestoppt. Alle ausstehenden Versandvorgänge wurden abgebrochen.');
+}
+```
+
+Killswitch ist im UI **immer prominent sichtbar**, sobald Mode `shadow` oder `auto` ist.
+
+### Settings-UI
+
+`resources/js/pages/Settings/SendMode.vue`:
+
+- Drei-Karten-Layout, jeweils mit Erklärung, Risiko-Badge und „Aktivieren"-Button
+- Aktive Karte visuell hervorgehoben
+- Beim Wechsel zu `shadow`: schlanker Confirmation-Dialog
+- Beim Wechsel zu `auto`: Confirmation-Dialog **mit Statistik** aus dem Shadow-Modus, falls vorhanden:
+  > „In den letzten 30 Tagen wurden 47 von 50 Shadow-Antworten ohne Änderung übernommen (94 %).
+  > Auto-Versand bedeutet: ab jetzt gehen Antworten automatisch an Gäste, sofern keine Sicherheitsregel greift.
+  > Möchten Sie wirklich aktivieren?"
+- Killswitch-Bereich rot hervorgehoben, immer sichtbar wenn Mode ≠ `manual`
+- Hard-Gate-Konfiguration (Party-Size-Limit, Min-Lead-Time) als Number-Inputs mit Slider
+
+Policy: **nur Owner** (nicht Staff) darf Mode wechseln (`RestaurantPolicy::manageSendMode`).
+
+### Detail-Drawer-Erweiterung
+
+`Dashboard.vue` Detail-Drawer für Shadow-Replies:
+
+- Neuer Banner oben: „Shadow-Modus – diese Antwort wurde **nicht** versendet"
+- Vergleichs-Block: Generierter Text + Hinweis „wäre versendet worden um {scheduled_at}"
+- Button: „Doch manuell freigeben & versenden" (führt durch normalen V1.0-Approve-Flow)
+- Wenn Owner den Body editiert → `shadow_was_modified = true` wird gesetzt (PRD-008-Analytik)
+
+Im `auto`-Modus für Replies im Cancel-Window:
+
+- Banner: „Wird automatisch versendet in {countdown}s" (Live-Countdown via Composable)
+- Button „Versand abbrechen" → setzt Status auf `cancelled_auto`, schreibt Audit, dispatcht keinen Send-Job
+
+---
+
+## Akzeptanzkriterien
+
+### Modus-Verwaltung
+- [ ] Default-Mode neuer Restaurants ist `manual` (V1.0-kompatibel, keine Migration ändert bestehende Daten in der Funktion)
+- [ ] Mode-Wechsel `manual → shadow` setzt `send_mode_changed_at` und `send_mode_changed_by`
+- [ ] Mode-Wechsel `shadow → auto` zeigt Statistik im Dialog (Übernahme-Rate aus letzten 30 Tagen)
+- [ ] Nur Owner kann Mode wechseln; Staff erhält 403
+- [ ] Killswitch setzt Mode auf `manual` UND cancelt alle `scheduled_auto_send`-Replies in einer Transaktion
+
+### Hard-Gates (jeder Gate einzeln testbar)
+- [ ] `needs_manual_review` blockt Auto-Send unabhängig vom Modus
+- [ ] `fallback_text` blockt Auto-Send (OpenAI-Fehler-Fallback)
+- [ ] `party_size > limit` blockt Auto-Send
+- [ ] `short_notice` (< `min_lead_time_minutes` Vorlauf) blockt Auto-Send
+- [ ] `first_time_guest` (keine vorherige `confirmed` Reservation derselben Adresse) blockt Auto-Send
+- [ ] `low_confidence_email` (< 0.9 Confidence aus PRD-003) blockt Auto-Send
+
+### Modus-Verhalten
+- [ ] Im `manual`-Modus: Verhalten 1:1 wie V1.0
+- [ ] Im `shadow`-Modus: Reply mit `status = shadow`, `Mail::fake()` erhält **keinen** Send
+- [ ] Im `auto`-Modus ohne Hard-Gate: Reply geht 60s nach Generierung automatisch raus
+- [ ] Im `auto`-Modus mit Hard-Gate: Status bleibt `draft`, Auto-Send-Audit dokumentiert den Reason
+
+### Cancel-Window
+- [ ] Klick auf „Versand abbrechen" innerhalb von 60s → Status `cancelled_auto`, kein Mailversand
+- [ ] Owner-Approve innerhalb des Cancel-Windows → V1.0-Pfad greift, Mail geht früher raus
+- [ ] Race-Condition: zwei parallele Approves → nur einer schreibt (DB-Transaktion)
+
+### Audit & Sichtbarkeit
+- [ ] `auto_send_audits` enthält pro Auto-Send einen Eintrag mit `decision`, `reason`, `triggered_by_user_id`
+- [ ] Bei Killswitch werden alle gecancelten Replies einzeln auditiert
+- [ ] Dashboard-Banner zeigt aktiven Mode prominent
+- [ ] Detail-Drawer zeigt bei Shadow den Vergleichs-Block, bei Cancel-Window den Countdown
+
+### Sicherheit
+- [ ] CLAUDE.md-Anpassung dokumentiert: V1.0-Verbot „Automatischer Mailversand ohne Freigabe" wird zu opt-in mit Hard-Gates
+- [ ] Datenschutzerklärungs-Hinweis im Settings-UI für `auto` und `shadow`
+- [ ] API-Key, IMAP-Passwort, Mail-Bodies erscheinen in keinem Audit-Eintrag oder Log
+
+### Code-Qualität
+- [ ] Alle Tests grün (`composer test`, `npm run test`)
+- [ ] Pint, ESLint, Prettier ohne Findings
+- [ ] Bestehende V1.0-Tests aus PRD-005 bleiben grün
+
+---
+
+## Tests
+
+**Unit (`tests/Unit/AI/AutoSendDeciderTest.php`)**
+
+- `it returns mode_manual when restaurant is in manual mode`
+- `it returns mode_shadow when restaurant is in shadow mode`
+- `it returns mode_auto when restaurant is in auto mode without hard gates`
+- Pro Hard-Gate ein dedizierter Test:
+  - `it blocks auto send when needs_manual_review is true`
+  - `it blocks auto send for fallback text`
+  - `it blocks auto send when party size exceeds limit`
+  - `it blocks auto send for short notice requests`
+  - `it blocks auto send for first time guests`
+  - `it blocks auto send for low confidence email parses`
+- `it considers a guest with prior confirmed reservation as returning`
+- `it counts a guest with only declined prior reservations as first time` (declined zählt nicht als Vertrauen)
+
+**Unit (`tests/Unit/AI/AutoSendDecisionTest.php`)**
+
+- Value-Object-Konstruktor-Varianten (`manual`, `shadow`, `autoSend`)
+- Serialisierung in `auto_send_decision`-JSON-Spalte und Re-Hydration
+
+**Feature (`tests/Feature/AutoSend/SendModeFlowTest.php`)**
+
+- `it dispatches scheduled job with 60s delay in auto mode` (mit `Queue::fake()`-Inspektion)
+- `it does not send mail in shadow mode` (mit `Mail::fake()`)
+- `it sends mail after 60s delay in auto mode` (Time-Travel mit `Carbon::setTestNow`)
+- `it cancels scheduled send when owner clicks cancel`
+- `it cancels scheduled send when owner approves manually within window`
+- `it re-evaluates hard gates in scheduled job before sending` (z. B. `desired_at` ist zwischenzeitlich kurzfristig geworden)
+
+**Feature (`tests/Feature/AutoSend/KillswitchTest.php`)**
+
+- `it resets mode to manual on killswitch`
+- `it cancels all scheduled auto sends within killswitch transaction`
+- `it writes audit entry for each cancelled reply`
+- `it forbids killswitch for staff users`
+
+**Feature (`tests/Feature/AutoSend/SendModeSettingsTest.php`)**
+
+- `it allows owner to switch from manual to shadow`
+- `it shows confirmation dialog with stats when switching to auto from shadow`
+- `it forbids staff from changing send mode`
+- `it persists party size limit and min lead time changes`
+- `it shows mode banner on dashboard when not manual`
+
+**Feature (`tests/Feature/AutoSend/AuditTrailTest.php`)**
+
+- `it writes an audit entry on every auto send decision`
+- `it includes reason and triggering user`
+- `it never logs guest email or reply body in audits`
+
+---
+
+## Zusammenarbeit mit dem Produktinhaber
+
+Drei Werte sind UI-konfigurierbar, müssen aber sinnvolle Defaults haben:
+
+| Wert                              | Default-Vorschlag | Begründung                                              |
+|-----------------------------------|-------------------|---------------------------------------------------------|
+| `auto_send_party_size_max`        | 10                | Größere Gruppen brauchen oft Sonderabsprachen           |
+| `auto_send_min_lead_time_minutes` | 90                | < 90 min: Owner sollte persönlich kurz prüfen           |
+| Cancel-Window-Dauer (`60s`)       | konstant          | Keine Konfiguration im UI – architektonische Konstante  |
+
+Die ersten zwei können vom Owner an sein Restaurant angepasst werden. Die Cancel-Window-Dauer ist bewusst nicht UI-konfigurierbar – sie ist Teil des Sicherheitsmodells, nicht der Geschäftslogik.
+
+**Definition of Done (Produktseite):**
+
+- Pilot-Restaurant kann von `manual` schrittweise zu `auto` wechseln, ohne dass dabei eine fehlerhafte Mail rausgeht
+- Mindestens 30 Tage `shadow`-Mode mit > 90 % Übernahme-Rate, bevor `auto` empfohlen wird (UI-Hint, kein Hard-Block)
+- Datenschutzerklärung des Restaurants enthält Hinweis auf Auto-Versand
+
+---
+
+## Risiken & offene Fragen
+
+- **Cancel-Window-Dauer ist Tradeoff** – 60 s ist Kompromiss zwischen „Owner kann stoppen" und „Gast wartet nicht zu lange". Bei Pilot-Daten neu bewerten. Eine zu lange Verzögerung untergräbt den USP („sofort beantwortet"); eine zu kurze macht den Killswitch nutzlos für Replies, die gerade rausgehen.
+- **Erstmaliger Auto-Send-Fehler kostet Vertrauen** – ein einziger Halluzinations-Fall an einen Erstgast wäre desaströs. Genau deshalb ist `first_time_guest` ein Hard-Gate. Akzeptierte Konsequenz: Stammgäste profitieren, Erstkunden bekommen V1.0-Service.
+- **DSGVO** – Auto-Versand ist nach Art. 22 DSGVO eine automatisierte Entscheidung im weiteren Sinne. Für die rechtliche Sauberkeit:
+  - Owner muss den Mode aktiv aktivieren (kein Default `auto`)
+  - Datenschutzerklärung des Restaurants muss Auto-Versand erwähnen
+  - Gast muss Möglichkeit zur manuellen Bearbeitung haben (gegeben durch Antwort an Restaurant-Mailadresse)
+- **`isFallbackText`-Match ist string-basiert** – wenn der Fallback-Text in PRD-005 jemals übersetzt oder restaurantspezifisch wird, verliert der Hard-Gate seine Wirkung. Gegenmaßnahme: zusätzlich ein Boolean-Flag `is_fallback` an `reservation_replies` einführen, das `OpenAiReplyGenerator` setzt. **Empfehlung: Flag-Spalte mitziehen** (eine Migration mehr, aber robuster).
+- **Killswitch-Race** – zwischen Mode-Reset und Cancel-Schleife könnte ein anderer Job einen `ScheduledAutoSendJob` starten. Der Job re-checkt `Restaurant::send_mode`, bevor er versendet – damit ist die Race abgefangen.
+- **CLAUDE.md-Update notwendig** – das aktuelle V1.0-Kernprinzip („Kein KI-generierter Text erreicht ohne menschliche Bestätigung einen Kunden") wird in V2.0 zu „Kein KI-generierter Text erreicht ohne menschliche Bestätigung **oder ausdrückliche Owner-Aktivierung mit Hard-Gates** einen Kunden". Diese Anpassung ist Teil der V2.0-Release-Planung, nicht Teil von PRD-007 selbst, aber muss vor V2.0-Release passiert sein.

--- a/docs/PRD-008-dashboard-analytics.md
+++ b/docs/PRD-008-dashboard-analytics.md
@@ -47,7 +47,8 @@ Wichtig: PRD-008 ist **kein Datalake**. Aggregate werden direkt aus der OLTP-Tab
 - Trend-Chart: Thread-Replies pro Tag (PRD-006), als Indikator für Gast-Engagement
 - Server-seitige Aggregation in `AnalyticsAggregator`
 - 5-Minuten-Cache pro `(restaurant_id, range)`
-- Mandantentrennung über bestehenden `RestaurantScope` aus PRD-001
+- Mandantentrennung über bestehenden `RestaurantScope` aus PRD-001 bzw. `whereHas('reservationRequest', ...)`-Joins für Models ohne eigene `restaurant_id`-Spalte (siehe Hinweis unter „Edit-Rate")
+- **Erweiterung PRD-005-Snapshot**: Migration / Anpassung `OpenAiReplyGenerator`, sodass der ursprünglich generierte Body zusätzlich als `original_body` in `ai_prompt_snapshot` persistiert wird. Voraussetzung für Edit-Rate und Shadow-Übernahme-Statistik.
 
 ### Out of Scope
 
@@ -131,22 +132,25 @@ Bei MySQL 8 / PostgreSQL würde sich `PERCENTILE_CONT` anbieten – wird aber be
 
 **Edit-Rate (V2.0-spezifisch):**
 
-```php
-$total = ReservationReply::where('restaurant_id', $restaurant->id)
-    ->where('created_at', '>=', $range->startsAt())
-    ->whereIn('status', [ReservationReplyStatus::Sent, ReservationReplyStatus::Approved])
-    ->count();
+`reservation_replies` hat per PRD-001-Schema **keine eigene `restaurant_id`-Spalte** – die Mandantentrennung erfolgt über die `reservation_request_id`-Beziehung. Aggregat-Queries müssen entsprechend joinen, statt direkt zu filtern. SQLite-kompatibel via `json_extract` statt MySQL-spezifischem `->>`-Operator.
 
-$modified = ReservationReply::where('restaurant_id', $restaurant->id)
+```php
+$base = ReservationReply::query()
+    ->whereHas('reservationRequest', fn ($q) => $q->where('restaurant_id', $restaurant->id))
     ->where('created_at', '>=', $range->startsAt())
-    ->whereIn('status', [ReservationReplyStatus::Sent, ReservationReplyStatus::Approved])
-    ->whereColumn('body', '!=', DB::raw('ai_prompt_snapshot->>"$.original_body"'))
+    ->whereIn('status', [ReservationReplyStatus::Sent, ReservationReplyStatus::Approved]);
+
+$total    = (clone $base)->count();
+$modified = (clone $base)
+    ->whereColumn('body', '!=', DB::raw("json_extract(ai_prompt_snapshot, '\$.original_body')"))
     ->count();
 
 $rate = $total > 0 ? round($modified / $total * 100, 1) : 0.0;
 ```
 
-**Hinweis:** PRD-007 + diese Auswertung erfordern, dass `ai_prompt_snapshot` zusätzlich den **ursprünglich generierten Body** enthält (zum Vergleich). Das ist eine kleine Erweiterung von PRD-005 (Snapshot-Format), die in PRD-008 mitgeliefert wird.
+`json_extract(...)` funktioniert auf SQLite, MySQL 8+ und MariaDB. PostgreSQL braucht eine alternative Schreibweise (`ai_prompt_snapshot->>'original_body'`); falls Postgres als Prod-DB gewählt wird, kapselt der Aggregator das hinter einem Repository-Interface mit DB-spezifischen Implementationen. Solange MySQL 8 die Zielplattform bleibt (PRD-001 Risiken), reicht `json_extract`.
+
+**Hinweis:** Diese Auswertung erfordert, dass `ai_prompt_snapshot` zusätzlich den **ursprünglich generierten Body** enthält (zum Vergleich). Das ist eine kleine Erweiterung von PRD-005 (Snapshot-Format) und wird **als Migrations- und Codeschritt in der In-Scope-Liste oben** (`Erweiterung PRD-005-Snapshot um original_body`) mitgeführt.
 
 **Send-Mode-Stats:**
 
@@ -156,7 +160,8 @@ if ($restaurant->send_mode === SendMode::Manual) {
     return null;
 }
 
-$shadow = ReservationReply::where('restaurant_id', $restaurant->id)
+$shadow = ReservationReply::query()
+    ->whereHas('reservationRequest', fn ($q) => $q->where('restaurant_id', $restaurant->id))
     ->where('created_at', '>=', $range->startsAt())
     ->where('send_mode_at_creation', SendMode::Shadow);
 
@@ -174,6 +179,8 @@ $gates = AutoSendAudit::where('restaurant_id', $restaurant->id)
     ->limit(3)
     ->get();
 ```
+
+`AutoSendAudit` hat eine eigene `restaurant_id`-Spalte (siehe PRD-007-Datenmodell), deshalb dort der direkte Filter. `ReservationReply` joint über `reservationRequest`.
 
 ### Trend-Daten
 

--- a/docs/PRD-008-dashboard-analytics.md
+++ b/docs/PRD-008-dashboard-analytics.md
@@ -1,0 +1,292 @@
+# PRD-008: Dashboard-Analytics
+
+**Produkt:** reservation-agent
+**Version:** V2.0
+**Priorität:** P1 – baut auf PRD-006 + PRD-007 auf, wird ohne sie weniger interessant
+**Entwicklungsphase:** V2-Phase 3 (nach PRD-007)
+
+---
+
+## Problem
+
+In V1.0 sieht der Owner im Dashboard nur den **Ist-Zustand**: aktuelle Anfragen, ihre Status, ihre Quellen. Es fehlt jede Antwort auf Fragen wie:
+
+- *„Wie viele Anfragen kamen letzten Monat?"*
+- *„Wie schnell beantworten wir Anfragen im Durchschnitt?"*
+- *„Bestätigt die KI-Antwort wirklich, oder lehnen wir mehr ab als sinnvoll?"*
+- *„Wie oft musste ich den KI-Vorschlag editieren?"* (Vertrauensindikator)
+- *„Im Shadow-Modus: hätte die KI wirklich verlässlich versendet?"* (Vorbereitung Wechsel auf `auto`)
+
+Ohne diese Sicht ist der Wechsel von `shadow` auf `auto` (PRD-007) eine Bauchentscheidung, und der Owner kann V2.0-Verbesserungen gegenüber V1.0 nicht messen.
+
+## Ziel
+
+Eine eigene Analytics-Seite im Dashboard, die die wichtigsten KPIs als Zahlen und einfache Trend-Charts zeigt. Drei Zeitfenster (heute / 7 Tage / 30 Tage). Keine BI-Plattform, kein Custom-Reporting – nur die Sicht, die Owner und Pilotbetreuung tatsächlich brauchen.
+
+Wichtig: PRD-008 ist **kein Datalake**. Aggregate werden direkt aus der OLTP-Tabelle gerechnet, mit Caching. Wenn Pilot-Volumen das später sprengt, wird ein Materialized-View-Pattern eingeführt – nicht jetzt.
+
+---
+
+## Scope V2.0
+
+### In Scope
+
+- Inertia-Page `resources/js/pages/Analytics.vue`
+- Range-Toggle: `today`, `7d`, `30d` (Server-seitig validiert)
+- Kennzahlen-Karten:
+  - Anfragen gesamt
+  - Anfragen pro Quelle (`web_form`, `email`)
+  - Bestätigungsquote (`confirmed` / Gesamt)
+  - Ablehnungsquote (`declined` / Gesamt)
+  - Durchschnittliche Zeit bis Antwort (Median + p90, in Minuten)
+  - Edit-Quote: Anteil der Drafts, deren Body nach Generation geändert wurde
+- Bei aktivem `shadow`-Modus zusätzlich: Übernahme-Rate (`shadow_was_modified = false` / Shadow-Gesamt)
+- Bei aktivem `auto`-Modus zusätzlich: Auto-Send-Quote, Anteil der Hard-Gate-Blockaden, häufigste Hard-Gate-Reasons (Top 3)
+- Trend-Chart: Anfragen pro Tag über 30 Tage (Line)
+- Trend-Chart: Bestätigungsquote pro Tag über 30 Tage (Line)
+- Trend-Chart: Thread-Replies pro Tag (PRD-006), als Indikator für Gast-Engagement
+- Server-seitige Aggregation in `AnalyticsAggregator`
+- 5-Minuten-Cache pro `(restaurant_id, range)`
+- Mandantentrennung über bestehenden `RestaurantScope` aus PRD-001
+
+### Out of Scope
+
+- Custom Time-Ranges (frei wählbares Datum) – V3.0
+- Cohort- und Retention-Analytics – V4.0
+- Vergleich zwischen Restaurants (Multi-Tenant-Crossing) – aktuell keine Use-Case
+- Export der Analytics-Reports als PDF (eigenes Issue, könnte in PRD-009 mitlaufen, ist aber nicht Pflicht)
+- Real-time Charts (WebSocket-Updates) – V3.0 mit Reverb
+
+---
+
+## Technische Anforderungen
+
+### Service-Schicht
+
+`app/Services/Analytics/AnalyticsAggregator.php`:
+
+```php
+final class AnalyticsAggregator
+{
+    public function __construct(
+        private readonly CacheRepository $cache,
+    ) {}
+
+    public function aggregate(Restaurant $restaurant, AnalyticsRange $range): AnalyticsSnapshot
+    {
+        $cacheKey = sprintf('analytics:%d:%s', $restaurant->id, $range->value);
+
+        return $this->cache->remember($cacheKey, now()->addMinutes(5), function () use ($restaurant, $range) {
+            return new AnalyticsSnapshot(
+                range: $range,
+                totals: $this->totals($restaurant, $range),
+                sources: $this->bySource($restaurant, $range),
+                statusBreakdown: $this->byStatus($restaurant, $range),
+                responseTime: $this->responseTime($restaurant, $range),
+                editRate: $this->editRate($restaurant, $range),
+                sendModeStats: $this->sendModeStats($restaurant, $range),
+                trends: $this->trends($restaurant, $range),
+            );
+        });
+    }
+}
+```
+
+`AnalyticsRange` ist ein Enum: `Today`, `Last7Days`, `Last30Days` mit Methoden `startsAt(): Carbon`, `endsAt(): Carbon`, `bucketSize(): string` (Tages- vs. Stunden-Buckets).
+
+`AnalyticsSnapshot` ist ein readonly DTO (kein Model), das direkt vom Controller in eine `AnalyticsSnapshotResource` geschickt wird.
+
+### SQL-Aggregation (Beispiele)
+
+**Totals:**
+
+```php
+ReservationRequest::query()
+    ->where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->count();
+```
+
+**Response-Time (Median, p90):**
+
+```php
+$durations = ReservationRequest::query()
+    ->where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->whereHas('replies', fn ($q) => $q->whereIn('status', [
+        ReservationReplyStatus::Sent,
+        ReservationReplyStatus::Approved,
+    ]))
+    ->with(['replies' => fn ($q) => $q->orderBy('sent_at')])
+    ->get()
+    ->map(fn ($r) => $r->created_at->diffInMinutes($r->replies->first()->sent_at))
+    ->sort()
+    ->values();
+
+$median = $this->percentile($durations, 0.5);
+$p90    = $this->percentile($durations, 0.9);
+```
+
+Bei MySQL 8 / PostgreSQL würde sich `PERCENTILE_CONT` anbieten – wird aber bewusst **nicht** genutzt, weil SQLite (lokal) das nicht hat. Stattdessen Aggregation in PHP. Performance bleibt akzeptabel bis ~10.000 Records pro Range; bei mehr wechseln wir auf DB-Aggregation hinter einem Repository-Interface.
+
+**Edit-Rate (V2.0-spezifisch):**
+
+```php
+$total = ReservationReply::where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->whereIn('status', [ReservationReplyStatus::Sent, ReservationReplyStatus::Approved])
+    ->count();
+
+$modified = ReservationReply::where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->whereIn('status', [ReservationReplyStatus::Sent, ReservationReplyStatus::Approved])
+    ->whereColumn('body', '!=', DB::raw('ai_prompt_snapshot->>"$.original_body"'))
+    ->count();
+
+$rate = $total > 0 ? round($modified / $total * 100, 1) : 0.0;
+```
+
+**Hinweis:** PRD-007 + diese Auswertung erfordern, dass `ai_prompt_snapshot` zusätzlich den **ursprünglich generierten Body** enthält (zum Vergleich). Das ist eine kleine Erweiterung von PRD-005 (Snapshot-Format), die in PRD-008 mitgeliefert wird.
+
+**Send-Mode-Stats:**
+
+```php
+// Nur relevant, wenn Restaurant aktuell shadow oder auto nutzt
+if ($restaurant->send_mode === SendMode::Manual) {
+    return null;
+}
+
+$shadow = ReservationReply::where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->where('send_mode_at_creation', SendMode::Shadow);
+
+$auto = AutoSendAudit::where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->where('decision', 'auto_send');
+
+$gates = AutoSendAudit::where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->where('decision', 'manual')
+    ->whereNotIn('reason', ['mode_manual'])
+    ->groupBy('reason')
+    ->selectRaw('reason, COUNT(*) as count')
+    ->orderByDesc('count')
+    ->limit(3)
+    ->get();
+```
+
+### Trend-Daten
+
+Tagesgenaue Buckets über 30 Tage:
+
+```php
+ReservationRequest::query()
+    ->where('restaurant_id', $restaurant->id)
+    ->where('created_at', '>=', $range->startsAt())
+    ->selectRaw('DATE(created_at) as day, COUNT(*) as count')
+    ->groupBy('day')
+    ->orderBy('day')
+    ->get();
+```
+
+Der Aggregator liefert eine vollständige Tagesreihe (auch Tage mit 0) zurück, damit das Chart keine Lücken zeigt.
+
+### Caching-Strategie
+
+- TTL: 5 Minuten pro `(restaurant_id, range)`
+- Invalidation: bewusst keine aktive Invalidation. Live-Daten warten max. 5 min – das ist akzeptabel, weil Analytics keine operative Sicht ist (operativ = Dashboard-Liste, polling 30 s).
+- Cache-Driver: Standard-Driver der Laravel-Konfiguration (`array` lokal, `database`/`redis` in Prod – nicht in PRD-008 entscheiden, das ist Infrastruktur)
+
+### Frontend
+
+`resources/js/pages/Analytics.vue`:
+
+- Range-Switch oben (drei Tabs: Heute / 7 Tage / 30 Tage), URL-Parameter `?range=7d`
+- Grid mit Karten für jede KPI – Reka UI `<Card>`-Component
+- Charts: leichte Library, Vorschlag **`vue-chartjs`** (Standard, gute Vue-3-Unterstützung, ~50 KB gzipped)
+- Charts laden serverseitig vorbereitete Daten aus den Inertia-Props – keine eigenen Fetch-Calls
+- Empty-State: wenn 0 Anfragen im Range → freundlicher Hinweis statt leerem Chart
+- Mobile-Friendly: Charts kollabieren auf 1 Spalte unterhalb 768 px
+
+Routing:
+
+```php
+Route::get('/analytics', [AnalyticsController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('analytics.index');
+```
+
+Sidebar-Eintrag im bestehenden Layout: „Analyse" mit Chart-Icon (Reka UI / lucide-vue-next).
+
+### Performance-Budget
+
+- Aggregator-Call (uncached) bis 10.000 Records: < 500 ms
+- Cached-Call: < 20 ms
+- Chart-Library im Initial-Bundle: < 60 KB gzipped (sonst Lazy-Loading via dynamischem Import)
+
+Benchmark wird Teil des PR-Review (Pest + `microtime(true)`-Fence-Test gegen Seed mit 10.000 Records).
+
+---
+
+## Akzeptanzkriterien
+
+- [ ] Analytics-Seite zeigt für jeden Range alle Kennzahlen-Karten korrekt
+- [ ] Range-Toggle ändert URL und Daten ohne Page-Reload (Inertia Partial Reload)
+- [ ] Send-Mode-Stats erscheinen nur, wenn Restaurant aktuell `shadow` oder `auto` nutzt
+- [ ] 30-Tage-Chart hat lückenlose Tagesachse (auch 0-Tage)
+- [ ] Cache-TTL von 5 min greift; identische Calls innerhalb dieser Zeit erzeugen keinen zweiten DB-Hit (Test mit `Cache::spy()`)
+- [ ] Mandantentrennung: User aus Restaurant B sieht keine Daten von Restaurant A
+- [ ] Direktzugriff auf `/analytics` ohne Auth → Redirect auf Login
+- [ ] Aggregator-Performance: bei 10.000 Reservierungen < 500 ms (uncached)
+- [ ] Edit-Rate-Berechnung erfordert die Snapshot-Erweiterung in PRD-005 (`original_body` im `ai_prompt_snapshot`); Migrations-Schritt dokumentiert
+- [ ] Alle Tests grün, Pint/ESLint/Prettier ohne Findings
+
+---
+
+## Tests
+
+**Unit (`tests/Unit/Analytics/AnalyticsAggregatorTest.php`)**
+
+Mit Seed-Daten in `RefreshDatabase`:
+
+- `it counts total requests within range`
+- `it counts requests by source`
+- `it computes confirmation rate`
+- `it computes median and p90 response time` (mit handgesetzten `created_at`/`sent_at`)
+- `it computes edit rate when body differs from original`
+- `it returns null sendModeStats for manual mode restaurants`
+- `it computes shadow takeover rate`
+- `it lists top 3 hard gate reasons in auto mode`
+- `it fills trend buckets even for days with zero requests`
+- `it scopes all queries to restaurant id` (kein Multi-Tenant-Leak)
+
+**Unit (`tests/Unit/Analytics/AnalyticsRangeTest.php`)**
+
+- Konvertierung Range → Carbon-Bereich
+- Bucket-Größe Today (Stunden) vs. 7d/30d (Tage)
+
+**Feature (`tests/Feature/Analytics/AnalyticsPageTest.php`)**
+
+- `it renders the analytics page for owner`
+- `it switches range via inertia partial reload`
+- `it caches aggregator results for 5 minutes`
+- `it does not show send mode stats for manual mode`
+- `it shows send mode stats for shadow mode`
+- `it forbids access for users without restaurant`
+- `it scopes data to current restaurant`
+
+**Frontend (Vitest, `resources/js/pages/Analytics.spec.ts`)**
+
+- `range-toggle switches active tab and emits update`
+- `chart renders with provided trend data`
+- `empty state shows when totals are zero`
+
+---
+
+## Risiken & offene Fragen
+
+- **PRD-005-Snapshot-Erweiterung notwendig** – die Edit-Rate vergleicht `body` mit `ai_prompt_snapshot->>"$.original_body"`. Aktuell speichert PRD-005 nur das Context-JSON, nicht den ursprünglichen Generated-Body. Diese Erweiterung wandert als Migrations-/Code-Schritt **in PRD-008**, weil sie hier den Wert hat. Risiko: Replies vor V2.0-Release haben kein `original_body` und werden in der Edit-Rate als „nicht-modifiziert" gezählt. Akzeptabel, weil V2.0 eine neue Baseline darstellt.
+- **PHP-seitige Percentile-Berechnung** – funktioniert für die Pilot-Größenordnung, wird aber bei zehntausenden Records pro Range zur Latenzbremse. Schwellwert (< 500 ms uncached bei 10.000 Records) wird benchmarkt; bei Überschreitung kommt SQL-seitige Aggregation als Folge-Issue.
+- **Time-to-Reply-Definition** – aktuell `created_at` der Request bis `sent_at` der ersten Reply. Bei `auto`-Modus liegt das nahe Null, was die Metrik verzerrt. Lösung: zusätzlich „Time to Owner Action" (= Wechsel aus `new`) als zweite Metrik in V2.1, falls Bedarf entsteht.
+- **Chart-Library als Bundle-Last** – `vue-chartjs` + `chart.js` sind ~60 KB gzipped. Falls das Initial-Bundle wegen anderer Features bereits eng ist, alternativ via dynamischem Import lazy laden, sodass Analytics-Seite nur bei Aufruf den Code zieht.
+- **Owner-Rolle vs. Staff-Rolle** – PRD-008 gibt aktuell beiden Rollen Zugriff auf Analytics. Falls in der Praxis Staff keine Reports sehen soll: Policy `viewAnalytics` einführen. Vorerst: alle authentifizierten User des Restaurants dürfen die Seite sehen.

--- a/docs/PRD-009-export-csv-pdf.md
+++ b/docs/PRD-009-export-csv-pdf.md
@@ -1,0 +1,294 @@
+# PRD-009: Export CSV/PDF
+
+**Produkt:** reservation-agent
+**Version:** V2.0
+**Priorität:** P2 – operativ nützlich, unabhängig von PRD-006/007/008
+**Entwicklungsphase:** V2 (parallel zu Phase 2/3)
+
+---
+
+## Problem
+
+Owner brauchen Reservierungslisten regelmäßig **außerhalb** des Dashboards:
+
+- **Service-Vorbereitung** – heute Abend, alle bestätigten Reservierungen mit Uhrzeit und Personenzahl auf einen Ausdruck
+- **Buchhaltung / Steuerberater** – monatliche Liste aller Reservierungen für Abrechnung oder Statistik
+- **Dokumentation gegenüber Personal** – Plan für die Schicht, ohne dass jeder Zugriff auf das System braucht
+
+In V1.0 ist die einzige Antwort darauf manuelles Abschreiben aus dem Dashboard. Das ist fehleranfällig und der naheliegendste Mehrwert für Pilotrestaurants.
+
+## Ziel
+
+Aus der gefilterten Dashboard-Ansicht heraus kann der Owner die aktuelle Liste als CSV oder PDF exportieren. CSV ist Excel-kompatibel (UTF-8 mit BOM, Semikolon-getrennt für deutsche Locales). PDF ist eine schlichte druckbare Tabelle mit Restaurant-Header, Datum und Liste – kein Marketing, keine Markenkonkurrenz mit dem Restaurant.
+
+Bei großen Listen (> 100 Records) läuft der Export asynchron als Job; das Ergebnis kommt per Mail mit Download-Link, der 24 Stunden gültig ist.
+
+---
+
+## Scope V2.0
+
+### In Scope
+
+- Export-Button im Dashboard-Header mit Dropdown „Als CSV" / „Als PDF"
+- Filter aus aktuellem Dashboard-State werden 1:1 übernommen (Status, Quelle, Datumsbereich, Suche)
+- CSV via `league/csv`, UTF-8 mit BOM, `;`-Separator (Excel-DE-kompatibel)
+- PDF via `barryvdh/laravel-dompdf` mit minimalem Template
+- Sync-Pfad bei ≤ 100 Records: direkter Download
+- Async-Pfad bei > 100 Records: Job dispatchen, Mail mit signed URL (24 h Lebensdauer)
+- Mailable `ExportReadyMail` mit Download-Link
+- Storage: `storage/app/exports/{user_id}/{filename}`, Lifecycle-Cleanup nach 24 h
+- Audit-Log: `export_audits` (wer, wann, welcher Filter, welches Format)
+- Mandantentrennung über bestehenden `RestaurantScope`
+
+### Out of Scope
+
+- Geplante / wiederkehrende Exporte („jeden Montag Mail mit letzter Woche") – V3.0
+- Export der Analytics-Reports aus PRD-008 als PDF – V2.1 (eigenes Issue, falls gewünscht)
+- Excel-Format `.xlsx` – V3.0 (nur falls Pilot-Feedback es fordert; CSV deckt Excel-Import ab)
+- Custom Spalten-Auswahl im UI – V3.0
+- Versand der Export-Datei direkt an externe Mail (Steuerberater-Mailadresse) – V3.0
+
+---
+
+## Technische Anforderungen
+
+### Routing
+
+```php
+Route::post('/exports/csv', [ExportController::class, 'csv'])->name('exports.csv');
+Route::post('/exports/pdf', [ExportController::class, 'pdf'])->name('exports.pdf');
+Route::get('/exports/download/{token}', [ExportController::class, 'download'])
+    ->name('exports.download')
+    ->middleware('signed');
+```
+
+### Controller
+
+`app/Http/Controllers/ExportController.php`:
+
+```php
+public function csv(ExportRequest $request, ExportDispatcher $dispatcher): Response|RedirectResponse
+{
+    $filters = $request->validated();
+    return $dispatcher->dispatch(ExportFormat::Csv, $filters, $request->user());
+}
+
+public function pdf(ExportRequest $request, ExportDispatcher $dispatcher): Response|RedirectResponse
+{
+    $filters = $request->validated();
+    return $dispatcher->dispatch(ExportFormat::Pdf, $filters, $request->user());
+}
+```
+
+`ExportRequest` valdiert dasselbe Filter-Schema wie `DashboardFilterRequest` aus PRD-004 – per Trait `WithDashboardFilters` geteilt.
+
+`ExportDispatcher` entscheidet anhand der Record-Anzahl synchron oder asynchron:
+
+```php
+final class ExportDispatcher
+{
+    public function dispatch(ExportFormat $format, array $filters, User $user): Response|RedirectResponse
+    {
+        $count = ReservationRequest::query()
+            ->filter($filters)
+            ->count();
+
+        $auditId = ExportAudit::open($user, $format, $filters, $count);
+
+        if ($count <= 100) {
+            return $this->generator->generateSync($format, $filters, $user, $auditId);
+        }
+
+        ExportReservationsJob::dispatch($format, $filters, $user->id, $auditId);
+
+        return back()->with('flash', 'Der Export wird vorbereitet. Sie erhalten in Kürze eine E-Mail mit dem Download-Link.');
+    }
+}
+```
+
+### Sync-Generator
+
+`ExportGenerator::generateSync(...)` liefert direkt eine `StreamedResponse`:
+
+- CSV: `league/csv\Writer::createFromString()` mit BOM `"\xEF\xBB\xBF"` voran, Spalten siehe unten
+- PDF: View `mail.exports.reservations-pdf` rendern, dompdf streamen
+
+### Async-Generator
+
+`ExportReservationsJob`:
+
+```php
+public function handle(ExportGenerator $generator): void
+{
+    $user = User::findOrFail($this->userId);
+    $path = $generator->generateToFile($this->format, $this->filters, $user, $this->auditId);
+
+    $url = URL::temporarySignedRoute(
+        'exports.download',
+        now()->addHours(24),
+        ['token' => $this->auditId]
+    );
+
+    Mail::to($user)->send(new ExportReadyMail($url, $this->format, expiresAt: now()->addHours(24)));
+}
+```
+
+`ExportController::download` lädt das File anhand des `ExportAudit`-Tokens und prüft, dass `auth()->id() === audit->user_id`. Signierte Route deckt Manipulation der URL ab; zusätzliche Owner-Prüfung deckt Login-Wechsel ab.
+
+### CSV-Spalten
+
+| Spalte             | Quelle                              |
+|--------------------|-------------------------------------|
+| ID                 | `reservation_requests.id`           |
+| Eingegangen        | `created_at` (Restaurant-TZ)        |
+| Status             | `status` (Enum-Label, deutsch)      |
+| Quelle             | `source` (Enum-Label, deutsch)      |
+| Wunschdatum        | `desired_at` (Restaurant-TZ)        |
+| Personen           | `party_size`                        |
+| Name               | `guest_name`                        |
+| E-Mail             | `guest_email`                       |
+| Telefon            | `guest_phone`                       |
+| Manuelle Prüfung   | `needs_manual_review` (Ja/Nein)     |
+| Letzte Antwort     | `replies->last()->status` (Label)   |
+
+DSGVO-Hinweis im UI: „Der Export enthält personenbezogene Daten. Verarbeitung gemäß Datenschutzerklärung des Restaurants."
+
+### PDF-Template
+
+`resources/views/exports/reservations-pdf.blade.php`:
+
+```blade
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: DejaVu Sans, sans-serif; font-size: 10pt; color: #1a1a1a; }
+    h1   { font-size: 14pt; margin: 0 0 4mm 0; }
+    .meta{ font-size: 9pt; color: #555; margin-bottom: 6mm; }
+    table{ width: 100%; border-collapse: collapse; }
+    th, td { border-bottom: 0.4pt solid #999; padding: 2mm 1.5mm; text-align: left; }
+    th   { background: #f5f5f5; font-weight: 600; }
+    .small{ font-size: 8pt; color: #666; }
+  </style>
+</head>
+<body>
+  <h1>{{ $restaurant->name }}</h1>
+  <div class="meta">
+    Reservierungs-Export &middot; erstellt {{ $generatedAt->format('d.m.Y H:i') }}<br>
+    Filter: {{ $filterSummary }}
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Datum</th><th>Zeit</th><th>Pers.</th><th>Name</th>
+        <th>Status</th><th>Quelle</th>
+      </tr>
+    </thead>
+    <tbody>
+      @foreach ($reservations as $r)
+        <tr>
+          <td>{{ optional($r->desired_at)->copy()->setTimezone($restaurant->timezone)->format('d.m.Y') }}</td>
+          <td>{{ optional($r->desired_at)->copy()->setTimezone($restaurant->timezone)->format('H:i') }}</td>
+          <td>{{ $r->party_size }}</td>
+          <td>{{ $r->guest_name }}</td>
+          <td>{{ $r->status->label() }}</td>
+          <td>{{ $r->source->label() }}</td>
+        </tr>
+      @endforeach
+    </tbody>
+  </table>
+  <p class="small">Seite {PAGE_NUM} / {PAGE_COUNT}</p>
+</body>
+</html>
+```
+
+dompdf paginiert automatisch. Bei sehr großen Listen (> 500 Records): Header pro Seite via `@page` und CSS-Property repeat.
+
+### Audit & Cleanup
+
+`export_audits`:
+
+| Spalte         | Typ           |
+|----------------|---------------|
+| id             | bigint PK     |
+| restaurant_id  | bigint FK     |
+| user_id        | bigint FK     |
+| format         | string        | `csv` \| `pdf` |
+| filter_snapshot| json          | für Reproduzierbarkeit + DSGVO-Auskunft |
+| record_count   | int           |
+| storage_path   | string null   | gesetzt bei Async-Pfad                   |
+| downloaded_at  | datetime null |                                          |
+| expires_at     | datetime null | bei Async-Pfad: created_at + 24 h        |
+| created_at     | timestamp     |                                          |
+
+**Cleanup-Job** `PurgeExpiredExportsJob` läuft alle 6 Stunden:
+
+- Löscht Files unter `storage/app/exports/*` mit `expires_at < now()`
+- Setzt `storage_path = null`, behält Audit-Eintrag (audit-trail-Pflicht)
+
+---
+
+## Akzeptanzkriterien
+
+- [ ] Dashboard-Header zeigt Export-Dropdown
+- [ ] CSV-Download enthält alle gefilterten Reservierungen mit korrekten Spalten
+- [ ] CSV mit deutschen Umlauten ist Excel-DE-kompatibel (UTF-8 BOM, `;`-Separator)
+- [ ] PDF-Download zeigt Restaurant-Name, Generierungszeit, Filter-Zusammenfassung, Tabelle
+- [ ] Sync-Pfad bei ≤ 100 Records, kein Job, direkter Download
+- [ ] Async-Pfad bei > 100 Records, Job dispatched, Mail mit signed URL (24 h)
+- [ ] Signed Download-URL läuft nach 24 h ab → 403
+- [ ] Anderer User kann Download-URL nicht missbrauchen → 403 (User-Mismatch)
+- [ ] Mandantentrennung: User aus Restaurant B kann keine Reservierungen aus Restaurant A exportieren
+- [ ] `PurgeExpiredExportsJob` löscht Files, behält Audit-Eintrag
+- [ ] Datenschutz-Hinweis im UI sichtbar
+- [ ] Alle Tests grün, Pint/ESLint/Prettier ohne Findings
+
+---
+
+## Tests
+
+**Feature (`tests/Feature/Exports/CsvExportTest.php`)**
+
+- `it streams a csv download for small result sets` (< 100 Records)
+- `it includes BOM and semicolons for excel de`
+- `it applies dashboard filters`
+- `it includes guest email and party size`
+- `it forbids cross-tenant export`
+
+**Feature (`tests/Feature/Exports/PdfExportTest.php`)**
+
+- `it streams a pdf for small result sets`
+- `it shows restaurant name and generated date`
+- `it shows filter summary in header`
+- `it paginates large lists`
+
+**Feature (`tests/Feature/Exports/AsyncExportTest.php`)**
+
+- `it dispatches export job when record count exceeds threshold` (mit `Queue::fake()`)
+- `it sends email with signed url after job completes` (mit `Mail::fake()`)
+- `it allows download for owner of audit within signed window`
+- `it rejects download after expiry`
+- `it rejects download for different user`
+
+**Feature (`tests/Feature/Exports/PurgeExpiredExportsJobTest.php`)**
+
+- `it deletes files older than expiry`
+- `it keeps audit record after file delete`
+- `it sets storage_path to null after delete`
+
+**Unit (`tests/Unit/Exports/ExportDispatcherTest.php`)**
+
+- `it picks sync path under threshold`
+- `it picks async path over threshold`
+- `it writes audit row in both paths`
+
+---
+
+## Risiken & offene Fragen
+
+- **DSGVO** – Exports enthalten personenbezogene Daten und müssen entsprechend dokumentiert werden. `export_audits` reicht für die Nachvollziehbarkeit. Hinweis im UI klärt den Owner. Eine Owner-Pflicht zur Vernichtung der Datei nach Verarbeitung lässt sich technisch nicht erzwingen; das wandert in die Datenschutzerklärung.
+- **PDF-Größe bei tausenden Records** – dompdf hält das gesamte Dokument im Memory. Pragmatisch: Async-Pfad ab 100 Records puffert das Dispatch-Risiko, Job kann mehrere Sekunden laufen ohne Web-Timeout. Bei > 5.000 Records denken wir über Streaming-PDF (z. B. `mpdf`-Output-Buffering) nach – aber erst auf Bedarf.
+- **Speicherort** – `storage/app/exports/` lokal ok, Prod sollte einen separaten Disk haben (`exports`-Disk in `config/filesystems.php`), idealerweise S3-kompatibel mit Lifecycle-Policy. Diese Infrastruktur-Entscheidung ist Teil der Prod-Setup-Doku, nicht Code-Scope von PRD-009.
+- **Excel-`.xlsx` statt CSV** – Steuerberater fragen manchmal explizit nach `.xlsx`. CSV deckt > 90 % der Use-Cases. Wenn ein Pilot drauf besteht: `maatwebsite/excel` als Folge-Issue, nicht V2.0.
+- **Filter-Snapshot ist groß** – wenn der Owner ungewöhnlich komplexe Filter setzt, wird das JSON groß. Akzeptabel; in der Praxis bleibt das im einstelligen KB-Bereich.

--- a/docs/PRD-010-push-and-sound-alerts.md
+++ b/docs/PRD-010-push-and-sound-alerts.md
@@ -1,0 +1,276 @@
+# PRD-010: Push & Sound-Alerts
+
+**Produkt:** reservation-agent
+**Version:** V2.0
+**Priorität:** P2 – operativer Komfort, baut auf PRD-004 (Polling) auf
+**Entwicklungsphase:** V2 (parallel zu Phase 2/3)
+
+---
+
+## Problem
+
+PRD-004-Polling lädt das Dashboard alle 30 Sekunden neu, aber **nur wenn der Tab im Vordergrund ist**. In der Realität:
+
+- Owner haben das Dashboard nebenbei in einem Tab offen, arbeiten aber an anderen Dingen.
+- Bei kurzfristigen Anfragen („Tisch für heute Abend, 4 Personen, 19:30") sind 30 Sekunden Verzögerung **plus** „Owner muss den Tab anschauen" zu lang – die Anfrage ist verloren, bevor sie gesehen wurde.
+- Außerhalb der Öffnungszeiten (z. B. 14–17 Uhr Pause) liegt das Dashboard niemandes Hand. Es entsteht ein toter Zeitraum, in dem Anfragen liegen bleiben.
+
+V1.0 lebt mit dieser Lücke, weil sie kein Killer ist – aber sie kostet Reaktionsgeschwindigkeit, was ein zentrales Verkaufsargument ist.
+
+## Ziel
+
+Sofortige akustische und visuelle Benachrichtigung über neue Anfragen via **Browser Notifications API** plus **optionalem Sound-Alert**. Beides per User-Setting de-/aktivierbar. Zusätzlich ein **täglicher E-Mail-Digest** als Fallback für User, die Browser-Notifications blockieren.
+
+Kein Service Worker, kein Push API, keine externe Infrastruktur. Notifications laufen **in dem Tab, der das Dashboard offen hat** – das deckt 90 % der Pilot-Use-Cases zu Null Infrastruktur-Kosten.
+
+---
+
+## Scope V2.0
+
+### In Scope
+
+- User-Settings `notification_settings` (JSON) am bestehenden `users`-Model
+- Settings-UI als Page `resources/js/pages/Settings/Notifications.vue`:
+  - Browser-Notifications: an / aus
+  - Sound-Alerts: an / aus + Lautstärke (0–100)
+  - Sound-Auswahl: 1 Default-Sound + 2 Alternativen
+  - Daily Digest: an / aus + Zeit (Default 18:00 Restaurant-Zeit)
+- Composable `useNotifications` für Permission-Handling, Trigger
+- Trigger-Punkt: Dashboard-Polling (PRD-004) erkennt neue Requests im Diff zwischen Reloads → Notification + Sound
+- Permission-Request: nur bei aktiver Owner-Aktion („Notifications aktivieren"-Button), nie automatisch beim Dashboard-Load
+- Email-Digest:
+  - Job `SendDailyDigestJob`, scheduled täglich, dispatcht pro Restaurant je nach User-Setting
+  - Mail enthält: Anzahl Anfragen heute, Anzahl bestätigt, Anzahl offen, Anzahl mit `needs_manual_review`
+  - Direktlink ins Dashboard
+- Audio-Files: 3 kurze Töne (~0.5 s) im `public/sounds/` als MP3, gemeinfrei
+- Frontend-Lautstärke via `HTMLAudioElement.volume`
+
+### Out of Scope
+
+- Browser-Push außerhalb des offenen Tabs (Service Worker + Push API) – V3.0
+- Mobile Push – V3.0 (gehört zu Mobile App)
+- SMS-Alerts – V3.0 oder darüber hinaus
+- Slack-/Teams-Integration – V3.0
+- Custom-Alarme („nur bei > 6 Personen") – V2.1, falls Pilot-Bedarf
+
+---
+
+## Technische Anforderungen
+
+### Datenmodell
+
+`users.notification_settings` (JSON, Default `{}`):
+
+```json
+{
+  "browser_notifications": false,
+  "sound_alerts": false,
+  "sound": "default",
+  "volume": 70,
+  "daily_digest": true,
+  "daily_digest_at": "18:00"
+}
+```
+
+Migration ergänzt die Spalte; `notification_settings` wird als JSON-Cast `'array'` ans User-Model gehängt. Default-Werte werden beim ersten Setting-Load aus einem Service `NotificationSettings::default()` gemerged, damit neue Felder rückwärtskompatibel sind, ohne Migration jedes bestehenden Users.
+
+### Composable `useNotifications`
+
+`resources/js/composables/useNotifications.ts`:
+
+```ts
+export function useNotifications(settings: Ref<NotificationSettings>) {
+  const permission = ref<NotificationPermission>(typeof Notification !== 'undefined' ? Notification.permission : 'denied');
+
+  async function requestPermission(): Promise<NotificationPermission> {
+    if (typeof Notification === 'undefined') return 'denied';
+    permission.value = await Notification.requestPermission();
+    return permission.value;
+  }
+
+  function notify(title: string, options: NotificationOptions = {}): Notification | null {
+    if (!settings.value.browser_notifications) return null;
+    if (permission.value !== 'granted') return null;
+    return new Notification(title, options);
+  }
+
+  function playSound(soundKey: string = settings.value.sound): void {
+    if (!settings.value.sound_alerts) return;
+    const audio = new Audio(`/sounds/${soundKey}.mp3`);
+    audio.volume = clamp(settings.value.volume / 100, 0, 1);
+    audio.play().catch(() => { /* user gesture missing – Browser blockt, ist ok */ });
+  }
+
+  return { permission, requestPermission, notify, playSound };
+}
+```
+
+Browser-Quirks bewusst eingerechnet:
+
+- `Notification` ist in einigen Test-Umgebungen nicht definiert → defensive Checks.
+- `audio.play()` benötigt User-Gesture beim ersten Ton; bei abgelehntem Promise schweigend weitermachen, **nicht** im UI als Fehler anzeigen.
+
+### Trigger im Dashboard
+
+`Dashboard.vue` erweitert die Polling-Logik aus PRD-004:
+
+```ts
+const previousIds = ref<Set<number>>(new Set());
+
+onUpdated(() => {
+  const currentIds = new Set(props.requests.data.map((r: Request) => r.id));
+  const newIds = [...currentIds].filter((id) => !previousIds.value.has(id));
+
+  if (previousIds.value.size > 0 && newIds.length > 0) {
+    notifications.notify('Neue Reservierungsanfrage', {
+      body: `${newIds.length} neue Anfrage${newIds.length > 1 ? 'n' : ''} – jetzt anschauen`,
+      tag: 'reservation-agent-new-request',
+    });
+    notifications.playSound();
+  }
+
+  previousIds.value = currentIds;
+});
+```
+
+Diff-basiert – damit der erste Page-Load **keine** Notification triggert. Tag-basierter De-Duplication-Hint im Notification-Tag, damit mehrere Notifications nicht stapeln.
+
+### Email-Digest
+
+`app/Jobs/SendDailyDigestJob.php`:
+
+```php
+public function handle(): void
+{
+    $users = User::whereJsonContains('notification_settings->daily_digest', true)
+        ->whereNotNull('restaurant_id')
+        ->with('restaurant')
+        ->get();
+
+    foreach ($users as $user) {
+        if (!$this->shouldSendNow($user)) {
+            continue;
+        }
+        Mail::to($user)->send(new DailyDigestMail($this->summaryFor($user)));
+    }
+}
+
+private function shouldSendNow(User $user): bool
+{
+    $sendAt = $user->notification_settings['daily_digest_at'] ?? '18:00';
+    $tz     = $user->restaurant->timezone;
+    $now    = now()->setTimezone($tz);
+
+    return $now->format('H:i') === $sendAt;
+}
+
+private function summaryFor(User $user): DigestSummary
+{
+    $restaurant = $user->restaurant;
+    $today = now()->setTimezone($restaurant->timezone)->startOfDay();
+
+    return new DigestSummary(
+        restaurantName: $restaurant->name,
+        totalToday:     ReservationRequest::where('restaurant_id', $restaurant->id)->whereDate('created_at', $today)->count(),
+        confirmed:      ReservationRequest::where('restaurant_id', $restaurant->id)->whereDate('created_at', $today)->where('status', ReservationStatus::Confirmed)->count(),
+        pending:        ReservationRequest::where('restaurant_id', $restaurant->id)->whereDate('created_at', $today)->whereIn('status', [ReservationStatus::New, ReservationStatus::InReview])->count(),
+        needsReview:    ReservationRequest::where('restaurant_id', $restaurant->id)->whereDate('created_at', $today)->where('needs_manual_review', true)->count(),
+        dashboardUrl:   route('dashboard'),
+    );
+}
+```
+
+`Schedule` in `routes/console.php`:
+
+```php
+Schedule::job(new SendDailyDigestJob())->hourly();
+```
+
+Stündliches Trigger-Intervall, weil verschiedene Restaurant-Zeitzonen den exakten Sende-Slot verschieben. `shouldSendNow` filtert intern auf den User-Zeit-Match.
+
+### Audio-Assets
+
+`public/sounds/`:
+
+- `default.mp3` – kurzer, neutraler Hinweiston (~500 ms)
+- `chime.mp3` – freundliches Glöckchen
+- `tap.mp3` – kurzes Klopfen
+
+Lizenz: gemeinfrei oder CC0. Lizenz-Eintrag in `public/sounds/LICENSE.txt`. Files < 30 KB jeweils.
+
+### Permission-Flow im UI
+
+`Settings/Notifications.vue`:
+
+1. Beim ersten Laden: aktuellen `Notification.permission`-Status anzeigen.
+2. Wenn `default`: Toggle „Browser-Notifications aktivieren" → on-click `requestPermission()` aufrufen.
+3. Wenn `granted`: Toggle steuert nur das User-Setting; Browser-Permission bleibt unangetastet.
+4. Wenn `denied`: Toggle disabled, Hinweistext „Du hast Notifications für diese Seite blockiert. Aktiviere sie in den Browser-Einstellungen."
+5. „Ton testen"-Button für jeden der drei Sounds (mit aktueller Volume-Einstellung).
+
+Daily-Digest-Toggle und -Zeit sind unabhängig vom Browser-Permission-Status.
+
+---
+
+## Akzeptanzkriterien
+
+- [ ] User kann Notifications/Sound/Digest unabhängig de-/aktivieren
+- [ ] Permission-Request erscheint NUR nach explizitem Owner-Klick auf „Aktivieren"
+- [ ] Bei neuer Anfrage im Dashboard: Browser-Notification wird gezeigt (wenn aktiviert + permission granted)
+- [ ] Bei neuer Anfrage: Sound spielt mit konfigurierter Lautstärke (wenn aktiviert)
+- [ ] Erster Page-Load triggert KEINE Notification (Diff-Logik)
+- [ ] Notification-Tag verhindert Stapeln mehrerer Reservation-Notifications
+- [ ] „Ton testen"-Button im Settings-UI spielt den ausgewählten Sound mit der eingestellten Lautstärke
+- [ ] Daily Digest läuft stündlich, sendet pro User exakt einmal in 24 h zur konfigurierten Zeit
+- [ ] Daily Digest enthält Zahlen für: gesamt, bestätigt, offen, manuelle Prüfung
+- [ ] Direktlink im Digest geht ins Dashboard
+- [ ] Mandantentrennung: Digest enthält nur Daten des eigenen Restaurants
+- [ ] User ohne `restaurant_id` (Admin) erhält keinen Digest
+- [ ] Settings persistieren über Sessions hinweg
+- [ ] Browser ohne Notifications-API fällt auf „nur Sound + Digest"-Modus zurück (kein JS-Fehler)
+- [ ] Alle Tests grün, Pint/ESLint/Prettier ohne Findings
+
+---
+
+## Tests
+
+**Frontend (Vitest, `resources/js/composables/useNotifications.test.ts`)**
+
+- `it does not call Notification when browser_notifications is off`
+- `it does not call Notification when permission is not granted`
+- `it triggers Notification with correct title when allowed`
+- `it returns denied permission when Notification API is undefined`
+- `it does not throw when audio.play rejects`
+- `it clamps volume to [0, 1]`
+
+**Frontend (`Dashboard.notifications.test.ts`)**
+
+- `it does not notify on initial load`
+- `it notifies when polling adds new request ids`
+- `it suppresses notification when user disabled browser_notifications`
+
+**Feature (`tests/Feature/Notifications/DailyDigestTest.php`)**
+
+- `it sends digest at user configured time in restaurant timezone` (mit `Carbon::setTestNow`)
+- `it does not send digest when daily_digest is off`
+- `it sends digest only once per user per day`
+- `it includes correct counts for today` (mit Seed-Daten)
+- `it skips users without restaurant_id`
+- `it includes dashboard URL`
+
+**Feature (`tests/Feature/Notifications/SettingsTest.php`)**
+
+- `it persists notification settings`
+- `it merges defaults for missing keys`
+- `it forbids editing other users settings`
+
+---
+
+## Risiken & offene Fragen
+
+- **Browser-Block** – wenn der Owner Notifications für die Domain global blockiert (passiert oft), bleibt nur Sound + Digest. Die UI muss das transparent zeigen (denied-State explizit ausweisen, nicht stillschweigend). Das ist die wichtigste UX-Falle.
+- **Sound nervt schnell** – Default OFF ist Pflicht. Nach 5+ Triggern in 10 Minuten könnte ein Hint im UI erscheinen („Soll der Ton zwischen 22 und 8 Uhr stumm bleiben?"). Das geht aber ins V2.1-Polishing.
+- **Polling-Diff im Dashboard** – die Diff-Logik basiert auf den IDs der aktuellen Page. Wenn der Owner gerade Filter umgeschaltet hat, kommen „neue" IDs durch das Filterwechseln, nicht durch echte Neuanfragen. Lösung: Diff nur dann auswerten, wenn `filters` zwischen den Polls **identisch** sind (Vergleich des Filter-Snapshots). Tests decken den Filter-Wechsel ab.
+- **Daily-Digest-Zeitzonen** – Restaurants in verschiedenen Zeitzonen haben unterschiedliche „18:00". Stündlicher Job + interner Zeit-Match ist der einfachste robuste Ansatz; bei Tausenden Restaurants müsste man auf Cron-pro-Zeitzone wechseln, aber das ist V3.0+.
+- **Audio-Lizenzen** – nur gemeinfreie oder CC0-Sounds verwenden, Lizenzdatei mitliefern. Klingt trivial, ist aber ein klassisches Open-Source-PR-Reject-Reason.
+- **Mehrere Tabs** – wenn der Owner das Dashboard in zwei Tabs offen hat, klingt der Sound zweimal. Akzeptabler V2.0-Tradeoff (BroadcastChannel-API für Cross-Tab-Sync ist möglich, aber Overengineering für den Pilot).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# reservation-agent – PRD-Übersicht V1.0
+# reservation-agent – PRD-Übersicht
 
 KI-gestütztes Reservierungssystem für die Gastronomie.
 **Zielgruppe:** inhabergeführte Restaurants und kleine Ketten (1–5 Standorte), die Reservierungen aktuell manuell über mehrere Kanäle bearbeiten.
@@ -17,7 +17,7 @@ KI-gestütztes Reservierungssystem für die Gastronomie.
 
 ---
 
-## Entwicklungs-Roadmap
+## Entwicklungs-Roadmap V1.0
 
 ```
 Woche 1   │ PRD-001 │ Laravel-Skeleton, Entities, Migrations, Auth
@@ -28,6 +28,41 @@ Woche 3   │ PRD-003 │ IMAP-Parser finalisieren, Error-Handling
 Woche 4   │ PRD-005 │ KI-Kontext-Builder, Prompt, Freigabe-Workflow, Mailversand
 Woche 5   │  –      │ Testing, Bugfixing, erstes Pilot-Restaurant
 ```
+
+---
+
+## PRDs V2.0
+
+V2.0 baut auf V1.0 auf und schließt die wichtigsten Lücken, die ohne Pilotbetrieb absehbar schmerzen werden – plus den meistgewünschten Komfort-Features.
+
+| Nr. | Titel                                                     | Priorität | Phase | Abhängigkeiten      |
+|-----|-----------------------------------------------------------|-----------|-------|---------------------|
+| [006](PRD-006-mail-threading.md)            | Mail-Threading                                | P0 | V2-Phase 1 | 003                |
+| [007](PRD-007-auto-send-trust-modes.md)     | Auto-Versand mit Vertrauensstufen             | P0 | V2-Phase 2 | 005, 006           |
+| [008](PRD-008-dashboard-analytics.md)       | Dashboard-Analytics                           | P1 | V2-Phase 3 | 004, 006, 007      |
+| [009](PRD-009-export-csv-pdf.md)            | Export CSV/PDF                                | P2 | V2-parallel | 004                |
+| [010](PRD-010-push-and-sound-alerts.md)     | Push & Sound-Alerts                           | P2 | V2-parallel | 004                |
+
+### Phasen-Reihenfolge
+
+```
+Phase 1 (Fundament)
+└── PRD-006  Mail-Threading
+              │
+              ▼
+Phase 2 (Kernfeature)
+└── PRD-007  Auto-Versand (Manual / Shadow / Auto)
+              │
+              ▼
+Phase 3 (Sichtbar machen)
+└── PRD-008  Dashboard-Analytics
+
+Parallel zu Phase 2/3 (unabhängig)
+├── PRD-009  Export CSV/PDF
+└── PRD-010  Push & Sound-Alerts
+```
+
+**Architekturkonsequenz V2.0:** PRD-007 hebt das V1.0-Verbot „kein automatischer Mailversand ohne Freigabe" als opt-in mit Hard-Gates auf. Die Anpassung von [`CLAUDE.md`](../CLAUDE.md) ist Teil des V2.0-Release-PRs (siehe Risiken-Abschnitt in PRD-007).
 
 ---
 
@@ -47,20 +82,28 @@ Jede automatische Antwort durchläuft einen Freigabe-Workflow – kein KI-generi
 
 ---
 
-## Bewusst NICHT in V1.0
+## Roadmap nach V1.0
 
-| Feature                                 | Version |
-|-----------------------------------------|---------|
-| OpenTable / TheFork / Quandoo Anbindung | V2.0    |
-| Google Reserve / Google Business        | V2.0    |
-| Automatischer Mailversand ohne Freigabe | V2.0    |
-| Tischplan / grafische Sitzordnung       | V2.0    |
-| Zahlungs-Hinterlegung / No-Show-Gebühr  | V2.0    |
-| Mehrsprachige Antworten                 | V2.0    |
-| Analytics / Reporting                   | V2.0    |
-| Multi-Standort-Verwaltung > 5 Standorte | V3.0    |
-| Mobile App                              | V3.0    |
-| Lokale KI (Ollama/Llama)                | V3.0    |
+| Feature                                          | Version | Status                                |
+|--------------------------------------------------|---------|---------------------------------------|
+| Mail-Threading                                   | V2.0    | scoped → [PRD-006](PRD-006-mail-threading.md) |
+| Automatischer Mailversand (opt-in mit Hard-Gates)| V2.0    | scoped → [PRD-007](PRD-007-auto-send-trust-modes.md) |
+| Analytics / Reporting (Counters & 30-Tage-Trend) | V2.0    | scoped → [PRD-008](PRD-008-dashboard-analytics.md) |
+| Export CSV/PDF                                   | V2.0    | scoped → [PRD-009](PRD-009-export-csv-pdf.md) |
+| Push-Benachrichtigungen / Sound-Alerts / Digest  | V2.0    | scoped → [PRD-010](PRD-010-push-and-sound-alerts.md) |
+| Tischplan / grafische Sitzordnung                | V3.0    | (Robustheit + Tischplan)              |
+| WebSockets via Laravel Reverb (Polling-Ablöse)   | V3.0    | siehe [decision](decisions/polling-vs-websockets-v1.md) |
+| DSGVO-UI für Betroffenen-Löschanträge            | V3.0    | siehe [decision](decisions/failed-email-imports-retention.md) |
+| Multi-Standort-Verwaltung > 5 Standorte          | V3.0    |                                       |
+| KI lernt aus manuellen Edits (RAG / Fine-Tuning) | V4.0    | (KI-Differenzierung)                  |
+| Tonalität / Prompt pro Restaurant statt global   | V4.0    | siehe [decision](decisions/ai-tonality-prompts.md) |
+| Mehrsprachige Antworten                          | V4.0    |                                       |
+| Lokale KI (Ollama / vLLM)                        | V4.0+   | siehe [decision](decisions/openai-data-protection.md) |
+| Embeddable Widget / iframe-Variante              | V5.0    | (Reichweite)                          |
+| OpenTable / TheFork / Quandoo Anbindung          | V5.0    | (Reichweite)                          |
+| Google Reserve / Google Business                 | V5.0    | (Reichweite)                          |
+| Mobile App                                       | V5.0+   | eigene Produkt-Linie                  |
+| Zahlungs-Hinterlegung / No-Show-Gebühr           | offen   | nicht versionsgebunden                |
 
 ---
 

--- a/docs/decisions/failed-email-imports-retention.md
+++ b/docs/decisions/failed-email-imports-retention.md
@@ -72,6 +72,14 @@ Jede Änderung erfordert Update dieser Datei, Anpassung der Datenschutzerklärun
 
 ## Nicht in diesem Dokument
 
-- UI für Betroffenen-Löschantrag (V2.0, eigenes Issue)
+- UI für Betroffenen-Löschantrag (V3.0, eigenes Issue – siehe Update unten)
 - Export von Quarantäne-Einträgen zur Offline-Analyse (nicht geplant)
 - Separate Retention-Frist für `reservation_requests` (eigene Entscheidung, wenn relevant)
+
+## Update April 2026 – Verschiebung der DSGVO-UI auf V3.0
+
+Diese Entscheidung hat in ihrer ursprünglichen Fassung die Betroffenen-Löschantrags-UI als „V2.0, eigenes Issue" geführt. Im Rahmen der V2.0-Roadmap-Brainstorming-Session (siehe [`docs/README.md`](../README.md) Abschnitt „Roadmap nach V1.0") wurde V2.0 bewusst auf das Schließen der zentralen Pilot-Pain-Points fokussiert (Threading, Auto-Versand, Analytics, Export, Push). Die DSGVO-UI wandert in V3.0 zusammen mit anderen operativen Robustheits-Themen (Reverb, Multi-Standort > 5).
+
+**Begründung:** Die 30-Tage-Auto-Löschung aus dieser Entscheidung erfüllt Art. 17 DSGVO bereits ohne UI – Betroffene können einen Löschantrag heute schon manuell durch den Restaurant-Owner per Tinker oder DB-Query bearbeiten lassen. Eine eigene UI ist Komfort, kein Compliance-Engpass. Die Verschiebung schiebt also keine rechtliche Pflicht auf.
+
+**Folgen für diese Entscheidung:** keine. Die Retention-Logik (30 Tage, hart) und das Audit-Log bleiben unverändert. Nur der „Nicht in diesem Dokument"-Hinweis ändert seine Versionsangabe.


### PR DESCRIPTION
## Summary

Adds the five V2.0 product requirement documents and re-buckets the post-V1.0 roadmap.

- **PRD-006 Mail-Threading** — outbound message-id stamping, four-strategy `ThreadResolver` with anti-spoof sender check, new `reservation_messages` table, drawer thread view. Foundation for PRD-007.
- **PRD-007 Auto-Send mit Vertrauensstufen** — `manual` / `shadow` / `auto` per restaurant, `AutoSendDecider` with six hard gates (manual review, fallback text, party-size, short notice, first-time guest, low parser confidence), 60-second cancel window, killswitch, audit trail. Lifts the V1.0 prohibition on automatic sending as opt-in.
- **PRD-008 Dashboard-Analytics** — totals, response time (median + p90), edit rate, shadow takeover rate, top-3 hard-gate reasons, 30-day trend charts. Five-minute cache, PHP-side percentiles for SQLite parity.
- **PRD-009 Export CSV/PDF** — Excel-DE compatible CSV (UTF-8 BOM, semicolon), dompdf PDF, sync ≤ 100 records / async > 100 with 24-hour signed URL, audit table, lifecycle cleanup.
- **PRD-010 Push & Sound-Alerts** — browser Notifications API (no service worker), optional sound, daily digest with timezone-aware scheduling. Diff-based polling trigger to avoid first-load notifications.

Roadmap mapping in both `README.md` and `docs/README.md` updated to reflect the new V2/V3/V4/V5 split agreed in the brainstorming session: V2 deepens pilot pain points, V3 covers robustness + table plan, V4 covers AI differentiation, V5 covers channel reach.

## Why

V1.0 ships with five known gaps that will hit pilot restaurants the moment they go live: replies to confirmation mails are misclassified as new requests, manual approval becomes a bottleneck under load, no analytics means the trust-build path to auto-send is invisible, no export means owners hand-copy lists, and notifications-via-polling miss requests outside active tabs. V2.0 closes all five with explicit safety nets — the auto-send rollout in particular is gated to prevent any silent reliability regression versus the V1.0 manual-approval guarantee.

The V2.0 PRD-007 hard-gates and the explicit `manual` default mean existing V1.0 restaurants keep the V1.0 contract until an owner deliberately opts in. The architectural shift is documented in PRD-007's risk section; the corresponding `CLAUDE.md` update is intentionally **out of scope** of this docs PR and will be part of the V2.0 release PR once implementation completes.

## Test plan

This PR is documentation only — no code changes, no migrations, no test runs. Review checklist:

- [ ] All five PRDs follow the V1.0 PRD structure (Problem / Ziel / Scope / Technische Anforderungen / Akzeptanzkriterien / Tests / Risiken)
- [ ] Cross-references between PRDs are consistent (006 ↔ 007 dependency, 007 ↔ 008 send-mode stats, 008 ↔ 005 snapshot extension)
- [ ] Roadmap tables in `README.md` and `docs/README.md` are identical in content
- [ ] No placeholders (TBD, TODO, FIXME) — verified via grep
- [ ] PRD-007 explicitly flags the `CLAUDE.md` update as a downstream change rather than silently breaking the V1.0 invariant

Closes none — this is a planning PR; per-PRD implementation issues will be opened at the start of each PRD.