### PR TITLE
Untrack Laravel storage artifacts and .playwright-mcp (#194)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,14 @@
 /.phpactor.json
 /storage/*.key
 /storage/pail
+/storage/framework/cache/data/*
+!/storage/framework/cache/data/.gitkeep
+/storage/framework/sessions/*
+!/storage/framework/sessions/.gitkeep
+/storage/framework/testing/*
+!/storage/framework/testing/.gitkeep
+/storage/framework/views/*
+!/storage/framework/views/.gitkeep
 /auth.json
 
 # Local SQLite (developer artefact, not source)
@@ -40,3 +48,6 @@ yarn-error.log
 *.log
 Homestead.json
 Homestead.yaml
+
+# Tooling scratch
+.playwright-mcp/


### PR DESCRIPTION
## Summary
Ergänzt Standard-Laravel-Patterns für `/storage/framework/cache/data`, `sessions`, `testing`, `views` (jeweils mit `!.gitkeep`-Negation) sowie `.playwright-mcp/` in `.gitignore`.

## Why
`git status` zeigte 46+ untracked `storage/framework/views/*.php` (kompilierte Blade-Views) plus das Playwright-MCP-Scratch-Verzeichnis. Beides sind generierte Artefakte, die niemals in den Index gehören. Das Risiko, dass jemand versehentlich `git add -A` macht und Cache-Dateien committed, war real.

## Test plan
- [x] `git status` ist nach dem Commit clean (keine `storage/framework/views`, keine `.playwright-mcp/`-Einträge)
- [x] `.gitkeep`-Dateien bleiben tracked (Negations-Pattern)
- [x] Self-Review via `code-review:code-review <PR#>` läuft nach Push

Closes #194