### PR TITLE
Add reservation_messages table + outbound_message_id (#201)

### DIFF
--- a/app/Enums/MessageDirection.php
+++ b/app/Enums/MessageDirection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Enums;
+
+enum MessageDirection: string
+{
+    case In = 'in';
+    case Out = 'out';
+}

--- a/app/Models/ReservationMessage.php
+++ b/app/Models/ReservationMessage.php
@@ -2,18 +2,15 @@
 
 namespace App\Models;
 
-use App\Enums\ReservationReplyStatus;
-use App\Models\Scopes\RestaurantScope;
-use Database\Factories\ReservationReplyFactory;
-use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use App\Enums\MessageDirection;
+use Database\Factories\ReservationMessageFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
-#[ScopedBy(RestaurantScope::class)]
-class ReservationReply extends Model
+final class ReservationMessage extends Model
 {
-    /** @use HasFactory<ReservationReplyFactory> */
+    /** @use HasFactory<ReservationMessageFactory> */
     use HasFactory;
 
     /**
@@ -23,14 +20,17 @@ class ReservationReply extends Model
      */
     protected $fillable = [
         'reservation_request_id',
-        'status',
-        'body',
-        'ai_prompt_snapshot',
-        'approved_by',
-        'approved_at',
+        'direction',
+        'message_id',
+        'in_reply_to',
+        'references',
+        'subject',
+        'from_address',
+        'to_address',
+        'body_plain',
+        'raw_headers',
         'sent_at',
-        'error_message',
-        'outbound_message_id',
+        'received_at',
     ];
 
     /**
@@ -41,10 +41,9 @@ class ReservationReply extends Model
     protected function casts(): array
     {
         return [
-            'status' => ReservationReplyStatus::class,
-            'ai_prompt_snapshot' => 'array',
-            'approved_at' => 'datetime',
+            'direction' => MessageDirection::class,
             'sent_at' => 'datetime',
+            'received_at' => 'datetime',
         ];
     }
 
@@ -54,13 +53,5 @@ class ReservationReply extends Model
     public function reservationRequest(): BelongsTo
     {
         return $this->belongsTo(ReservationRequest::class);
-    }
-
-    /**
-     * @return BelongsTo<User, $this>
-     */
-    public function approver(): BelongsTo
-    {
-        return $this->belongsTo(User::class, 'approved_by');
     }
 }

--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -76,6 +76,14 @@ class ReservationRequest extends Model
     }
 
     /**
+     * @return HasMany<ReservationMessage, $this>
+     */
+    public function messages(): HasMany
+    {
+        return $this->hasMany(ReservationMessage::class);
+    }
+
+    /**
      * @return HasOne<ReservationReply, $this>
      */
     public function latestReply(): HasOne

--- a/database/factories/ReservationMessageFactory.php
+++ b/database/factories/ReservationMessageFactory.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\MessageDirection;
+use App\Models\ReservationMessage;
+use App\Models\ReservationRequest;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ReservationMessage>
+ */
+class ReservationMessageFactory extends Factory
+{
+    protected $model = ReservationMessage::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $direction = fake()->randomElement([MessageDirection::In, MessageDirection::Out]);
+
+        return [
+            'reservation_request_id' => ReservationRequest::factory(),
+            'direction' => $direction,
+            'message_id' => $this->fakeMessageId(),
+            'in_reply_to' => null,
+            'references' => null,
+            'subject' => fake()->sentence(),
+            'from_address' => fake()->safeEmail(),
+            'to_address' => fake()->safeEmail(),
+            'body_plain' => fake()->paragraph(),
+            'raw_headers' => 'From: '.fake()->safeEmail()."\nSubject: ".fake()->sentence(),
+            'sent_at' => $direction === MessageDirection::Out ? now() : null,
+            'received_at' => $direction === MessageDirection::In ? now() : null,
+        ];
+    }
+
+    public function inbound(): static
+    {
+        return $this->state(fn () => [
+            'direction' => MessageDirection::In,
+            'sent_at' => null,
+            'received_at' => now(),
+        ]);
+    }
+
+    public function outbound(): static
+    {
+        return $this->state(fn () => [
+            'direction' => MessageDirection::Out,
+            'sent_at' => now(),
+            'received_at' => null,
+        ]);
+    }
+
+    public function forReservationRequest(ReservationRequest $request): static
+    {
+        return $this->state(fn () => [
+            'reservation_request_id' => $request->id,
+        ]);
+    }
+
+    private function fakeMessageId(): string
+    {
+        return '<'.Str::lower(Str::random(24)).'@example.test>';
+    }
+}

--- a/database/migrations/2026_04_29_224058_create_reservation_messages_table.php
+++ b/database/migrations/2026_04_29_224058_create_reservation_messages_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reservation_messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reservation_request_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('direction');
+            $table->string('message_id')->unique();
+            $table->string('in_reply_to')->nullable();
+            $table->text('references')->nullable();
+            $table->string('subject');
+            $table->string('from_address');
+            $table->string('to_address');
+            $table->text('body_plain');
+            $table->text('raw_headers');
+            $table->dateTime('sent_at')->nullable();
+            $table->dateTime('received_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['reservation_request_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reservation_messages');
+    }
+};

--- a/database/migrations/2026_04_29_224059_add_outbound_message_id_to_reservation_replies_table.php
+++ b/database/migrations/2026_04_29_224059_add_outbound_message_id_to_reservation_replies_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->string('outbound_message_id')->nullable()->after('error_message');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->dropColumn('outbound_message_id');
+        });
+    }
+};

--- a/tests/Feature/Models/ReservationMessageTest.php
+++ b/tests/Feature/Models/ReservationMessageTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Enums\MessageDirection;
+use App\Models\ReservationMessage;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ReservationMessageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_factory_creates_a_valid_message(): void
+    {
+        $message = ReservationMessage::factory()->create();
+
+        $this->assertTrue($message->exists);
+        $this->assertNotEmpty($message->message_id);
+        $this->assertInstanceOf(MessageDirection::class, $message->direction);
+        $this->assertNotEmpty($message->raw_headers);
+    }
+
+    public function test_inbound_state_sets_received_at_and_clears_sent_at(): void
+    {
+        $message = ReservationMessage::factory()->inbound()->create();
+
+        $this->assertSame(MessageDirection::In, $message->direction);
+        $this->assertInstanceOf(Carbon::class, $message->received_at);
+        $this->assertNull($message->sent_at);
+    }
+
+    public function test_outbound_state_sets_sent_at_and_clears_received_at(): void
+    {
+        $message = ReservationMessage::factory()->outbound()->create();
+
+        $this->assertSame(MessageDirection::Out, $message->direction);
+        $this->assertInstanceOf(Carbon::class, $message->sent_at);
+        $this->assertNull($message->received_at);
+    }
+
+    public function test_belongs_to_reservation_request(): void
+    {
+        $request = ReservationRequest::factory()->create();
+        $message = ReservationMessage::factory()->forReservationRequest($request)->create();
+
+        $this->assertSame($request->id, $message->reservationRequest->id);
+    }
+
+    public function test_reservation_request_has_many_messages_in_creation_order(): void
+    {
+        $request = ReservationRequest::factory()->create();
+
+        $first = ReservationMessage::factory()
+            ->forReservationRequest($request)
+            ->inbound()
+            ->create(['created_at' => now()->subMinutes(10)]);
+        $second = ReservationMessage::factory()
+            ->forReservationRequest($request)
+            ->outbound()
+            ->create(['created_at' => now()->subMinutes(5)]);
+
+        $messages = $request->messages()->orderBy('created_at')->get();
+
+        $this->assertCount(2, $messages);
+        $this->assertSame($first->id, $messages[0]->id);
+        $this->assertSame($second->id, $messages[1]->id);
+    }
+
+    public function test_message_id_is_globally_unique(): void
+    {
+        $messageId = '<unique@example.test>';
+
+        ReservationMessage::factory()->create(['message_id' => $messageId]);
+
+        $this->expectException(QueryException::class);
+
+        ReservationMessage::factory()->create(['message_id' => $messageId]);
+    }
+
+    public function test_message_id_is_unique_across_restaurants(): void
+    {
+        $restaurantA = Restaurant::factory()->create();
+        $restaurantB = Restaurant::factory()->create();
+
+        $requestA = ReservationRequest::factory()->forRestaurant($restaurantA)->create();
+        $requestB = ReservationRequest::factory()->forRestaurant($restaurantB)->create();
+
+        $messageId = '<cross-tenant@example.test>';
+
+        ReservationMessage::factory()
+            ->forReservationRequest($requestA)
+            ->create(['message_id' => $messageId]);
+
+        $this->expectException(QueryException::class);
+
+        ReservationMessage::factory()
+            ->forReservationRequest($requestB)
+            ->create(['message_id' => $messageId]);
+    }
+
+    public function test_messages_cascade_delete_when_reservation_request_is_deleted(): void
+    {
+        $request = ReservationRequest::factory()->create();
+        ReservationMessage::factory()->forReservationRequest($request)->count(3)->create();
+
+        $other = ReservationRequest::factory()->create();
+        ReservationMessage::factory()->forReservationRequest($other)->create();
+
+        $this->assertSame(4, ReservationMessage::query()->count());
+
+        $request->delete();
+
+        $this->assertSame(1, ReservationMessage::query()->count());
+    }
+
+    public function test_table_has_composite_index_on_request_id_and_created_at(): void
+    {
+        $this->assertTrue(
+            collect(Schema::getIndexes('reservation_messages'))
+                ->contains(fn (array $index) => $index['columns'] === ['reservation_request_id', 'created_at']),
+            'reservation_messages must have a composite index on (reservation_request_id, created_at)'
+        );
+    }
+
+    public function test_direction_is_cast_to_enum(): void
+    {
+        $message = ReservationMessage::factory()->create(['direction' => 'in']);
+
+        $this->assertSame(MessageDirection::In, $message->fresh()->direction);
+    }
+
+    public function test_references_column_can_persist_long_chains(): void
+    {
+        $references = collect(range(1, 20))
+            ->map(fn (int $i) => '<msg-'.$i.'@example.test>')
+            ->implode(' ');
+
+        $message = ReservationMessage::factory()->create(['references' => $references]);
+
+        $this->assertSame($references, $message->fresh()->references);
+    }
+}

--- a/tests/Feature/Models/ReservationReplyOutboundMessageIdTest.php
+++ b/tests/Feature/Models/ReservationReplyOutboundMessageIdTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Models\ReservationReply;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class ReservationReplyOutboundMessageIdTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_table_has_outbound_message_id_column(): void
+    {
+        $this->assertTrue(Schema::hasColumn('reservation_replies', 'outbound_message_id'));
+    }
+
+    public function test_outbound_message_id_defaults_to_null(): void
+    {
+        $reply = ReservationReply::factory()->draft()->create();
+
+        $this->assertNull($reply->outbound_message_id);
+    }
+
+    public function test_outbound_message_id_is_persisted_when_set(): void
+    {
+        $messageId = '<outbound-42@example.test>';
+
+        $reply = ReservationReply::factory()->sent()->create([
+            'outbound_message_id' => $messageId,
+        ]);
+
+        $this->assertSame($messageId, $reply->fresh()->outbound_message_id);
+    }
+}


### PR DESCRIPTION
## Summary

Data-model foundation for PRD-006 mail threading.

- New `reservation_messages` table with all 14 columns from PRD-006 §Datenmodell, composite index `(reservation_request_id, created_at)` for the drawer query, and globally unique `message_id`.
- `outbound_message_id` column added to `reservation_replies` (nullable, populated on send).
- `ReservationMessage` model (final, `MessageDirection` enum cast, BelongsTo `reservationRequest`).
- `ReservationMessageFactory` with `inbound()` / `outbound()` / `forReservationRequest()` states.
- HasMany `messages()` relation on `ReservationRequest`.

## Why

Without this table, no thread history can be persisted. The unique `message_id` is what makes the threading dedupe in #205 idempotent across both the new-reservation path and the thread-message path. Building the schema first unblocks the entire ThreadResolver chain (#202–205).

## Test plan

- [x] `php artisan test` — 516 tests, 1645 assertions, all green
- [x] New tests: `ReservationMessageTest` (11 cases) + `ReservationReplyOutboundMessageIdTest` (3 cases) cover factory, relations, cascade-delete, global message_id uniqueness (incl. cross-restaurant), composite index existence, enum cast, long references chains, nullable outbound_message_id
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean
- [x] Migration verified with `php artisan migrate:fresh --env=testing`

Closes #201