### PR TITLE
Add ThreadResolver skeleton + verifySender anti-spoofing (#202)

### DIFF
--- a/app/Services/Email/ThreadResolver.php
+++ b/app/Services/Email/ThreadResolver.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Email;
+
+use App\Models\ReservationRequest;
+use Psr\Log\LoggerInterface;
+use Webklex\PHPIMAP\Message;
+
+/**
+ * Resolves an incoming mail to an existing ReservationRequest using a
+ * four-strategy cascade. Every positive resolution is re-verified via
+ * verifySender, so a spoofed In-Reply-To cannot hijack a foreign thread.
+ *
+ * Strategy bodies are introduced in dedicated issues (#203, #204).
+ *
+ * Not declared `final` (against the project default) so the cascade
+ * contract can be exercised by a test-only subclass that swaps a single
+ * strategy stub. Production code MUST NOT subclass this — extend the
+ * strategies themselves once they are split out, not the cascade.
+ */
+class ThreadResolver
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Tries to attach an inbound mail to an existing reservation. Returns
+     * null when no strategy matches or when the verified sender does not
+     * match the reservation's stored guest email.
+     */
+    public function resolveForIncoming(Message $message, int $restaurantId): ?ReservationRequest
+    {
+        if ($candidate = $this->byInReplyTo($message, $restaurantId)) {
+            return $this->verifySender($candidate, $message);
+        }
+
+        if ($candidate = $this->byReferences($message, $restaurantId)) {
+            return $this->verifySender($candidate, $message);
+        }
+
+        if ($candidate = $this->bySubjectMarker($message, $restaurantId)) {
+            return $this->verifySender($candidate, $message);
+        }
+
+        if ($candidate = $this->byHeuristic($message, $restaurantId)) {
+            return $this->verifySender($candidate, $message);
+        }
+
+        return null;
+    }
+
+    protected function byInReplyTo(Message $message, int $restaurantId): ?ReservationRequest
+    {
+        return null;
+    }
+
+    protected function byReferences(Message $message, int $restaurantId): ?ReservationRequest
+    {
+        return null;
+    }
+
+    protected function bySubjectMarker(Message $message, int $restaurantId): ?ReservationRequest
+    {
+        return null;
+    }
+
+    protected function byHeuristic(Message $message, int $restaurantId): ?ReservationRequest
+    {
+        return null;
+    }
+
+    protected function verifySender(ReservationRequest $request, Message $message): ?ReservationRequest
+    {
+        $from = strtolower(trim((string) ($message->getFrom()[0]->mail ?? '')));
+        $expected = strtolower(trim((string) $request->guest_email));
+
+        if ($from === '' || $expected === '' || $from !== $expected) {
+            $this->logger->warning('thread resolver: sender mismatch, falling back to new reservation', [
+                'reservation_id' => $request->id,
+                'message_id' => (string) $message->getMessageId(),
+            ]);
+
+            return null;
+        }
+
+        return $request;
+    }
+}

--- a/tests/Unit/Services/Email/ThreadResolverTest.php
+++ b/tests/Unit/Services/Email/ThreadResolverTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Email;
+
+use App\Models\ReservationRequest;
+use App\Services\Email\ThreadResolver;
+use Mockery;
+use Mockery\MockInterface;
+use Psr\Log\LoggerInterface;
+use Tests\TestCase;
+use Webklex\PHPIMAP\Address;
+use Webklex\PHPIMAP\Message;
+
+class ThreadResolverTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_it_returns_null_when_no_strategy_matches(): void
+    {
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('warning');
+
+        $resolver = new ThreadResolver($logger);
+
+        $this->assertNull($resolver->resolveForIncoming($this->makeMessage('attacker@example.com'), 1));
+    }
+
+    public function test_it_rejects_spoofed_sender_even_when_a_strategy_matches(): void
+    {
+        $request = new ReservationRequest;
+        $request->id = 42;
+        $request->guest_email = 'guest@example.com';
+
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('warning')->once();
+
+        $resolver = $this->makeResolverWithStrategyHit($logger, $request);
+
+        $this->assertNull(
+            $resolver->resolveForIncoming($this->makeMessage('attacker@example.com', '<spoof@x>'), 1),
+            'Spoofed sender must not yield a thread match.',
+        );
+    }
+
+    public function test_it_does_not_log_guest_email_or_sender_address_on_mismatch(): void
+    {
+        $request = new ReservationRequest;
+        $request->id = 7;
+        $request->guest_email = 'guest@example.com';
+
+        $captured = [];
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('warning')
+            ->once()
+            ->andReturnUsing(function (string $message, array $context) use (&$captured): void {
+                $captured = ['message' => $message, 'context' => $context];
+            });
+
+        $resolver = $this->makeResolverWithStrategyHit($logger, $request);
+
+        $resolver->resolveForIncoming($this->makeMessage('attacker@example.com', '<m@x>'), 1);
+
+        $serialized = $captured['message'].json_encode($captured['context']);
+
+        $this->assertStringNotContainsString('guest@example.com', $serialized);
+        $this->assertStringNotContainsString('attacker@example.com', $serialized);
+    }
+
+    public function test_it_returns_the_request_when_sender_matches(): void
+    {
+        $request = new ReservationRequest;
+        $request->id = 1;
+        $request->guest_email = 'Guest@Example.com';
+
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('warning');
+
+        $resolver = $this->makeResolverWithStrategyHit($logger, $request);
+
+        $resolved = $resolver->resolveForIncoming($this->makeMessage(' guest@example.com '), 1);
+
+        $this->assertSame($request, $resolved);
+    }
+
+    private function makeResolverWithStrategyHit(LoggerInterface $logger, ReservationRequest $hit): ThreadResolver
+    {
+        return new class($logger, $hit) extends ThreadResolver
+        {
+            public function __construct(LoggerInterface $logger, private readonly ReservationRequest $hit)
+            {
+                parent::__construct($logger);
+            }
+
+            protected function byInReplyTo(Message $message, int $restaurantId): ?ReservationRequest
+            {
+                return $this->hit;
+            }
+        };
+    }
+
+    /**
+     * Builds a Mockery double of Webklex Message with a single From address
+     * and a Message-ID. The Address class has a public `mail` property, so
+     * a stdClass-equivalent stub via Mockery is enough — the resolver only
+     * reads `getFrom()[0]->mail` and `getMessageId()`.
+     */
+    private function makeMessage(string $fromMail, string $messageId = '<test@example.com>'): Message&MockInterface
+    {
+        $address = Mockery::mock(Address::class);
+        $address->mail = $fromMail;
+
+        $message = Mockery::mock(Message::class);
+        $message->shouldReceive('getFrom')->andReturn([$address]);
+        $message->shouldReceive('getMessageId')->andReturn($messageId);
+
+        return $message;
+    }
+}


### PR DESCRIPTION
## Summary

Cascade scaffold for PRD-006 mail threading.

- New `app/Services/Email/ThreadResolver.php` with constructor-injected `LoggerInterface`.
- Public `resolveForIncoming(Message, int $restaurantId): ?ReservationRequest` runs four strategy stubs (`byInReplyTo`, `byReferences`, `bySubjectMarker`, `byHeuristic`) and pipes every hit through `verifySender`.
- Strategy bodies are stubs returning `null`; implementations follow in #203 and #204.
- `verifySender` compares lowercased/trimmed From against `ReservationRequest.guest_email`, returns `null` on mismatch, and logs a warning with `reservation_id` + `message_id` only — never the addresses themselves.

## Why

Spoofing protection has to land **before** any strategy goes live. Once `byInReplyTo` actually queries `reservation_messages` (#203), an attacker forging an `In-Reply-To` could otherwise be silently routed into a foreign thread. Putting `verifySender` between every strategy and its return value closes that gap up front.

## Notable decisions

- **Class is not `final`.** Project default is `final` for services (CLAUDE.md), but the AC test "rejects spoofed sender even when a strategy matches" requires a test-only subclass that overrides one strategy stub. The minimal-deviation alternatives (strategy-pattern refactor with five new files, or reflection in tests) felt heavier than this single docblock-noted exception. The class docblock explicitly forbids production subclasses.
- **Strategy methods are `protected` (not `private`).** Same reason: subclassable in tests only. `verifySender` is also `protected` so the test subclass shares the contract.
- **Test path is `tests/Unit/Services/Email/`** instead of the issue's `tests/Unit/Email/`. Repo convention places service tests under `tests/Unit/Services/<Namespace>/` (see `EmailReservationParserTest`); deviating would have introduced a new pattern, which CLAUDE.md forbids.

## Test plan

- [x] `php artisan test --filter=ThreadResolverTest` — 4 cases, 5 assertions, green
- [x] `php artisan test` — 520 tests, 1650 assertions, all green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean

Test cases:
1. returns null when no strategy matches (no warning logged)
2. rejects spoofed sender even when a strategy matches (warning logged)
3. does not log guest email or sender address on mismatch (asserts the captured log payload)
4. returns the request when sender matches (case-insensitive + trimmed)

Closes #202