### PR TITLE
Implement byInReplyTo + byReferences strategies (#203)

### DIFF
--- a/app/Services/Email/ThreadResolver.php
+++ b/app/Services/Email/ThreadResolver.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\Email;
 
+use App\Enums\MessageDirection;
+use App\Models\ReservationMessage;
 use App\Models\ReservationRequest;
 use Psr\Log\LoggerInterface;
 use Webklex\PHPIMAP\Message;
@@ -13,7 +15,8 @@ use Webklex\PHPIMAP\Message;
  * four-strategy cascade. Every positive resolution is re-verified via
  * verifySender, so a spoofed In-Reply-To cannot hijack a foreign thread.
  *
- * Strategy bodies are introduced in dedicated issues (#203, #204).
+ * Strategy bodies arrive incrementally: byInReplyTo + byReferences (#203),
+ * bySubjectMarker + byHeuristic (#204).
  *
  * Not declared `final` (against the project default) so the cascade
  * contract can be exercised by a test-only subclass that swaps a single
@@ -54,12 +57,44 @@ class ThreadResolver
 
     protected function byInReplyTo(Message $message, int $restaurantId): ?ReservationRequest
     {
-        return null;
+        return $this->lookupOutboundMessage(trim((string) $message->getInReplyTo()), $restaurantId);
     }
 
     protected function byReferences(Message $message, int $restaurantId): ?ReservationRequest
     {
+        $references = trim((string) $message->getReferences());
+        if ($references === '') {
+            return null;
+        }
+
+        foreach (preg_split('/\s+/', $references) ?: [] as $candidate) {
+            $candidate = trim($candidate);
+            if ($candidate === '') {
+                continue;
+            }
+
+            if ($match = $this->lookupOutboundMessage($candidate, $restaurantId)) {
+                return $match;
+            }
+        }
+
         return null;
+    }
+
+    private function lookupOutboundMessage(string $messageId, int $restaurantId): ?ReservationRequest
+    {
+        if ($messageId === '') {
+            return null;
+        }
+
+        $hit = ReservationMessage::query()
+            ->where('direction', MessageDirection::Out)
+            ->where('message_id', $messageId)
+            ->whereHas('reservationRequest', fn ($query) => $query->where('restaurant_id', $restaurantId))
+            ->with('reservationRequest')
+            ->first();
+
+        return $hit?->reservationRequest;
     }
 
     protected function bySubjectMarker(Message $message, int $restaurantId): ?ReservationRequest

--- a/tests/Unit/Services/Email/ThreadResolverTest.php
+++ b/tests/Unit/Services/Email/ThreadResolverTest.php
@@ -4,17 +4,23 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\Email;
 
+use App\Models\ReservationMessage;
 use App\Models\ReservationRequest;
+use App\Models\Restaurant;
 use App\Services\Email\ThreadResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
 use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
 use Tests\TestCase;
 use Webklex\PHPIMAP\Address;
 use Webklex\PHPIMAP\Message;
 
 class ThreadResolverTest extends TestCase
 {
+    use RefreshDatabase;
+
     protected function tearDown(): void
     {
         Mockery::close();
@@ -104,20 +110,116 @@ class ThreadResolverTest extends TestCase
         };
     }
 
-    /**
-     * Builds a Mockery double of Webklex Message with a single From address
-     * and a Message-ID. The Address class has a public `mail` property, so
-     * a stdClass-equivalent stub via Mockery is enough — the resolver only
-     * reads `getFrom()[0]->mail` and `getMessageId()`.
-     */
-    private function makeMessage(string $fromMail, string $messageId = '<test@example.com>'): Message&MockInterface
+    public function test_it_resolves_by_in_reply_to_header(): void
     {
+        [$request, $outboundId] = $this->seedOutboundThread('guest@example.com');
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('guest@example.com', inReplyTo: $outboundId),
+            $request->restaurant_id,
+        );
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_it_resolves_by_references_chain_when_in_reply_to_is_unknown(): void
+    {
+        [$request, $outboundId] = $this->seedOutboundThread('guest@example.com');
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage(
+                'guest@example.com',
+                inReplyTo: '<unknown@x>',
+                references: '<root@x> '.$outboundId.' <other@x>',
+            ),
+            $request->restaurant_id,
+        );
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_it_does_not_match_across_restaurants(): void
+    {
+        [$request, $outboundId] = $this->seedOutboundThread('guest@example.com');
+
+        $otherRestaurant = Restaurant::factory()->create();
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('guest@example.com', inReplyTo: $outboundId),
+            $otherRestaurant->id,
+        );
+
+        $this->assertNull(
+            $resolved,
+            'An outbound message belonging to restaurant A must not resolve when the inbound mail targets restaurant B.',
+        );
+        $this->assertNotSame($request->restaurant_id, $otherRestaurant->id);
+    }
+
+    public function test_it_rejects_spoofed_in_reply_to_when_sender_does_not_match(): void
+    {
+        [$request, $outboundId] = $this->seedOutboundThread('guest@example.com');
+
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('warning')->once();
+
+        $resolver = new ThreadResolver($logger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('attacker@example.com', inReplyTo: $outboundId),
+            $request->restaurant_id,
+        );
+
+        $this->assertNull($resolved, 'A spoofed In-Reply-To must not yield a thread match when the sender differs.');
+    }
+
+    /**
+     * @return array{0: ReservationRequest, 1: string} the request and the outbound message-id
+     */
+    private function seedOutboundThread(string $guestEmail): array
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => $guestEmail,
+        ]);
+
+        $outbound = ReservationMessage::factory()
+            ->outbound()
+            ->forReservationRequest($request)
+            ->create();
+
+        return [$request, $outbound->message_id];
+    }
+
+    /**
+     * Builds a Mockery double of Webklex Message with a single From address,
+     * Message-ID, In-Reply-To and References headers. Defaults keep the older
+     * tests stable: when In-Reply-To/References are empty strings the new
+     * strategies short-circuit just like before.
+     */
+    private function makeMessage(
+        string $fromMail,
+        string $messageId = '<test@example.com>',
+        string $inReplyTo = '',
+        string $references = '',
+    ): Message&MockInterface {
         $address = Mockery::mock(Address::class);
         $address->mail = $fromMail;
 
         $message = Mockery::mock(Message::class);
         $message->shouldReceive('getFrom')->andReturn([$address]);
         $message->shouldReceive('getMessageId')->andReturn($messageId);
+        $message->shouldReceive('getInReplyTo')->andReturn($inReplyTo);
+        $message->shouldReceive('getReferences')->andReturn($references);
 
         return $message;
     }


### PR DESCRIPTION
## Summary

Implements the two header-based strategies in `ThreadResolver` (PRD-006).

- `byInReplyTo` — looks up `reservation_messages` where `direction = out` and `message_id` equals the inbound `In-Reply-To`, scoped via `whereHas('reservationRequest', restaurant_id = ?)`.
- `byReferences` — splits the `References` header on whitespace, returns the first restaurant-scoped hit.
- Both still flow through `verifySender`, so a forged `In-Reply-To` from the wrong sender still falls back to a new reservation.
- Shared private helper `lookupOutboundMessage()` short-circuits on empty input.

## Why

These two strategies are the most reliable threading signals (RFC-5322 thread headers) and run before the subject-marker / heuristic fallbacks (#204). Putting them behind the `verifySender` gate from #202 closes the spoofing path before the weaker strategies arrive.

## Test plan

- [x] `php artisan test --filter=ThreadResolverTest` — 8 cases / 12 assertions, green
- [x] `php artisan test` — 524 tests / 1657 assertions, green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean

New test cases (DB-backed via `RefreshDatabase`):
- `it_resolves_by_in_reply_to_header`
- `it_resolves_by_references_chain_when_in_reply_to_is_unknown`
- `it_does_not_match_across_restaurants` — outbound message belongs to restaurant A, inbound targets B → null
- `it_rejects_spoofed_in_reply_to_when_sender_does_not_match` — real DB row, attacker From, spoofed In-Reply-To → null + warning

Closes #203