### PR TITLE
Implement bySubjectMarker + byHeuristic strategies (#204)

### DIFF
--- a/app/Services/Email/ThreadResolver.php
+++ b/app/Services/Email/ThreadResolver.php
@@ -15,8 +15,10 @@ use Webklex\PHPIMAP\Message;
  * four-strategy cascade. Every positive resolution is re-verified via
  * verifySender, so a spoofed In-Reply-To cannot hijack a foreign thread.
  *
- * Strategy bodies arrive incrementally: byInReplyTo + byReferences (#203),
- * bySubjectMarker + byHeuristic (#204).
+ * Strategies, in cascade order: header-based (byInReplyTo, byReferences),
+ * then subject-based fallbacks (bySubjectMarker, byHeuristic). The
+ * heuristic is the weakest signal, so it runs last and additionally
+ * filters by sender + 30-day window before verifySender.
  *
  * Not declared `final` (against the project default) so the cascade
  * contract can be exercised by a test-only subclass that swaps a single
@@ -99,12 +101,52 @@ class ThreadResolver
 
     protected function bySubjectMarker(Message $message, int $restaurantId): ?ReservationRequest
     {
-        return null;
+        $subject = (string) $message->getSubject();
+
+        if (! preg_match('/\[Res #(\d+)\]/', $subject, $matches)) {
+            return null;
+        }
+
+        return ReservationRequest::query()
+            ->whereKey((int) $matches[1])
+            ->where('restaurant_id', $restaurantId)
+            ->first();
     }
+
+    private const REPLY_PREFIX_PATTERN = '/^(?:re|aw|antw)(?:\[\d+\])?:\s*/i';
 
     protected function byHeuristic(Message $message, int $restaurantId): ?ReservationRequest
     {
-        return null;
+        $subject = (string) $message->getSubject();
+
+        if (! preg_match(self::REPLY_PREFIX_PATTERN, $subject)) {
+            return null;
+        }
+
+        $stripped = trim((string) preg_replace(self::REPLY_PREFIX_PATTERN, '', $subject));
+        if ($stripped === '') {
+            return null;
+        }
+
+        $from = strtolower(trim((string) ($message->getFrom()[0]->mail ?? '')));
+        if ($from === '') {
+            return null;
+        }
+
+        $candidates = ReservationMessage::query()
+            ->where('direction', MessageDirection::Out)
+            ->where('subject', $stripped)
+            ->where('sent_at', '>=', now()->subDays(30))
+            ->whereHas('reservationRequest', fn ($query) => $query->where('restaurant_id', $restaurantId))
+            ->with('reservationRequest')
+            ->latest('sent_at')
+            ->get();
+
+        $match = $candidates->first(
+            fn (ReservationMessage $candidate) => strtolower(trim((string) $candidate->reservationRequest?->guest_email)) === $from,
+        );
+
+        return $match?->reservationRequest;
     }
 
     protected function verifySender(ReservationRequest $request, Message $message): ?ReservationRequest

--- a/tests/Unit/Services/Email/ThreadResolverTest.php
+++ b/tests/Unit/Services/Email/ThreadResolverTest.php
@@ -200,17 +200,150 @@ class ThreadResolverTest extends TestCase
         return [$request, $outbound->message_id];
     }
 
+    public function test_it_resolves_by_subject_marker(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'guest@example.com',
+        ]);
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('guest@example.com', subject: 'Re: [Res #'.$request->id.'] Reservierung'),
+            $restaurant->id,
+        );
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_subject_marker_is_scoped_to_restaurant(): void
+    {
+        $request = ReservationRequest::factory()->create(['guest_email' => 'guest@example.com']);
+        $otherRestaurant = Restaurant::factory()->create();
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('guest@example.com', subject: '[Res #'.$request->id.']'),
+            $otherRestaurant->id,
+        );
+
+        $this->assertNull($resolved, 'A subject marker pointing at restaurant A must not resolve when targeting B.');
+    }
+
+    public function test_it_resolves_by_heuristic_when_within_30_days(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'guest@example.com',
+        ]);
+        ReservationMessage::factory()->outbound()->forReservationRequest($request)->create([
+            'subject' => 'Reservierung am 12.05.',
+            'sent_at' => now()->subDays(5),
+        ]);
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('guest@example.com', subject: 'Re: Reservierung am 12.05.'),
+            $restaurant->id,
+        );
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_it_does_not_resolve_by_heuristic_when_older_than_30_days(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'guest@example.com',
+        ]);
+        ReservationMessage::factory()->outbound()->forReservationRequest($request)->create([
+            'subject' => 'Reservierung am 01.01.',
+            'sent_at' => now()->subDays(40),
+        ]);
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('guest@example.com', subject: 'Re: Reservierung am 01.01.'),
+            $restaurant->id,
+        );
+
+        $this->assertNull($resolved, 'Heuristic must not match outbound messages older than the 30-day window.');
+    }
+
+    public function test_heuristic_normalizes_various_reply_prefixes(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'guest@example.com',
+        ]);
+        ReservationMessage::factory()->outbound()->forReservationRequest($request)->create([
+            'subject' => 'Tisch fuer 4 Personen',
+            'sent_at' => now()->subDays(2),
+        ]);
+
+        $resolver = new ThreadResolver(new NullLogger);
+
+        foreach (['Re:', 'RE:', 'AW:', 'Antw:', 'Re[2]:'] as $prefix) {
+            $resolved = $resolver->resolveForIncoming(
+                $this->makeMessage('guest@example.com', subject: $prefix.' Tisch fuer 4 Personen'),
+                $restaurant->id,
+            );
+
+            $this->assertNotNull($resolved, "Prefix '{$prefix}' should normalize for the heuristic.");
+            $this->assertSame($request->id, $resolved->id);
+        }
+    }
+
+    public function test_heuristic_requires_sender_to_match_guest_email(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'guest@example.com',
+        ]);
+        ReservationMessage::factory()->outbound()->forReservationRequest($request)->create([
+            'subject' => 'Reservierung Mai',
+            'sent_at' => now()->subDays(3),
+        ]);
+
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldNotReceive('warning');
+
+        $resolver = new ThreadResolver($logger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->makeMessage('attacker@example.com', subject: 'Re: Reservierung Mai'),
+            $restaurant->id,
+        );
+
+        $this->assertNull(
+            $resolved,
+            'Heuristic must filter by sender BEFORE verifySender — no warning should be logged.',
+        );
+    }
+
     /**
      * Builds a Mockery double of Webklex Message with a single From address,
-     * Message-ID, In-Reply-To and References headers. Defaults keep the older
-     * tests stable: when In-Reply-To/References are empty strings the new
-     * strategies short-circuit just like before.
+     * Message-ID, In-Reply-To, References, and Subject. Defaults keep the
+     * older tests stable: when In-Reply-To/References/Subject are empty
+     * strings the strategies short-circuit just like before.
      */
     private function makeMessage(
         string $fromMail,
         string $messageId = '<test@example.com>',
         string $inReplyTo = '',
         string $references = '',
+        string $subject = '',
     ): Message&MockInterface {
         $address = Mockery::mock(Address::class);
         $address->mail = $fromMail;
@@ -220,6 +353,7 @@ class ThreadResolverTest extends TestCase
         $message->shouldReceive('getMessageId')->andReturn($messageId);
         $message->shouldReceive('getInReplyTo')->andReturn($inReplyTo);
         $message->shouldReceive('getReferences')->andReturn($references);
+        $message->shouldReceive('getSubject')->andReturn($subject);
 
         return $message;
     }


### PR DESCRIPTION
## Summary

Closes the four-strategy ThreadResolver cascade with the two subject-based fallbacks for PRD-006.

- `bySubjectMarker` matches `/\[Res #(\d+)\]/` and loads the reservation by primary key, scoped to the passed restaurant.
- `byHeuristic` accepts subjects with a reply prefix matching `/^(re|aw|antw)(\[\d+\])?:\s*/i` (covers `Re:`, `RE:`, `AW:`, `Antw:`, `Re[2]:`), then looks for an outbound `ReservationMessage` from the same restaurant within the **last 30 days** whose stripped subject matches. Candidates are filtered in PHP by case-insensitive `guest_email == sender` to satisfy the AC's belt-and-braces sender check, before the cascade's later `verifySender` pass.

## Why

These are the weakest signals — they run after the header-based strategies (#203) and only when the inbound mail genuinely looks like a reply (`Re:`-class prefix). The 30-day window bounds the heuristic to recent threads so it cannot accidentally hijack an old reservation, and the in-PHP sender filter means a heuristic mismatch returns null silently — no `verifySender` warning, no log noise.

## Notable decisions

- **Sender filter in PHP, not SQL.** A `LOWER(guest_email) = ?` would be a `whereRaw`, which the project rule "kein direktes SQL statt Eloquent/Query Builder" pushes back on. The candidate set is bounded by "outbound mails for this restaurant, exact subject, last 30 days" — small in practice — so loading and filtering in PHP is acceptable and avoids the raw fragment.
- **`whereKey` for the marker lookup** keeps the query Eloquent-idiomatic.
- **`latest('sent_at')` on heuristic** picks the most recent outbound mail when a restaurant has sent the same subject to multiple guests, which only matters before the `guest_email` filter narrows it down.

## Test plan

- [x] `php artisan test --filter=ThreadResolverTest` — 14 cases / 29 assertions, green
- [x] `php artisan test` — 530 tests / 1674 assertions, green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean

New cases:
- `it_resolves_by_subject_marker`
- `subject_marker_is_scoped_to_restaurant`
- `it_resolves_by_heuristic_when_within_30_days`
- `it_does_not_resolve_by_heuristic_when_older_than_30_days`
- `heuristic_normalizes_various_reply_prefixes` (loops Re:, RE:, AW:, Antw:, Re[2]:)
- `heuristic_requires_sender_to_match_guest_email` — asserts heuristic returns null AND no warning is logged when sender differs

Closes #204