### PR TITLE
Integrate ThreadResolver into FetchReservationEmailsJob (#205)

### DIFF
--- a/app/Jobs/FetchReservationEmailsJob.php
+++ b/app/Jobs/FetchReservationEmailsJob.php
@@ -4,14 +4,17 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Enums\MessageDirection;
 use App\Events\ReservationRequestReceived;
 use App\Models\FailedEmailImport;
+use App\Models\ReservationMessage;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Services\Email\Contracts\ImapMailbox;
 use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\DTO\FetchedEmail;
 use App\Services\Email\EmailReservationParser;
+use App\Services\Email\ThreadResolver;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Queue\Queueable;
@@ -49,8 +52,11 @@ final class FetchReservationEmailsJob implements ShouldQueue
         ]);
     }
 
-    public function handle(ImapMailboxFactory $factory, EmailReservationParser $parser): void
-    {
+    public function handle(
+        ImapMailboxFactory $factory,
+        EmailReservationParser $parser,
+        ThreadResolver $threadResolver,
+    ): void {
         $restaurant = Restaurant::find($this->restaurantId);
 
         if ($restaurant === null || $restaurant->imap_host === null || $restaurant->imap_host === '') {
@@ -61,7 +67,7 @@ final class FetchReservationEmailsJob implements ShouldQueue
 
         foreach ($mailbox->fetchUnseen() as $email) {
             try {
-                $this->processEmail($email, $mailbox, $parser, $restaurant);
+                $this->processEmail($email, $mailbox, $parser, $threadResolver, $restaurant);
             } catch (Throwable $e) {
                 $this->recordFailure($restaurant, $email, $e);
             }
@@ -72,9 +78,17 @@ final class FetchReservationEmailsJob implements ShouldQueue
         FetchedEmail $email,
         ImapMailbox $mailbox,
         EmailReservationParser $parser,
+        ThreadResolver $threadResolver,
         Restaurant $restaurant,
     ): void {
         if ($email->messageId !== '' && $this->alreadyImported($email->messageId)) {
+            $mailbox->markSeen($email);
+
+            return;
+        }
+
+        if ($threadParent = $threadResolver->resolveForIncoming($email, $restaurant->id)) {
+            $this->appendAsThreadMessage($threadParent, $email);
             $mailbox->markSeen($email);
 
             return;
@@ -114,7 +128,33 @@ final class FetchReservationEmailsJob implements ShouldQueue
 
     private function alreadyImported(string $messageId): bool
     {
-        return ReservationRequest::where('email_message_id', $messageId)->exists();
+        return ReservationRequest::where('email_message_id', $messageId)->exists()
+            || ReservationMessage::where('message_id', $messageId)->exists();
+    }
+
+    private function appendAsThreadMessage(ReservationRequest $parent, FetchedEmail $email): void
+    {
+        try {
+            ReservationMessage::create([
+                'reservation_request_id' => $parent->id,
+                'direction' => MessageDirection::In,
+                'message_id' => $email->messageId,
+                'in_reply_to' => $email->inReplyTo !== '' ? $email->inReplyTo : null,
+                'references' => $email->references !== '' ? $email->references : null,
+                'subject' => $email->subject,
+                'from_address' => $email->senderEmail,
+                'to_address' => $email->toAddress,
+                'body_plain' => $email->body,
+                'raw_headers' => $email->rawHeaders,
+                'received_at' => now(),
+            ]);
+        } catch (QueryException $e) {
+            // The unique constraint on message_id makes thread-message inserts
+            // idempotent — a duplicate fetch is a no-op, not an error path.
+            if (! $this->isUniqueViolation($e)) {
+                throw $e;
+            }
+        }
     }
 
     private function isUniqueViolation(QueryException $e): bool

--- a/app/Services/Email/DTO/FetchedEmail.php
+++ b/app/Services/Email/DTO/FetchedEmail.php
@@ -13,5 +13,9 @@ final readonly class FetchedEmail
         public ?string $senderName,
         public string $rawHeaders,
         public string $rawBody,
+        public string $inReplyTo = '',
+        public string $references = '',
+        public string $subject = '',
+        public string $toAddress = '',
     ) {}
 }

--- a/app/Services/Email/ThreadResolver.php
+++ b/app/Services/Email/ThreadResolver.php
@@ -7,8 +7,8 @@ namespace App\Services\Email;
 use App\Enums\MessageDirection;
 use App\Models\ReservationMessage;
 use App\Models\ReservationRequest;
+use App\Services\Email\DTO\FetchedEmail;
 use Psr\Log\LoggerInterface;
-use Webklex\PHPIMAP\Message;
 
 /**
  * Resolves an incoming mail to an existing ReservationRequest using a
@@ -27,6 +27,8 @@ use Webklex\PHPIMAP\Message;
  */
 class ThreadResolver
 {
+    private const REPLY_PREFIX_PATTERN = '/^(?:re|aw|antw)(?:\[\d+\])?:\s*/i';
+
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {}
@@ -36,35 +38,35 @@ class ThreadResolver
      * null when no strategy matches or when the verified sender does not
      * match the reservation's stored guest email.
      */
-    public function resolveForIncoming(Message $message, int $restaurantId): ?ReservationRequest
+    public function resolveForIncoming(FetchedEmail $email, int $restaurantId): ?ReservationRequest
     {
-        if ($candidate = $this->byInReplyTo($message, $restaurantId)) {
-            return $this->verifySender($candidate, $message);
+        if ($candidate = $this->byInReplyTo($email, $restaurantId)) {
+            return $this->verifySender($candidate, $email);
         }
 
-        if ($candidate = $this->byReferences($message, $restaurantId)) {
-            return $this->verifySender($candidate, $message);
+        if ($candidate = $this->byReferences($email, $restaurantId)) {
+            return $this->verifySender($candidate, $email);
         }
 
-        if ($candidate = $this->bySubjectMarker($message, $restaurantId)) {
-            return $this->verifySender($candidate, $message);
+        if ($candidate = $this->bySubjectMarker($email, $restaurantId)) {
+            return $this->verifySender($candidate, $email);
         }
 
-        if ($candidate = $this->byHeuristic($message, $restaurantId)) {
-            return $this->verifySender($candidate, $message);
+        if ($candidate = $this->byHeuristic($email, $restaurantId)) {
+            return $this->verifySender($candidate, $email);
         }
 
         return null;
     }
 
-    protected function byInReplyTo(Message $message, int $restaurantId): ?ReservationRequest
+    protected function byInReplyTo(FetchedEmail $email, int $restaurantId): ?ReservationRequest
     {
-        return $this->lookupOutboundMessage(trim((string) $message->getInReplyTo()), $restaurantId);
+        return $this->lookupOutboundMessage(trim($email->inReplyTo), $restaurantId);
     }
 
-    protected function byReferences(Message $message, int $restaurantId): ?ReservationRequest
+    protected function byReferences(FetchedEmail $email, int $restaurantId): ?ReservationRequest
     {
-        $references = trim((string) $message->getReferences());
+        $references = trim($email->references);
         if ($references === '') {
             return null;
         }
@@ -83,27 +85,9 @@ class ThreadResolver
         return null;
     }
 
-    private function lookupOutboundMessage(string $messageId, int $restaurantId): ?ReservationRequest
+    protected function bySubjectMarker(FetchedEmail $email, int $restaurantId): ?ReservationRequest
     {
-        if ($messageId === '') {
-            return null;
-        }
-
-        $hit = ReservationMessage::query()
-            ->where('direction', MessageDirection::Out)
-            ->where('message_id', $messageId)
-            ->whereHas('reservationRequest', fn ($query) => $query->where('restaurant_id', $restaurantId))
-            ->with('reservationRequest')
-            ->first();
-
-        return $hit?->reservationRequest;
-    }
-
-    protected function bySubjectMarker(Message $message, int $restaurantId): ?ReservationRequest
-    {
-        $subject = (string) $message->getSubject();
-
-        if (! preg_match('/\[Res #(\d+)\]/', $subject, $matches)) {
+        if (! preg_match('/\[Res #(\d+)\]/', $email->subject, $matches)) {
             return null;
         }
 
@@ -113,11 +97,9 @@ class ThreadResolver
             ->first();
     }
 
-    private const REPLY_PREFIX_PATTERN = '/^(?:re|aw|antw)(?:\[\d+\])?:\s*/i';
-
-    protected function byHeuristic(Message $message, int $restaurantId): ?ReservationRequest
+    protected function byHeuristic(FetchedEmail $email, int $restaurantId): ?ReservationRequest
     {
-        $subject = (string) $message->getSubject();
+        $subject = $email->subject;
 
         if (! preg_match(self::REPLY_PREFIX_PATTERN, $subject)) {
             return null;
@@ -128,7 +110,7 @@ class ThreadResolver
             return null;
         }
 
-        $from = strtolower(trim((string) ($message->getFrom()[0]->mail ?? '')));
+        $from = strtolower(trim($email->senderEmail));
         if ($from === '') {
             return null;
         }
@@ -149,15 +131,31 @@ class ThreadResolver
         return $match?->reservationRequest;
     }
 
-    protected function verifySender(ReservationRequest $request, Message $message): ?ReservationRequest
+    private function lookupOutboundMessage(string $messageId, int $restaurantId): ?ReservationRequest
     {
-        $from = strtolower(trim((string) ($message->getFrom()[0]->mail ?? '')));
+        if ($messageId === '') {
+            return null;
+        }
+
+        $hit = ReservationMessage::query()
+            ->where('direction', MessageDirection::Out)
+            ->where('message_id', $messageId)
+            ->whereHas('reservationRequest', fn ($query) => $query->where('restaurant_id', $restaurantId))
+            ->with('reservationRequest')
+            ->first();
+
+        return $hit?->reservationRequest;
+    }
+
+    protected function verifySender(ReservationRequest $request, FetchedEmail $email): ?ReservationRequest
+    {
+        $from = strtolower(trim($email->senderEmail));
         $expected = strtolower(trim((string) $request->guest_email));
 
         if ($from === '' || $expected === '' || $from !== $expected) {
             $this->logger->warning('thread resolver: sender mismatch, falling back to new reservation', [
                 'reservation_id' => $request->id,
-                'message_id' => (string) $message->getMessageId(),
+                'message_id' => $email->messageId,
             ]);
 
             return null;

--- a/app/Services/Email/WebklexImapMailbox.php
+++ b/app/Services/Email/WebklexImapMailbox.php
@@ -43,6 +43,10 @@ final class WebklexImapMailbox implements ImapMailbox
                 senderName: $senderName,
                 rawHeaders: (string) $message->getHeader()->raw,
                 rawBody: $body,
+                inReplyTo: trim((string) $message->getInReplyTo()),
+                references: trim((string) $message->getReferences()),
+                subject: trim((string) $message->getSubject()),
+                toAddress: $this->extractFirstRecipient($message),
             );
 
             $this->seenCache[$messageId] = $message;
@@ -100,6 +104,23 @@ final class WebklexImapMailbox implements ImapMailbox
         );
 
         return $result ?? $value;
+    }
+
+    private function extractFirstRecipient(Message $message): string
+    {
+        try {
+            $to = $message->getTo();
+        } catch (Throwable) {
+            return '';
+        }
+
+        if ($to === null) {
+            return '';
+        }
+
+        $first = is_array($to) ? ($to[0] ?? null) : (method_exists($to, 'first') ? $to->first() : null);
+
+        return $first instanceof Address ? (string) $first->mail : '';
     }
 
     private function extractSender(Message $message): ?Address

--- a/tests/Feature/Email/ThreadingFlowTest.php
+++ b/tests/Feature/Email/ThreadingFlowTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Enums\MessageDirection;
+use App\Jobs\FetchReservationEmailsJob;
+use App\Models\ReservationMessage;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Email\Contracts\ImapMailboxFactory;
+use App\Services\Email\DTO\FetchedEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Tests\Support\Email\FakeImapMailboxFactory;
+use Tests\TestCase;
+
+class ThreadingFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_appends_reply_as_thread_message_instead_of_creating_new_reservation(): void
+    {
+        [$restaurant, $request, $outboundMessageId] = $this->seedRestaurantWithOutboundMessage();
+
+        $reply = $this->makeReply(
+            messageId: '<inbound-reply-1@example.com>',
+            from: 'guest@example.com',
+            inReplyTo: $outboundMessageId,
+            subject: 'Re: Reservierung',
+        );
+
+        $this->runJobWith($restaurant->id, [$reply]);
+
+        $this->assertSame(
+            1,
+            ReservationRequest::query()->where('restaurant_id', $restaurant->id)->count(),
+            'Threaded reply must NOT create a new reservation.',
+        );
+        $this->assertSame(
+            1,
+            ReservationMessage::query()
+                ->where('reservation_request_id', $request->id)
+                ->where('direction', MessageDirection::In)
+                ->count(),
+            'Threaded reply must be appended as an inbound ReservationMessage.',
+        );
+    }
+
+    public function test_it_falls_back_to_new_reservation_when_sender_does_not_match(): void
+    {
+        [$restaurant, , $outboundMessageId] = $this->seedRestaurantWithOutboundMessage();
+
+        $spoofed = $this->makeReply(
+            messageId: '<inbound-spoof-1@example.com>',
+            from: 'attacker@example.com',
+            inReplyTo: $outboundMessageId,
+            subject: 'Re: Tisch fuer 4 Personen am 12.05.2026 um 19:30',
+            body: 'Tisch für 4 Personen am 12.05.2026 um 19:30',
+        );
+
+        $this->runJobWith($restaurant->id, [$spoofed]);
+
+        $this->assertSame(
+            2,
+            ReservationRequest::query()->where('restaurant_id', $restaurant->id)->count(),
+            'Spoofed reply must fall back to creating a new reservation, not be silently dropped.',
+        );
+        $this->assertSame(
+            0,
+            ReservationMessage::query()
+                ->where('direction', MessageDirection::In)
+                ->count(),
+            'Spoofed reply must NOT be appended as a thread message on the original reservation.',
+        );
+    }
+
+    public function test_it_dedupes_by_message_id_even_with_thread_fallback(): void
+    {
+        [$restaurant, $request, $outboundMessageId] = $this->seedRestaurantWithOutboundMessage();
+
+        $reply = $this->makeReply(
+            messageId: '<inbound-dup-1@example.com>',
+            from: 'guest@example.com',
+            inReplyTo: $outboundMessageId,
+            subject: 'Re: Reservierung',
+        );
+
+        $this->runJobWith($restaurant->id, [$reply]);
+        $this->runJobWith($restaurant->id, [$reply]);
+
+        $this->assertSame(
+            1,
+            ReservationMessage::query()
+                ->where('reservation_request_id', $request->id)
+                ->where('direction', MessageDirection::In)
+                ->count(),
+            'Same Message-ID must not be ingested twice as a thread message.',
+        );
+        $this->assertSame(
+            1,
+            ReservationRequest::query()->where('restaurant_id', $restaurant->id)->count(),
+            'Same Message-ID must not flip into a new reservation on a re-fetch.',
+        );
+    }
+
+    /**
+     * @return array{0: Restaurant, 1: ReservationRequest, 2: string}
+     */
+    private function seedRestaurantWithOutboundMessage(): array
+    {
+        $restaurant = Restaurant::factory()->create([
+            'imap_host' => 'mail.example.com',
+            'imap_username' => 'mailbox@example.com',
+            'imap_password' => 'secret',
+        ]);
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'guest@example.com',
+        ]);
+        $outbound = ReservationMessage::factory()
+            ->outbound()
+            ->forReservationRequest($request)
+            ->create();
+
+        return [$restaurant, $request, $outbound->message_id];
+    }
+
+    private function makeReply(
+        string $messageId,
+        string $from,
+        string $inReplyTo,
+        string $subject = '',
+        string $body = '',
+    ): FetchedEmail {
+        return new FetchedEmail(
+            messageId: $messageId,
+            body: $body,
+            senderEmail: $from,
+            senderName: null,
+            rawHeaders: 'From: '.$from,
+            rawBody: $body,
+            inReplyTo: $inReplyTo,
+            references: $inReplyTo,
+            subject: $subject,
+            toAddress: 'mailbox@example.com',
+        );
+    }
+
+    /**
+     * @param  list<FetchedEmail>  $emails
+     */
+    private function runJobWith(int $restaurantId, array $emails): void
+    {
+        $factory = new FakeImapMailboxFactory($emails);
+
+        $this->app->instance(ImapMailboxFactory::class, $factory);
+
+        Bus::dispatchSync(new FetchReservationEmailsJob($restaurantId));
+    }
+}

--- a/tests/Unit/Jobs/FetchReservationEmailsJobTest.php
+++ b/tests/Unit/Jobs/FetchReservationEmailsJobTest.php
@@ -10,9 +10,11 @@ use App\Models\Restaurant;
 use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\DTO\FetchedEmail;
 use App\Services\Email\EmailReservationParser;
+use App\Services\Email\ThreadResolver;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Log;
+use Psr\Log\NullLogger;
 use RuntimeException;
 use Tests\Support\Email\FakeImapMailboxFactory;
 use Tests\Support\Email\ThrowingImapMailboxFactory;
@@ -175,7 +177,7 @@ class FetchReservationEmailsJobTest extends TestCase
     private function runJob(int $restaurantId, ImapMailboxFactory $factory): void
     {
         $job = new FetchReservationEmailsJob($restaurantId);
-        $job->handle($factory, new EmailReservationParser);
+        $job->handle($factory, new EmailReservationParser, new ThreadResolver(new NullLogger));
     }
 
     private function makeEmail(

--- a/tests/Unit/Services/Email/ThreadResolverTest.php
+++ b/tests/Unit/Services/Email/ThreadResolverTest.php
@@ -7,15 +7,13 @@ namespace Tests\Unit\Services\Email;
 use App\Models\ReservationMessage;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
+use App\Services\Email\DTO\FetchedEmail;
 use App\Services\Email\ThreadResolver;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
-use Mockery\MockInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Tests\TestCase;
-use Webklex\PHPIMAP\Address;
-use Webklex\PHPIMAP\Message;
 
 class ThreadResolverTest extends TestCase
 {
@@ -34,7 +32,7 @@ class ThreadResolverTest extends TestCase
 
         $resolver = new ThreadResolver($logger);
 
-        $this->assertNull($resolver->resolveForIncoming($this->makeMessage('attacker@example.com'), 1));
+        $this->assertNull($resolver->resolveForIncoming($this->makeEmail('attacker@example.com'), 1));
     }
 
     public function test_it_rejects_spoofed_sender_even_when_a_strategy_matches(): void
@@ -49,7 +47,7 @@ class ThreadResolverTest extends TestCase
         $resolver = $this->makeResolverWithStrategyHit($logger, $request);
 
         $this->assertNull(
-            $resolver->resolveForIncoming($this->makeMessage('attacker@example.com', '<spoof@x>'), 1),
+            $resolver->resolveForIncoming($this->makeEmail('attacker@example.com', '<spoof@x>'), 1),
             'Spoofed sender must not yield a thread match.',
         );
     }
@@ -70,7 +68,7 @@ class ThreadResolverTest extends TestCase
 
         $resolver = $this->makeResolverWithStrategyHit($logger, $request);
 
-        $resolver->resolveForIncoming($this->makeMessage('attacker@example.com', '<m@x>'), 1);
+        $resolver->resolveForIncoming($this->makeEmail('attacker@example.com', '<m@x>'), 1);
 
         $serialized = $captured['message'].json_encode($captured['context']);
 
@@ -89,25 +87,9 @@ class ThreadResolverTest extends TestCase
 
         $resolver = $this->makeResolverWithStrategyHit($logger, $request);
 
-        $resolved = $resolver->resolveForIncoming($this->makeMessage(' guest@example.com '), 1);
+        $resolved = $resolver->resolveForIncoming($this->makeEmail(' guest@example.com '), 1);
 
         $this->assertSame($request, $resolved);
-    }
-
-    private function makeResolverWithStrategyHit(LoggerInterface $logger, ReservationRequest $hit): ThreadResolver
-    {
-        return new class($logger, $hit) extends ThreadResolver
-        {
-            public function __construct(LoggerInterface $logger, private readonly ReservationRequest $hit)
-            {
-                parent::__construct($logger);
-            }
-
-            protected function byInReplyTo(Message $message, int $restaurantId): ?ReservationRequest
-            {
-                return $this->hit;
-            }
-        };
     }
 
     public function test_it_resolves_by_in_reply_to_header(): void
@@ -117,7 +99,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver(new NullLogger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('guest@example.com', inReplyTo: $outboundId),
+            $this->makeEmail('guest@example.com', inReplyTo: $outboundId),
             $request->restaurant_id,
         );
 
@@ -132,7 +114,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver(new NullLogger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage(
+            $this->makeEmail(
                 'guest@example.com',
                 inReplyTo: '<unknown@x>',
                 references: '<root@x> '.$outboundId.' <other@x>',
@@ -153,7 +135,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver(new NullLogger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('guest@example.com', inReplyTo: $outboundId),
+            $this->makeEmail('guest@example.com', inReplyTo: $outboundId),
             $otherRestaurant->id,
         );
 
@@ -174,30 +156,11 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver($logger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('attacker@example.com', inReplyTo: $outboundId),
+            $this->makeEmail('attacker@example.com', inReplyTo: $outboundId),
             $request->restaurant_id,
         );
 
         $this->assertNull($resolved, 'A spoofed In-Reply-To must not yield a thread match when the sender differs.');
-    }
-
-    /**
-     * @return array{0: ReservationRequest, 1: string} the request and the outbound message-id
-     */
-    private function seedOutboundThread(string $guestEmail): array
-    {
-        $restaurant = Restaurant::factory()->create();
-        $request = ReservationRequest::factory()->create([
-            'restaurant_id' => $restaurant->id,
-            'guest_email' => $guestEmail,
-        ]);
-
-        $outbound = ReservationMessage::factory()
-            ->outbound()
-            ->forReservationRequest($request)
-            ->create();
-
-        return [$request, $outbound->message_id];
     }
 
     public function test_it_resolves_by_subject_marker(): void
@@ -211,7 +174,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver(new NullLogger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('guest@example.com', subject: 'Re: [Res #'.$request->id.'] Reservierung'),
+            $this->makeEmail('guest@example.com', subject: 'Re: [Res #'.$request->id.'] Reservierung'),
             $restaurant->id,
         );
 
@@ -227,7 +190,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver(new NullLogger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('guest@example.com', subject: '[Res #'.$request->id.']'),
+            $this->makeEmail('guest@example.com', subject: '[Res #'.$request->id.']'),
             $otherRestaurant->id,
         );
 
@@ -249,7 +212,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver(new NullLogger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('guest@example.com', subject: 'Re: Reservierung am 12.05.'),
+            $this->makeEmail('guest@example.com', subject: 'Re: Reservierung am 12.05.'),
             $restaurant->id,
         );
 
@@ -272,7 +235,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver(new NullLogger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('guest@example.com', subject: 'Re: Reservierung am 01.01.'),
+            $this->makeEmail('guest@example.com', subject: 'Re: Reservierung am 01.01.'),
             $restaurant->id,
         );
 
@@ -295,7 +258,7 @@ class ThreadResolverTest extends TestCase
 
         foreach (['Re:', 'RE:', 'AW:', 'Antw:', 'Re[2]:'] as $prefix) {
             $resolved = $resolver->resolveForIncoming(
-                $this->makeMessage('guest@example.com', subject: $prefix.' Tisch fuer 4 Personen'),
+                $this->makeEmail('guest@example.com', subject: $prefix.' Tisch fuer 4 Personen'),
                 $restaurant->id,
             );
 
@@ -322,7 +285,7 @@ class ThreadResolverTest extends TestCase
         $resolver = new ThreadResolver($logger);
 
         $resolved = $resolver->resolveForIncoming(
-            $this->makeMessage('attacker@example.com', subject: 'Re: Reservierung Mai'),
+            $this->makeEmail('attacker@example.com', subject: 'Re: Reservierung Mai'),
             $restaurant->id,
         );
 
@@ -332,29 +295,58 @@ class ThreadResolverTest extends TestCase
         );
     }
 
+    private function makeResolverWithStrategyHit(LoggerInterface $logger, ReservationRequest $hit): ThreadResolver
+    {
+        return new class($logger, $hit) extends ThreadResolver
+        {
+            public function __construct(LoggerInterface $logger, private readonly ReservationRequest $hit)
+            {
+                parent::__construct($logger);
+            }
+
+            protected function byInReplyTo(FetchedEmail $email, int $restaurantId): ?ReservationRequest
+            {
+                return $this->hit;
+            }
+        };
+    }
+
     /**
-     * Builds a Mockery double of Webklex Message with a single From address,
-     * Message-ID, In-Reply-To, References, and Subject. Defaults keep the
-     * older tests stable: when In-Reply-To/References/Subject are empty
-     * strings the strategies short-circuit just like before.
+     * @return array{0: ReservationRequest, 1: string} the request and the outbound message-id
      */
-    private function makeMessage(
+    private function seedOutboundThread(string $guestEmail): array
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => $guestEmail,
+        ]);
+
+        $outbound = ReservationMessage::factory()
+            ->outbound()
+            ->forReservationRequest($request)
+            ->create();
+
+        return [$request, $outbound->message_id];
+    }
+
+    private function makeEmail(
         string $fromMail,
         string $messageId = '<test@example.com>',
         string $inReplyTo = '',
         string $references = '',
         string $subject = '',
-    ): Message&MockInterface {
-        $address = Mockery::mock(Address::class);
-        $address->mail = $fromMail;
-
-        $message = Mockery::mock(Message::class);
-        $message->shouldReceive('getFrom')->andReturn([$address]);
-        $message->shouldReceive('getMessageId')->andReturn($messageId);
-        $message->shouldReceive('getInReplyTo')->andReturn($inReplyTo);
-        $message->shouldReceive('getReferences')->andReturn($references);
-        $message->shouldReceive('getSubject')->andReturn($subject);
-
-        return $message;
+    ): FetchedEmail {
+        return new FetchedEmail(
+            messageId: $messageId,
+            body: '',
+            senderEmail: $fromMail,
+            senderName: null,
+            rawHeaders: '',
+            rawBody: '',
+            inReplyTo: $inReplyTo,
+            references: $references,
+            subject: $subject,
+        );
     }
 }


### PR DESCRIPTION
## Summary

The fetch job now runs `ThreadResolver` between the dedup check and the parser path. A successful resolution appends an inbound `ReservationMessage`; misses fall back to the V1.0 parser path unchanged.

- `FetchedEmail` now carries `inReplyTo`, `references`, `subject`, `toAddress` (defaulting to empty strings — backward compatible with all existing constructions).
- `WebklexImapMailbox` populates the new fields from `getInReplyTo` / `getReferences` / `getSubject` / `getTo`.
- `ThreadResolver` API is now `resolveForIncoming(FetchedEmail, int)`. The resolver no longer depends on Webklex `Message`/`Address`, and the unit tests no longer need Mockery doubles for those types.
- `FetchReservationEmailsJob::handle` injects `ThreadResolver` as a third parameter (Laravel resolves it from the container). On hit it calls `appendAsThreadMessage(parent, email)` and marks seen; on miss the existing parser path runs.
- `alreadyImported` checks `reservation_messages.message_id` in addition to `reservation_requests.email_message_id`.
- `appendAsThreadMessage` absorbs unique-constraint violations on `message_id` so the same fetch twice is a no-op rather than an error.

## Why

Without integration, the resolver was dead code. The integration path additionally answers the dedup question PRD-006 calls out explicitly: same Message-ID must never be ingested twice, regardless of whether it would land as a thread message or as a new reservation. The dual `alreadyImported` check + the unique constraint guard in `appendAsThreadMessage` make this true even under race conditions where two workers pick up the same mail.

## Notable decisions

- **Refactored ThreadResolver to consume FetchedEmail** rather than Webklex `Message`. The IMAP boundary already produces `FetchedEmail`, so threading the Webklex type through the resolver was a leak. This drops the Mockery `Message`/`Address` indirection from the resolver test and lets the new feature test build replies as plain DTOs.
- **Backward-compat on FetchedEmail**: new fields are constructor-tail with defaults, so the existing test factories (`tests/Unit/Jobs/FetchReservationEmailsJobTest::makeEmail` and the Feature peer) continue to work without modification.

## Test plan

- [x] `php artisan test` — 533 tests / 1680 assertions, green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean

New feature suite (`tests/Feature/Email/ThreadingFlowTest`):
- `it_appends_reply_as_thread_message_instead_of_creating_new_reservation` — happy path, counts: 1 ReservationRequest, 1 inbound ReservationMessage
- `it_falls_back_to_new_reservation_when_sender_does_not_match` — spoofed `From` produces a new reservation, NOT a thread message on the original
- `it_dedupes_by_message_id_even_with_thread_fallback` — running the job twice with the same Message-ID writes one ReservationMessage and zero new ReservationRequests

ThreadResolver unit suite (14 cases) updated to use FetchedEmail; existing FetchReservationEmailsJob suites (15 cases) updated to pass the new `ThreadResolver` argument and continue to pass.

Closes #205