### PR TITLE
Outbound stable Message-ID + subject marker (#206)

### DIFF
--- a/app/Jobs/SendReservationReplyJob.php
+++ b/app/Jobs/SendReservationReplyJob.php
@@ -73,11 +73,14 @@ final class SendReservationReplyJob implements ShouldQueue
         }
 
         try {
-            Mail::to($email)->send(new ReservationReplyMail($reply));
+            $mail = new ReservationReplyMail($reply);
+
+            Mail::to($email)->send($mail);
 
             $reply->forceFill([
                 'status' => ReservationReplyStatus::Sent,
                 'sent_at' => now(),
+                'outbound_message_id' => $mail->messageId,
                 'error_message' => null,
             ])->save();
 

--- a/app/Mail/ReservationReplyMail.php
+++ b/app/Mail/ReservationReplyMail.php
@@ -9,6 +9,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Mail\Mailables\Headers;
 use Illuminate\Queue\SerializesModels;
 
 /**
@@ -18,20 +19,38 @@ use Illuminate\Queue\SerializesModels;
  * internal IDs, no JSON snapshots, no debug data — and a plaintext view
  * is the canonical rendering. From-address falls back to the application
  * mail config; per-restaurant from-addresses are a V1.1 extension.
+ *
+ * V2.0 / PRD-006 mail threading: every send carries a stable RFC-2822
+ * Message-ID (`<reservation-{reply_id}-{16hex}@{domain}>`) and the subject
+ * is suffixed with the threading marker `[Res #<reservation_request_id>]`
+ * so the inbound resolver can route replies back to the same reservation.
  */
 final class ReservationReplyMail extends Mailable
 {
     use Queueable;
     use SerializesModels;
 
-    public function __construct(public readonly ReservationReply $reply) {}
+    public readonly string $messageId;
+
+    public function __construct(public readonly ReservationReply $reply)
+    {
+        $this->messageId = self::generateMessageId($reply->id);
+    }
 
     public function envelope(): Envelope
     {
         $restaurant = $this->reply->reservationRequest->restaurant;
+        $defaultSubject = 'Reservierung bei '.$restaurant->name;
 
         return new Envelope(
-            subject: 'Ihre Reservierungsanfrage bei '.$restaurant->name,
+            subject: $this->buildSubjectWithMarker($defaultSubject, $this->reply->reservation_request_id),
+        );
+    }
+
+    public function headers(): Headers
+    {
+        return new Headers(
+            messageId: $this->messageId,
         );
     }
 
@@ -49,5 +68,43 @@ final class ReservationReplyMail extends Mailable
                 'body' => $this->reply->body,
             ],
         );
+    }
+
+    /**
+     * RFC-2822 Message-ID for outbound replies. Stable per reply, unique
+     * per send (16 random hex bytes prevent retries from colliding).
+     */
+    public static function generateMessageId(int $replyId): string
+    {
+        return sprintf(
+            'reservation-%d-%s@%s',
+            $replyId,
+            bin2hex(random_bytes(8)),
+            self::deriveDomain(),
+        );
+    }
+
+    private static function deriveDomain(): string
+    {
+        $from = config('mail.from.address');
+
+        if (! is_string($from) || ! str_contains($from, '@')) {
+            return 'localhost';
+        }
+
+        $domain = substr($from, strrpos($from, '@') + 1);
+
+        return $domain !== '' ? $domain : 'localhost';
+    }
+
+    private function buildSubjectWithMarker(string $subject, int $reservationRequestId): string
+    {
+        $marker = sprintf('[Res #%d]', $reservationRequestId);
+
+        if (str_contains($subject, $marker)) {
+            return $subject;
+        }
+
+        return trim($subject.' '.$marker);
     }
 }

--- a/tests/Feature/Email/ThreadingFlowTest.php
+++ b/tests/Feature/Email/ThreadingFlowTest.php
@@ -5,14 +5,19 @@ declare(strict_types=1);
 namespace Tests\Feature\Email;
 
 use App\Enums\MessageDirection;
+use App\Enums\ReservationReplyStatus;
 use App\Jobs\FetchReservationEmailsJob;
+use App\Jobs\SendReservationReplyJob;
+use App\Mail\ReservationReplyMail;
 use App\Models\ReservationMessage;
+use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\DTO\FetchedEmail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Mail;
 use Tests\Support\Email\FakeImapMailboxFactory;
 use Tests\TestCase;
 
@@ -158,5 +163,105 @@ class ThreadingFlowTest extends TestCase
         $this->app->instance(ImapMailboxFactory::class, $factory);
 
         Bus::dispatchSync(new FetchReservationEmailsJob($restaurantId));
+    }
+
+    public function test_it_generates_stable_message_id_for_outbound_mail(): void
+    {
+        config()->set('mail.from.address', 'noreply@restaurant.example');
+
+        $reply = $this->makeApprovedReply();
+
+        $mail = new ReservationReplyMail($reply);
+
+        $this->assertMatchesRegularExpression(
+            '/^reservation-'.$reply->id.'-[0-9a-f]{16}@restaurant\.example$/',
+            $mail->messageId,
+            'Outbound Message-ID must follow <reservation-{reply_id}-{16hex}@{domain}>.',
+        );
+
+        $rendered = $mail->render();
+        $this->assertNotEmpty($rendered);
+    }
+
+    public function test_message_id_falls_back_to_localhost_when_from_address_is_unparseable(): void
+    {
+        config()->set('mail.from.address', null);
+
+        $reply = $this->makeApprovedReply();
+
+        $mail = new ReservationReplyMail($reply);
+
+        $this->assertStringEndsWith('@localhost', $mail->messageId);
+    }
+
+    public function test_it_inserts_subject_marker_for_outbound_mail(): void
+    {
+        $reply = $this->makeApprovedReply(restaurantName: 'Le Bistro');
+
+        $mail = new ReservationReplyMail($reply);
+
+        $mail->assertHasSubject('Reservierung bei Le Bistro [Res #'.$reply->reservation_request_id.']');
+    }
+
+    public function test_it_does_not_double_insert_subject_marker_if_already_present(): void
+    {
+        $restaurant = Restaurant::factory()->create(['name' => 'Le Bistro']);
+        $request = ReservationRequest::factory()->create(['restaurant_id' => $restaurant->id]);
+
+        // Force the restaurant name to already contain the marker for this
+        // exact reservation id, so the default subject template would emit
+        // a duplicate marker if buildSubjectWithMarker did not deduplicate.
+        $restaurant->forceFill(['name' => 'Le Bistro [Res #'.$request->id.']'])->save();
+
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Approved,
+        ]);
+
+        $mail = new ReservationReplyMail($reply->fresh());
+
+        $subject = $mail->envelope()->subject;
+
+        $marker = '[Res #'.$request->id.']';
+        $this->assertSame(
+            1,
+            substr_count((string) $subject, $marker),
+            'Subject marker must not be inserted twice when the source subject already contains it.',
+        );
+    }
+
+    public function test_outbound_mail_send_persists_message_id_on_reservation_reply(): void
+    {
+        Mail::fake();
+
+        $reply = $this->makeApprovedReply(guestEmail: 'guest@example.com');
+
+        Bus::dispatchSync(new SendReservationReplyJob($reply->id));
+
+        $reply->refresh();
+
+        $this->assertNotNull($reply->outbound_message_id);
+        $this->assertMatchesRegularExpression(
+            '/^reservation-'.$reply->id.'-[0-9a-f]{16}@/',
+            (string) $reply->outbound_message_id,
+        );
+
+        Mail::assertSent(ReservationReplyMail::class, function (ReservationReplyMail $sent) use ($reply): bool {
+            return $sent->messageId === $reply->outbound_message_id;
+        });
+    }
+
+    private function makeApprovedReply(string $restaurantName = 'La Trattoria', string $guestEmail = 'guest@example.com'): ReservationReply
+    {
+        $restaurant = Restaurant::factory()->create(['name' => $restaurantName]);
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => $guestEmail,
+        ]);
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Approved,
+        ]);
     }
 }

--- a/tests/Feature/Mail/ReservationReplyMailTest.php
+++ b/tests/Feature/Mail/ReservationReplyMailTest.php
@@ -28,13 +28,13 @@ class ReservationReplyMailTest extends TestCase
         ]);
     }
 
-    public function test_subject_references_the_restaurant_name(): void
+    public function test_subject_references_the_restaurant_name_and_carries_threading_marker(): void
     {
         $reply = $this->makeReply('Guten Tag, gerne!', restaurantName: 'Le Bistro');
 
         $mailable = new ReservationReplyMail($reply);
 
-        $mailable->assertHasSubject('Ihre Reservierungsanfrage bei Le Bistro');
+        $mailable->assertHasSubject('Reservierung bei Le Bistro [Res #'.$reply->reservation_request_id.']');
     }
 
     public function test_body_renders_only_the_operator_approved_text(): void


### PR DESCRIPTION
## Summary

Closes the threading loop: every outbound reply now carries a stable RFC-2822 Message-ID and a `[Res #<id>]` subject marker so inbound replies route back via #203 / #204.

- `ReservationReplyMail::generateMessageId(int $replyId): string` — `<reservation-{reply_id}-{16hex}@{domain}>` with `bin2hex(random_bytes(8))`. Domain derived from `config('mail.from.address')`, fallback `localhost`.
- The Mailable computes the id in its constructor and exposes it as a public readonly property.
- `headers()` returns `new Headers(messageId: $this->messageId)` — the modern Laravel-12 equivalent of the PRD's `withSymfonyMessage` example. Functionally identical: the Symfony `Email` ends up with a `Message-ID` header carrying the generated id.
- `buildSubjectWithMarker()` defaults to `Reservierung bei {restaurant->name}` and suffixes `[Res #<id>]`. Idempotent — never double-inserts.
- `SendReservationReplyJob` persists `mail->messageId` to `reservation_replies.outbound_message_id` in the same `forceFill` that flips status to Sent.

## Why

Without this, inbound replies cannot match the header strategies (`byInReplyTo`, `byReferences`) because there is no outbound Message-ID to match against. The marker provides a third path (`bySubjectMarker`) for clients that strip thread headers.

## Notable decisions

- **Subject default wording change**: V1.0 used `Ihre Reservierungsanfrage bei {name}`; PRD-006 V2.0 specifies `Reservierung bei {name}`. Updated to match the spec — the existing `ReservationReplyMailTest::test_subject_references_the_restaurant_name` is renamed and updated.
- **`headers()` over `withSymfonyMessage`**: Laravel 12's idiomatic way to set a Message-ID. The PRD example uses `build()` + `withSymfonyMessage`, but the existing Mailable already follows the modern `envelope()/content()/headers()` style. Mixing patterns would violate "Continue existing patterns".
- **Message-ID generated in the Mailable, not the job**: keeps the public surface small and testable in isolation. The job reads `mail->messageId` after construction — no duplication.

## Test plan

- [x] `php artisan test` — 538 tests / 1688 assertions, green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean

New cases in `tests/Feature/Email/ThreadingFlowTest`:
- `it_generates_stable_message_id_for_outbound_mail` — regex matches `<reservation-{id}-{16hex}@{domain}>`
- `message_id_falls_back_to_localhost_when_from_address_is_unparseable`
- `it_inserts_subject_marker_for_outbound_mail`
- `it_does_not_double_insert_subject_marker_if_already_present` — restaurant name pre-seeded with marker, asserts `substr_count == 1`
- `outbound_mail_send_persists_message_id_on_reservation_reply` — Mail::fake + SendReservationReplyJob, asserts persistence and that the captured Mailable carries the same id

Existing test `ReservationReplyMailTest::test_subject_references_the_restaurant_name` renamed to `…_and_carries_threading_marker` and updated.

Closes #206