### PR TITLE
Outbound References/In-Reply-To chain + persist outbound ReservationMessage (#207)

### DIFF
--- a/app/Jobs/SendReservationReplyJob.php
+++ b/app/Jobs/SendReservationReplyJob.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Jobs;
 
+use App\Enums\MessageDirection;
 use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationStatus;
 use App\Mail\ReservationReplyMail;
+use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -76,6 +78,24 @@ final class SendReservationReplyJob implements ShouldQueue
             $mail = new ReservationReplyMail($reply);
 
             Mail::to($email)->send($mail);
+
+            $fromAddress = (string) (config('mail.from.address') ?: 'noreply@localhost');
+            $subject = (string) $mail->envelope()->subject;
+
+            ReservationMessage::create([
+                'reservation_request_id' => $reply->reservation_request_id,
+                'direction' => MessageDirection::Out,
+                'message_id' => $mail->messageId,
+                'subject' => $subject,
+                'from_address' => $fromAddress,
+                'to_address' => $email,
+                'body_plain' => $reply->body,
+                // Outbound mails don't carry raw IMAP headers — synthesize a
+                // minimal RFC-2822-style envelope from what we authored, so
+                // the audit + drawer-history queries have something to render.
+                'raw_headers' => "Message-ID: <{$mail->messageId}>\nFrom: {$fromAddress}\nTo: {$email}\nSubject: {$subject}",
+                'sent_at' => now(),
+            ]);
 
             $reply->forceFill([
                 'status' => ReservationReplyStatus::Sent,

--- a/app/Mail/ReservationReplyMail.php
+++ b/app/Mail/ReservationReplyMail.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Mail;
 
+use App\Enums\MessageDirection;
+use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
@@ -49,9 +51,41 @@ final class ReservationReplyMail extends Mailable
 
     public function headers(): Headers
     {
+        $previousIds = $this->previousMessageIds();
+
+        // In-Reply-To takes the most recent predecessor; the project-wide
+        // convention for Message-IDs in `text:` headers is to wrap them in
+        // angle brackets explicitly (the `references:` slot wraps for us).
+        $text = $previousIds === []
+            ? []
+            : ['In-Reply-To' => '<'.end($previousIds).'>'];
+
         return new Headers(
             messageId: $this->messageId,
+            references: $previousIds,
+            text: $text,
         );
+    }
+
+    /**
+     * Up to the most recent ten outbound Message-IDs for this reservation,
+     * in chronological order. The current send is excluded — it has not
+     * been persisted yet — so this returns the predecessor chain only.
+     *
+     * @return list<string>
+     */
+    private function previousMessageIds(): array
+    {
+        return ReservationMessage::query()
+            ->where('reservation_request_id', $this->reply->reservation_request_id)
+            ->where('direction', MessageDirection::Out)
+            ->whereNotNull('message_id')
+            ->orderBy('sent_at')
+            ->orderBy('id')
+            ->pluck('message_id')
+            ->slice(-10)
+            ->values()
+            ->all();
     }
 
     public function content(): Content

--- a/tests/Feature/Email/ThreadingFlowTest.php
+++ b/tests/Feature/Email/ThreadingFlowTest.php
@@ -251,6 +251,83 @@ class ThreadingFlowTest extends TestCase
         });
     }
 
+    public function test_it_builds_references_chain_on_second_outbound_mail(): void
+    {
+        $reply = $this->makeApprovedReply();
+
+        $previousId = '<reservation-99-aaaaaaaaaaaaaaaa@restaurant.example>';
+        ReservationMessage::factory()
+            ->outbound()
+            ->forReservationRequest($reply->reservationRequest)
+            ->create([
+                'message_id' => $previousId,
+                'sent_at' => now()->subHour(),
+            ]);
+
+        $mail = new ReservationReplyMail($reply->fresh());
+        $headers = $mail->headers();
+
+        $this->assertSame([$previousId], $headers->references);
+        $this->assertSame('<'.$previousId.'>', $headers->text['In-Reply-To'] ?? null);
+    }
+
+    public function test_first_outbound_mail_carries_no_references_or_in_reply_to(): void
+    {
+        $reply = $this->makeApprovedReply();
+
+        $mail = new ReservationReplyMail($reply);
+        $headers = $mail->headers();
+
+        $this->assertSame([], $headers->references);
+        $this->assertArrayNotHasKey('In-Reply-To', $headers->text);
+    }
+
+    public function test_it_persists_outbound_reservation_message_after_send(): void
+    {
+        Mail::fake();
+
+        $reply = $this->makeApprovedReply(guestEmail: 'guest@example.com');
+
+        Bus::dispatchSync(new SendReservationReplyJob($reply->id));
+
+        $outbound = ReservationMessage::query()
+            ->where('reservation_request_id', $reply->reservation_request_id)
+            ->where('direction', MessageDirection::Out)
+            ->first();
+
+        $this->assertNotNull($outbound, 'A successful send must persist an outbound ReservationMessage row.');
+        $this->assertSame($reply->fresh()->outbound_message_id, $outbound->message_id);
+        $this->assertSame('guest@example.com', $outbound->to_address);
+        $this->assertSame($reply->body, $outbound->body_plain);
+        $this->assertNotNull($outbound->sent_at);
+    }
+
+    public function test_it_trims_references_to_last_ten_message_ids(): void
+    {
+        $reply = $this->makeApprovedReply();
+        $request = $reply->reservationRequest;
+
+        $allIds = [];
+        for ($i = 1; $i <= 15; $i++) {
+            $id = sprintf('<reservation-%d-%s@restaurant.example>', $i, str_repeat('0', 15).$i);
+            $allIds[] = $id;
+            ReservationMessage::factory()
+                ->outbound()
+                ->forReservationRequest($request)
+                ->create([
+                    'message_id' => $id,
+                    'sent_at' => now()->subHours(15 - $i + 1),
+                ]);
+        }
+
+        $mail = new ReservationReplyMail($reply->fresh());
+        $headers = $mail->headers();
+
+        $this->assertCount(10, $headers->references);
+        $this->assertSame(array_slice($allIds, 5), $headers->references, 'Should keep the most recent 10 ids in chronological order.');
+        $this->assertSame('<'.end($allIds).'>', $headers->text['In-Reply-To']);
+    }
+
     private function makeApprovedReply(string $restaurantName = 'La Trattoria', string $guestEmail = 'guest@example.com'): ReservationReply
     {
         $restaurant = Restaurant::factory()->create(['name' => $restaurantName]);


### PR DESCRIPTION
## Summary

Closes the outbound side of the threading loop.

- `ReservationReplyMail::previousMessageIds()` returns up to the most recent 10 outbound Message-IDs for the reservation, in chronological order. Sort key is `sent_at`, then `id` for tie-breaking.
- `headers()` populates `references` (Laravel wraps each id in angle brackets via `Headers::referencesString()`) and adds an explicit `In-Reply-To: <latest>` text header. First outbound (empty predecessor list) emits neither.
- `SendReservationReplyJob` writes a `ReservationMessage` (`direction=out`) right after `Mail::send` succeeds and before the Sent forceFill. The persisted row carries the generated Message-ID, subject (with marker), from/to addresses, the operator-approved body, a synthesized minimal `raw_headers` envelope, and `sent_at = now()`.

## Why

Without this, the resolver's header strategies (#203) only had inbound rows to look up against, so a guest reply to an outbound mail couldn't match by `byInReplyTo`/`byReferences`. The outbound row gives them something to find. The chain trim to 10 keeps the `References` header within RFC-friendly length on long-running reservation threads.

## Notable decisions

- **Persist before forceFill**, not in a single transaction: keeps the existing retry/error semantics (the catch in `handle()` only flips `error_message`, never `Sent`/`Failed`). If `Mail::send` succeeds and either DB write crashes, the existing retry path resends — same trade-off as the V1.0 send path.
- **Synthesized `raw_headers`**: the schema requires NOT NULL. Outbound mails have no inbound IMAP headers to copy, so the job synthesizes a 4-line envelope (Message-ID/From/To/Subject) for audit + drawer-history uniformity. Real header inspection isn't a goal for outbound rows; the inbound side still carries the full original.
- **`In-Reply-To` via `text:` header** with explicit angle-bracket wrapping. The `Headers` contract has no dedicated `inReplyTo` slot, but `text:` writes the raw value. Wrapping keeps it RFC-2822 compliant.

## Test plan

- [x] `php artisan test` — 542 tests / 1700 assertions, green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean

New cases (`tests/Feature/Email/ThreadingFlowTest`):
- `it_builds_references_chain_on_second_outbound_mail`
- `first_outbound_mail_carries_no_references_or_in_reply_to`
- `it_persists_outbound_reservation_message_after_send`
- `it_trims_references_to_last_ten_message_ids` (seeds 15, asserts `references` count is 10 and contains the most recent 10 in chronological order, with `In-Reply-To` pointing at the latest)

Closes #207