### PR TITLE
Add reservations.messages.index endpoint + ReservationMessageResource (#208)

### DIFF
--- a/app/Http/Controllers/ReservationMessagesController.php
+++ b/app/Http/Controllers/ReservationMessagesController.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Resources\ReservationMessageResource;
+use App\Models\ReservationRequest;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Facades\Gate;
+
+final class ReservationMessagesController extends Controller
+{
+    public function index(int $reservation): AnonymousResourceCollection
+    {
+        // Bypass the RestaurantScope so a cross-tenant id surfaces a 403
+        // (policy denial) rather than a 404 — the AC distinguishes "not
+        // yours" from "doesn't exist" for this endpoint.
+        $request = ReservationRequest::withoutGlobalScopes()->findOrFail($reservation);
+
+        Gate::authorize('view', $request);
+
+        $messages = $request->messages()
+            ->with(['outboundReply.approver:id,name'])
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get();
+
+        return ReservationMessageResource::collection($messages);
+    }
+}

--- a/app/Http/Resources/ReservationMessageResource.php
+++ b/app/Http/Resources/ReservationMessageResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\ReservationMessage;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Drawer-history projection of a ReservationMessage. Exposes only the
+ * fields the UI needs and explicitly omits `raw_headers` and the
+ * threading-internal columns (`in_reply_to`, `references`) — those stay
+ * server-side and are reserved for the resolver / audit.
+ *
+ * @property-read ReservationMessage $resource
+ */
+final class ReservationMessageResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'direction' => $this->resource->direction->value,
+            'subject' => $this->resource->subject,
+            'from_address' => $this->resource->from_address,
+            'to_address' => $this->resource->to_address,
+            'body_plain' => $this->resource->body_plain,
+            'sent_at' => $this->resource->sent_at?->toIso8601String(),
+            'received_at' => $this->resource->received_at?->toIso8601String(),
+            'approved_by' => $this->resource->outboundReply?->approver?->name,
+        ];
+    }
+}

--- a/app/Models/ReservationMessage.php
+++ b/app/Models/ReservationMessage.php
@@ -7,6 +7,7 @@ use Database\Factories\ReservationMessageFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 final class ReservationMessage extends Model
 {
@@ -53,5 +54,17 @@ final class ReservationMessage extends Model
     public function reservationRequest(): BelongsTo
     {
         return $this->belongsTo(ReservationRequest::class);
+    }
+
+    /**
+     * Loose join: an outbound message's `message_id` matches the
+     * `outbound_message_id` persisted on the originating ReservationReply.
+     * Used to surface the operator who approved the send in the drawer.
+     *
+     * @return HasOne<ReservationReply, $this>
+     */
+    public function outboundReply(): HasOne
+    {
+        return $this->hasOne(ReservationReply::class, 'outbound_message_id', 'message_id');
     }
 }

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -9,6 +9,12 @@ declare module 'ziggy-js' {
             "required": true
         }
     ],
+    "reservations.messages.index": [
+        {
+            "name": "reservation",
+            "required": true
+        }
+    ],
     "reservations.bulk-status": [],
     "reservation-replies.approve": [
         {

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PublicReservationController;
+use App\Http\Controllers\ReservationMessagesController;
 use App\Http\Controllers\ReservationReplyController;
 use App\Http\Controllers\ReservationRequestController;
 use Illuminate\Support\Facades\Route;
@@ -19,6 +20,11 @@ Route::get('reservations/{reservation}', [ReservationRequestController::class, '
     ->whereNumber('reservation')
     ->middleware(['auth', 'verified'])
     ->name('reservations.show');
+
+Route::get('reservations/{reservation}/messages', [ReservationMessagesController::class, 'index'])
+    ->whereNumber('reservation')
+    ->middleware(['auth', 'verified'])
+    ->name('reservations.messages.index');
 
 Route::post('reservations/bulk-status', [ReservationRequestController::class, 'bulkStatus'])
     ->middleware(['auth', 'verified'])

--- a/tests/Feature/Email/ThreadingFlowTest.php
+++ b/tests/Feature/Email/ThreadingFlowTest.php
@@ -13,6 +13,7 @@ use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
+use App\Models\User;
 use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\DTO\FetchedEmail;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -340,5 +341,81 @@ class ThreadingFlowTest extends TestCase
             'reservation_request_id' => $request->id,
             'status' => ReservationReplyStatus::Approved,
         ]);
+    }
+
+    public function test_it_lists_thread_messages_in_detail_drawer_chronologically(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create(['restaurant_id' => $restaurant->id]);
+        $user = User::factory()->create(['restaurant_id' => $restaurant->id, 'name' => 'Operator Anna']);
+
+        $first = ReservationMessage::factory()->outbound()->forReservationRequest($request)->create([
+            'subject' => 'Reservierung bei XYZ [Res #'.$request->id.']',
+            'sent_at' => now()->subHours(3),
+            'created_at' => now()->subHours(3),
+        ]);
+        ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Sent,
+            'outbound_message_id' => $first->message_id,
+            'approved_by' => $user->id,
+        ]);
+        $second = ReservationMessage::factory()->inbound()->forReservationRequest($request)->create([
+            'subject' => 'Re: Reservierung bei XYZ [Res #'.$request->id.']',
+            'received_at' => now()->subHour(),
+            'created_at' => now()->subHour(),
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson(route('reservations.messages.index', $request));
+
+        $response->assertOk()
+            ->assertJsonCount(2, 'data')
+            ->assertJsonPath('data.0.id', $first->id)
+            ->assertJsonPath('data.0.direction', 'out')
+            ->assertJsonPath('data.0.approved_by', 'Operator Anna')
+            ->assertJsonPath('data.1.id', $second->id)
+            ->assertJsonPath('data.1.direction', 'in')
+            ->assertJsonPath('data.1.approved_by', null);
+    }
+
+    public function test_it_forbids_cross_tenant_access_to_messages_endpoint(): void
+    {
+        $restaurantA = Restaurant::factory()->create();
+        $restaurantB = Restaurant::factory()->create();
+        $requestOnA = ReservationRequest::factory()->create(['restaurant_id' => $restaurantA->id]);
+        $userOfB = User::factory()->create(['restaurant_id' => $restaurantB->id]);
+
+        $this->actingAs($userOfB)
+            ->getJson(route('reservations.messages.index', $requestOnA))
+            ->assertForbidden();
+    }
+
+    public function test_it_returns_404_for_unknown_reservation(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->getJson(route('reservations.messages.index', 999_999))
+            ->assertNotFound();
+    }
+
+    public function test_it_does_not_expose_raw_headers_in_resource(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create(['restaurant_id' => $restaurant->id]);
+        $user = User::factory()->create(['restaurant_id' => $restaurant->id]);
+
+        $secret = 'X-Internal-Token: super-secret-do-not-leak';
+        ReservationMessage::factory()->inbound()->forReservationRequest($request)->create([
+            'raw_headers' => $secret,
+        ]);
+
+        $response = $this->actingAs($user)
+            ->getJson(route('reservations.messages.index', $request));
+
+        $response->assertOk();
+        $response->assertJsonMissingPath('data.0.raw_headers');
+        $this->assertStringNotContainsString($secret, $response->getContent() ?: '');
     }
 }


### PR DESCRIPTION
## Summary

Drawer-history API for the mail-threading detail tab.

- `GET /reservations/{reservation}/messages` (named `reservations.messages.index`, auth + verified middleware).
- `ReservationMessagesController@index` loads messages ordered by `created_at` then `id`, eager-loads `outboundReply.approver:id,name` for the operator name.
- `ReservationMessageResource` projects only the drawer-facing fields. `raw_headers`, `in_reply_to`, and `references` stay server-side.
- New `ReservationMessage::outboundReply` hasOne relation joins loosely on `outbound_message_id ⇄ message_id`, exposing the approver for outbound rows.

## Why

The drawer's History tab needs a thread view (#209), and the dashboard would otherwise have to read raw mail data through the existing reservation detail props. Carving the endpoint out keeps the resource projection narrow (no PII-laden raw_headers) and gives #209 a stable contract to consume.

## Notable decisions

- **Controller calls `withoutGlobalScopes()` before `findOrFail`** so a cross-tenant id surfaces a 403 (policy denial) rather than a 404. The AC explicitly differentiates 'not yours' from 'doesn't exist'.
- **`approved_by` resolution via hasOne, not a lookup table on each row**: the new `outboundReply` relation matches outbound `message_id` against the originating `ReservationReply.outbound_message_id` written in #207. Eager-loading it keeps the resource serialization N+1-free.
- **Resource omits threading-internal columns** (`raw_headers`, `in_reply_to`, `references`). These belong to the resolver / audit and would be PII leakage in the drawer payload.

## Test plan

- [x] `php artisan test` — 546 tests / 1713 assertions, green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean
- [x] `php artisan ziggy:generate --types-only resources/js/ziggy.d.ts` — committed

New cases (`tests/Feature/Email/ThreadingFlowTest`):
- `it_lists_thread_messages_in_detail_drawer_chronologically` — outbound-then-inbound, asserts \`approved_by\` resolves to the operator name on outbound, null on inbound
- `it_forbids_cross_tenant_access_to_messages_endpoint` — 403, not 404
- `it_returns_404_for_unknown_reservation`
- `it_does_not_expose_raw_headers_in_resource` — sets a recognizable secret in raw_headers and asserts both \`assertJsonMissingPath\` and string-not-contains on the response body

Closes #208