### PR TITLE
Drawer History tab with chronological thread view (#209)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Enums\ReservationStatus;
 use App\Enums\UserRole;
 use App\Http\Requests\DashboardFilterRequest;
+use App\Http\Resources\ReservationMessageResource;
 use App\Http\Resources\ReservationRequestDetailResource;
 use App\Http\Resources\ReservationRequestResource;
 use App\Models\ReservationRequest;
@@ -48,6 +49,7 @@ final class DashboardController extends Controller
                     ->count(),
             ],
             'selectedRequest' => fn () => $this->resolveSelected($selectedId, $request),
+            'threadMessages' => fn () => $this->resolveThreadMessages($selectedId, $request),
             // Owner-only banner. The flag is global (V1.0 has one OpenAI key
             // app-wide); dismissing-by-user is intentionally NOT supported
             // (issue #76) so a stale alert can't outlive a still-broken key.
@@ -73,6 +75,37 @@ final class DashboardController extends Controller
         }
 
         return (new ReservationRequestDetailResource($reservation))->toArray($request);
+    }
+
+    /**
+     * Lazy prop for the drawer's History tab. The frontend triggers a
+     * partial reload (`router.reload({ only: ['threadMessages'] })`) on
+     * tab activation, so this only runs when the operator opens History
+     * on the currently-selected reservation.
+     *
+     * @return array<int, array<string, mixed>>|null
+     */
+    private function resolveThreadMessages(?int $id, DashboardFilterRequest $request): ?array
+    {
+        if ($id === null) {
+            return null;
+        }
+
+        $reservation = ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->find($id);
+
+        if ($reservation === null || ! Gate::forUser($request->user())->allows('view', $reservation)) {
+            return null;
+        }
+
+        $messages = $reservation->messages()
+            ->with(['outboundReply.approver:id,name'])
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get();
+
+        return ReservationMessageResource::collection($messages)->resolve($request);
     }
 
     /**

--- a/resources/js/components/ReservationThreadHistory.test.ts
+++ b/resources/js/components/ReservationThreadHistory.test.ts
@@ -1,0 +1,64 @@
+import type { ThreadMessage } from '@/types';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import ReservationThreadHistory from './ReservationThreadHistory.vue';
+
+const outbound: ThreadMessage = {
+    id: 11,
+    direction: 'out',
+    subject: 'Reservierung bei Le Bistro [Res #42]',
+    from_address: 'noreply@bistro.example',
+    to_address: 'guest@example.com',
+    body_plain: 'Guten Tag, gerne!',
+    sent_at: '2026-04-29T18:00:00+00:00',
+    received_at: null,
+    approved_by: 'Operator Anna',
+};
+
+const inbound: ThreadMessage = {
+    id: 12,
+    direction: 'in',
+    subject: 'Re: Reservierung bei Le Bistro [Res #42]',
+    from_address: 'guest@example.com',
+    to_address: 'noreply@bistro.example',
+    body_plain: 'Vielen Dank, bis dann!',
+    sent_at: null,
+    received_at: '2026-04-29T19:00:00+00:00',
+    approved_by: null,
+};
+
+describe('ReservationThreadHistory', () => {
+    it('renders the empty state when there are no messages', () => {
+        const wrapper = mount(ReservationThreadHistory, { props: { messages: [] } });
+
+        expect(wrapper.find('[data-testid="thread-history-empty"]').exists()).toBe(true);
+        expect(wrapper.find('[data-testid="thread-history-list"]').exists()).toBe(false);
+    });
+
+    it('renders a chronological list of inbound and outbound messages', () => {
+        const wrapper = mount(ReservationThreadHistory, { props: { messages: [outbound, inbound] } });
+
+        const items = wrapper.findAll('[data-testid^="thread-message-"]');
+        expect(items).toHaveLength(2);
+
+        expect(items[0].attributes('data-testid')).toBe('thread-message-11');
+        expect(items[0].attributes('data-direction')).toBe('out');
+        expect(items[0].text()).toContain('Reservierung bei Le Bistro [Res #42]');
+        expect(items[0].text()).toContain('Guten Tag, gerne!');
+        expect(items[0].text()).toContain('Freigegeben von Operator Anna');
+
+        expect(items[1].attributes('data-testid')).toBe('thread-message-12');
+        expect(items[1].attributes('data-direction')).toBe('in');
+        expect(items[1].text()).toContain('Re: Reservierung bei Le Bistro [Res #42]');
+        expect(items[1].text()).toContain('Vielen Dank, bis dann!');
+        // Inbound rows must NOT show "Freigegeben von …" — that's outbound-only.
+        expect(items[1].text()).not.toContain('Freigegeben von');
+    });
+
+    it('renders the loading state when messages are null and loading is true', () => {
+        const wrapper = mount(ReservationThreadHistory, { props: { messages: null, loading: true } });
+
+        expect(wrapper.find('[data-testid="thread-history-loading"]').exists()).toBe(true);
+        expect(wrapper.find('[data-testid="thread-history-list"]').exists()).toBe(false);
+    });
+});

--- a/resources/js/components/ReservationThreadHistory.vue
+++ b/resources/js/components/ReservationThreadHistory.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+import { formatDateTime } from '@/lib/format-datetime';
+import type { ThreadMessage } from '@/types';
+import { ArrowDownLeft, ArrowUpRight } from 'lucide-vue-next';
+import { computed } from 'vue';
+
+interface Props {
+    messages: ThreadMessage[] | null | undefined;
+    timezone?: string | null;
+    loading?: boolean;
+}
+
+const props = defineProps<Props>();
+
+const list = computed(() => props.messages ?? []);
+
+function timestamp(message: ThreadMessage): string | null {
+    return message.direction === 'out' ? message.sent_at : message.received_at;
+}
+</script>
+
+<template>
+    <div data-testid="reservation-thread-history" class="space-y-3">
+        <div
+            v-if="loading && list.length === 0"
+            class="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground"
+            data-testid="thread-history-loading"
+        >
+            Lade Nachrichtenverlauf …
+        </div>
+
+        <div
+            v-else-if="list.length === 0"
+            class="rounded-md border border-dashed border-border p-4 text-sm text-muted-foreground"
+            data-testid="thread-history-empty"
+        >
+            Noch keine Nachrichten zu dieser Reservierung.
+        </div>
+
+        <ol v-else class="space-y-3" data-testid="thread-history-list">
+            <li
+                v-for="message in list"
+                :key="message.id"
+                class="space-y-1.5 rounded-md border border-border bg-muted/20 p-3"
+                :data-testid="`thread-message-${message.id}`"
+                :data-direction="message.direction"
+            >
+                <div class="flex items-start justify-between gap-2 text-xs text-muted-foreground">
+                    <div class="flex items-center gap-1.5">
+                        <ArrowUpRight
+                            v-if="message.direction === 'out'"
+                            class="size-3.5 text-emerald-700 dark:text-emerald-400"
+                            aria-label="Outbound"
+                        />
+                        <ArrowDownLeft v-else class="size-3.5 text-sky-700 dark:text-sky-400" aria-label="Inbound" />
+                        <span>{{ message.from_address }}</span>
+                    </div>
+                    <time :datetime="timestamp(message) ?? ''">{{ formatDateTime(timestamp(message), { timeZone: timezone ?? undefined }) }}</time>
+                </div>
+
+                <p class="text-sm font-medium">{{ message.subject }}</p>
+                <p class="whitespace-pre-line text-sm text-foreground">{{ message.body_plain }}</p>
+
+                <p v-if="message.direction === 'out' && message.approved_by" class="text-xs text-muted-foreground">
+                    Freigegeben von {{ message.approved_by }}
+                </p>
+            </li>
+        </ol>
+    </div>
+</template>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import ReservationThreadHistory from '@/components/ReservationThreadHistory.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -19,6 +20,7 @@ import {
     type ReservationSource,
     type ReservationStatus,
     type SharedData,
+    type ThreadMessage,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
 import { ChevronDown, Info } from 'lucide-vue-next';
@@ -31,6 +33,7 @@ interface DashboardProps {
     requests: PaginatedReservationRequests;
     stats: DashboardStats;
     selectedRequest?: ReservationRequestDetail | null;
+    threadMessages?: ThreadMessage[] | null;
     openaiKeyRejectedAt?: string | null;
 }
 
@@ -195,6 +198,44 @@ const drawerOpen = computed({
 });
 
 const rawEmailOpen = ref(false);
+
+type DrawerTab = 'details' | 'history';
+const activeDrawerTab = ref<DrawerTab>('details');
+const threadMessagesLoading = ref(false);
+
+watch(
+    () => props.selectedRequest?.id,
+    (id, prev) => {
+        if (id !== prev) {
+            // Reset to Details when the selection changes so the operator
+            // doesn't land on a stale History tab from a previous request.
+            activeDrawerTab.value = 'details';
+        }
+    },
+);
+
+function selectDrawerTab(tab: DrawerTab): void {
+    if (activeDrawerTab.value === tab) {
+        return;
+    }
+    activeDrawerTab.value = tab;
+
+    // History data is loaded lazily on first activation per drawer-open
+    // cycle. Repeating the partial reload on every tab switch would burn
+    // a server roundtrip for unchanged data; the page polling refresh
+    // already covers steady-state updates.
+    if (tab === 'history' && props.selectedRequest != null && props.threadMessages == null) {
+        threadMessagesLoading.value = true;
+        router.reload({
+            only: ['threadMessages'],
+            preserveScroll: true,
+            preserveState: true,
+            onFinish: () => {
+                threadMessagesLoading.value = false;
+            },
+        });
+    }
+}
 
 const REPLY_STATUS_LABEL: Record<'draft' | 'approved' | 'sent' | 'failed', string> = {
     draft: 'KI-Vorschlag verfügbar',
@@ -604,112 +645,162 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                     </SheetDescription>
                 </SheetHeader>
 
-                <dl class="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-2 text-sm" data-testid="reservation-detail-fields">
-                    <dt class="font-medium text-muted-foreground">Eingegangen</dt>
-                    <dd>{{ renderTime(props.selectedRequest.created_at) }}</dd>
+                <div class="-mx-1 inline-flex gap-1 border-b border-border" role="tablist" data-testid="drawer-tabs">
+                    <button
+                        type="button"
+                        role="tab"
+                        :aria-selected="activeDrawerTab === 'details'"
+                        class="px-3 py-2 text-sm font-medium transition-colors"
+                        :class="
+                            activeDrawerTab === 'details'
+                                ? 'border-b-2 border-primary text-foreground'
+                                : 'text-muted-foreground hover:text-foreground'
+                        "
+                        data-testid="drawer-tab-details"
+                        @click="selectDrawerTab('details')"
+                    >
+                        Details
+                    </button>
+                    <button
+                        type="button"
+                        role="tab"
+                        :aria-selected="activeDrawerTab === 'history'"
+                        class="px-3 py-2 text-sm font-medium transition-colors"
+                        :class="
+                            activeDrawerTab === 'history'
+                                ? 'border-b-2 border-primary text-foreground'
+                                : 'text-muted-foreground hover:text-foreground'
+                        "
+                        data-testid="drawer-tab-history"
+                        @click="selectDrawerTab('history')"
+                    >
+                        Verlauf
+                    </button>
+                </div>
 
-                    <dt class="font-medium text-muted-foreground">Wunschzeit</dt>
-                    <dd>{{ renderTime(props.selectedRequest.desired_at) }}</dd>
+                <ReservationThreadHistory
+                    v-if="activeDrawerTab === 'history'"
+                    :messages="props.threadMessages"
+                    :timezone="restaurantTimezone"
+                    :loading="threadMessagesLoading"
+                />
 
-                    <dt class="font-medium text-muted-foreground">Personen</dt>
-                    <dd>{{ props.selectedRequest.party_size }}</dd>
+                <template v-if="activeDrawerTab === 'details'">
+                    <dl class="grid grid-cols-[8rem_1fr] gap-x-3 gap-y-2 text-sm" data-testid="reservation-detail-fields">
+                        <dt class="font-medium text-muted-foreground">Eingegangen</dt>
+                        <dd>{{ renderTime(props.selectedRequest.created_at) }}</dd>
 
-                    <dt class="font-medium text-muted-foreground">E-Mail</dt>
-                    <dd class="break-all">{{ props.selectedRequest.guest_email ?? '–' }}</dd>
+                        <dt class="font-medium text-muted-foreground">Wunschzeit</dt>
+                        <dd>{{ renderTime(props.selectedRequest.desired_at) }}</dd>
 
-                    <dt class="font-medium text-muted-foreground">Telefon</dt>
-                    <dd>{{ props.selectedRequest.guest_phone ?? '–' }}</dd>
-                </dl>
+                        <dt class="font-medium text-muted-foreground">Personen</dt>
+                        <dd>{{ props.selectedRequest.party_size }}</dd>
 
-                <section v-if="props.selectedRequest.message" class="space-y-1.5">
-                    <h3 class="text-sm font-medium text-muted-foreground">Nachricht</h3>
-                    <p class="whitespace-pre-line rounded-md border border-border bg-muted/30 p-3 text-sm">
-                        {{ props.selectedRequest.message }}
-                    </p>
-                </section>
+                        <dt class="font-medium text-muted-foreground">E-Mail</dt>
+                        <dd class="break-all">{{ props.selectedRequest.guest_email ?? '–' }}</dd>
 
-                <Collapsible
-                    v-if="props.selectedRequest.raw_email_body"
-                    v-model:open="rawEmailOpen"
-                    class="space-y-2"
-                    data-testid="raw-email-collapsible"
-                >
-                    <CollapsibleTrigger as-child>
-                        <Button variant="outline" size="sm" class="w-full justify-between">
-                            <span>Original-E-Mail anzeigen</span>
-                            <ChevronDown class="size-4 transition-transform" :class="rawEmailOpen ? 'rotate-180' : ''" />
-                        </Button>
-                    </CollapsibleTrigger>
-                    <CollapsibleContent>
-                        <pre
-                            class="max-h-80 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed"
-                            data-testid="raw-email-body"
-                            >{{ props.selectedRequest.raw_email_body }}</pre
-                        >
-                    </CollapsibleContent>
-                </Collapsible>
+                        <dt class="font-medium text-muted-foreground">Telefon</dt>
+                        <dd>{{ props.selectedRequest.guest_phone ?? '–' }}</dd>
+                    </dl>
 
-                <section v-if="props.selectedRequest.latest_reply" class="space-y-2 border-t border-border pt-4" data-testid="ai-reply-section">
-                    <div class="flex items-center justify-between">
-                        <h3 class="text-sm font-medium">KI-Antwortvorschlag</h3>
-                        <span
-                            class="rounded-full px-2 py-0.5 text-xs font-medium"
-                            :class="REPLY_STATUS_BADGE[props.selectedRequest.latest_reply.status]"
-                            data-testid="ai-reply-status"
-                        >
-                            {{ REPLY_STATUS_LABEL[props.selectedRequest.latest_reply.status] }}
-                        </span>
-                    </div>
+                    <section v-if="props.selectedRequest.message" class="space-y-1.5">
+                        <h3 class="text-sm font-medium text-muted-foreground">Nachricht</h3>
+                        <p class="whitespace-pre-line rounded-md border border-border bg-muted/30 p-3 text-sm">
+                            {{ props.selectedRequest.message }}
+                        </p>
+                    </section>
 
-                    <textarea
-                        v-model="replyBody"
-                        :disabled="!isReplyEditable"
-                        rows="8"
-                        class="w-full resize-y rounded-md border border-border bg-background p-3 text-sm leading-relaxed disabled:cursor-not-allowed disabled:opacity-60"
-                        data-testid="ai-reply-textarea"
-                    ></textarea>
-
-                    <Collapsible v-if="isReplyEditable && isEdited" v-model:open="diffOpen" class="space-y-2" data-testid="ai-reply-diff-collapsible">
+                    <Collapsible
+                        v-if="props.selectedRequest.raw_email_body"
+                        v-model:open="rawEmailOpen"
+                        class="space-y-2"
+                        data-testid="raw-email-collapsible"
+                    >
                         <CollapsibleTrigger as-child>
-                            <Button variant="outline" size="sm" class="w-full justify-between" data-testid="ai-reply-diff-toggle">
-                                <span>Änderungen gegenüber dem KI-Vorschlag anzeigen</span>
-                                <ChevronDown class="size-4 transition-transform" :class="diffOpen ? 'rotate-180' : ''" />
+                            <Button variant="outline" size="sm" class="w-full justify-between">
+                                <span>Original-E-Mail anzeigen</span>
+                                <ChevronDown class="size-4 transition-transform" :class="rawEmailOpen ? 'rotate-180' : ''" />
                             </Button>
                         </CollapsibleTrigger>
                         <CollapsibleContent>
-                            <ol class="space-y-1 rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed" data-testid="ai-reply-diff">
-                                <li
-                                    v-for="(line, idx) in replyDiff"
-                                    :key="idx"
-                                    :class="{
-                                        'text-emerald-700 dark:text-emerald-400': line.kind === 'added',
-                                        'text-red-700 line-through dark:text-red-400': line.kind === 'removed',
-                                        'text-muted-foreground': line.kind === 'context',
-                                    }"
-                                >
-                                    <span class="select-none pr-2 font-mono">{{ DIFF_PREFIX[line.kind] }}</span>
-                                    <span class="whitespace-pre-wrap">{{ line.text || ' ' }}</span>
-                                </li>
-                            </ol>
+                            <pre
+                                class="max-h-80 overflow-auto whitespace-pre-wrap rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed"
+                                data-testid="raw-email-body"
+                                >{{ props.selectedRequest.raw_email_body }}</pre
+                            >
                         </CollapsibleContent>
                     </Collapsible>
 
-                    <p
-                        v-if="props.selectedRequest.latest_reply.status === 'failed' && props.selectedRequest.latest_reply.error_message"
-                        class="text-xs text-red-600 dark:text-red-400"
-                        data-testid="ai-reply-error"
-                    >
-                        Versand fehlgeschlagen: {{ props.selectedRequest.latest_reply.error_message }}
-                    </p>
+                    <section v-if="props.selectedRequest.latest_reply" class="space-y-2 border-t border-border pt-4" data-testid="ai-reply-section">
+                        <div class="flex items-center justify-between">
+                            <h3 class="text-sm font-medium">KI-Antwortvorschlag</h3>
+                            <span
+                                class="rounded-full px-2 py-0.5 text-xs font-medium"
+                                :class="REPLY_STATUS_BADGE[props.selectedRequest.latest_reply.status]"
+                                data-testid="ai-reply-status"
+                            >
+                                {{ REPLY_STATUS_LABEL[props.selectedRequest.latest_reply.status] }}
+                            </span>
+                        </div>
 
-                    <p v-if="props.selectedRequest.latest_reply.sent_at" class="text-xs text-muted-foreground" data-testid="ai-reply-sent-at">
-                        Versendet: {{ renderTime(props.selectedRequest.latest_reply.sent_at) }}
-                    </p>
+                        <textarea
+                            v-model="replyBody"
+                            :disabled="!isReplyEditable"
+                            rows="8"
+                            class="w-full resize-y rounded-md border border-border bg-background p-3 text-sm leading-relaxed disabled:cursor-not-allowed disabled:opacity-60"
+                            data-testid="ai-reply-textarea"
+                        ></textarea>
 
-                    <Button v-if="isReplyEditable" :disabled="approving" class="w-full" data-testid="ai-reply-approve" @click="submitApproval">
-                        {{ isEdited ? 'Bearbeitete Version senden' : 'Freigeben & Versenden' }}
-                    </Button>
-                </section>
+                        <Collapsible
+                            v-if="isReplyEditable && isEdited"
+                            v-model:open="diffOpen"
+                            class="space-y-2"
+                            data-testid="ai-reply-diff-collapsible"
+                        >
+                            <CollapsibleTrigger as-child>
+                                <Button variant="outline" size="sm" class="w-full justify-between" data-testid="ai-reply-diff-toggle">
+                                    <span>Änderungen gegenüber dem KI-Vorschlag anzeigen</span>
+                                    <ChevronDown class="size-4 transition-transform" :class="diffOpen ? 'rotate-180' : ''" />
+                                </Button>
+                            </CollapsibleTrigger>
+                            <CollapsibleContent>
+                                <ol
+                                    class="space-y-1 rounded-md border border-border bg-muted/30 p-3 text-xs leading-relaxed"
+                                    data-testid="ai-reply-diff"
+                                >
+                                    <li
+                                        v-for="(line, idx) in replyDiff"
+                                        :key="idx"
+                                        :class="{
+                                            'text-emerald-700 dark:text-emerald-400': line.kind === 'added',
+                                            'text-red-700 line-through dark:text-red-400': line.kind === 'removed',
+                                            'text-muted-foreground': line.kind === 'context',
+                                        }"
+                                    >
+                                        <span class="select-none pr-2 font-mono">{{ DIFF_PREFIX[line.kind] }}</span>
+                                        <span class="whitespace-pre-wrap">{{ line.text || ' ' }}</span>
+                                    </li>
+                                </ol>
+                            </CollapsibleContent>
+                        </Collapsible>
+
+                        <p
+                            v-if="props.selectedRequest.latest_reply.status === 'failed' && props.selectedRequest.latest_reply.error_message"
+                            class="text-xs text-red-600 dark:text-red-400"
+                            data-testid="ai-reply-error"
+                        >
+                            Versand fehlgeschlagen: {{ props.selectedRequest.latest_reply.error_message }}
+                        </p>
+
+                        <p v-if="props.selectedRequest.latest_reply.sent_at" class="text-xs text-muted-foreground" data-testid="ai-reply-sent-at">
+                            Versendet: {{ renderTime(props.selectedRequest.latest_reply.sent_at) }}
+                        </p>
+
+                        <Button v-if="isReplyEditable" :disabled="approving" class="w-full" data-testid="ai-reply-approve" @click="submitApproval">
+                            {{ isEdited ? 'Bearbeitete Version senden' : 'Freigeben & Versenden' }}
+                        </Button>
+                    </section>
+                </template>
             </SheetContent>
         </Sheet>
     </AppLayout>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -121,3 +121,17 @@ export interface ReservationRequestDetail extends ReservationRequestRow {
     raw_email_body: string | null;
     latest_reply: ReservationReplySummary | null;
 }
+
+export type MessageDirection = 'in' | 'out';
+
+export interface ThreadMessage {
+    id: number;
+    direction: MessageDirection;
+    subject: string;
+    from_address: string;
+    to_address: string;
+    body_plain: string;
+    sent_at: string | null;
+    received_at: string | null;
+    approved_by: string | null;
+}

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature;
 
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
+use App\Models\ReservationMessage;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Models\User;
@@ -478,6 +479,58 @@ class DashboardTest extends TestCase
     // framework behaviour. The application-level guarantee is that
     // `selectedRequest` is wired as a closure, which Inertia evaluates
     // lazily — covered indirectly by the `?selected=` tests above.
+
+    public function test_thread_messages_prop_is_loaded_when_drawer_is_open(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $reservation = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $first = ReservationMessage::factory()
+            ->outbound()
+            ->forReservationRequest($reservation)
+            ->create([
+                'subject' => 'Reservierung [Res #'.$reservation->id.']',
+                'sent_at' => Carbon::now()->subHours(2),
+                'created_at' => Carbon::now()->subHours(2),
+            ]);
+        $second = ReservationMessage::factory()
+            ->inbound()
+            ->forReservationRequest($reservation)
+            ->create([
+                'subject' => 'Re: Reservierung [Res #'.$reservation->id.']',
+                'received_at' => Carbon::now()->subHour(),
+                'created_at' => Carbon::now()->subHour(),
+            ]);
+
+        $this->actingAs($user)
+            ->get('/dashboard?selected='.$reservation->id)
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->has('threadMessages', 2)
+                ->where('threadMessages.0.id', $first->id)
+                ->where('threadMessages.0.direction', 'out')
+                ->where('threadMessages.1.id', $second->id)
+                ->where('threadMessages.1.direction', 'in')
+                ->etc()
+            );
+    }
+
+    public function test_thread_messages_prop_is_null_when_drawer_is_closed(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($user)
+            ->get('/dashboard')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->where('threadMessages', null)
+                ->etc()
+            );
+    }
 
     public function test_invalid_selected_param_is_rejected_by_validation(): void
     {


### PR DESCRIPTION
## Summary

Detail drawer now has Details and Verlauf (History) tabs. Switching to History triggers an Inertia partial reload of a new `threadMessages` prop and renders an extracted `ReservationThreadHistory.vue` component.

- New lazy `threadMessages` prop on `DashboardController`: returns `ReservationMessageResource::collection` for the selected reservation, ordered by `created_at` then `id`, eager-loading `outboundReply.approver:id,name`.
- Drawer wraps existing detail body in `v-if="activeDrawerTab === 'details'"`. Tab buttons live just below the drawer header.
- `selectDrawerTab('history')` triggers `router.reload({ only: ['threadMessages'] })` the first time the History tab is opened in a drawer-open cycle. Subsequent in-cycle switches are free; the existing page polling refresh (PRD-004) covers steady-state.
- Selection-change watcher resets `activeDrawerTab` to `'details'` so an operator never lands in a stale History tab from a previous reservation.
- New `resources/js/components/ReservationThreadHistory.vue`: chronological list with direction icon (ArrowUpRight outbound, ArrowDownLeft inbound), restaurant-TZ timestamp, subject, plaintext body (whitespace-preserved), sender address. Outbound rows show "Freigegeben von {operator}" when the originating reply links via `outbound_message_id`. Empty state and a loading state when messages are null + `loading=true`.
- New TypeScript types `MessageDirection` and `ThreadMessage`.

## Why

The PRD-006 inbound + outbound work is invisible without a UI surface. The History tab is the first operator-facing piece of the threading feature: it shows the full conversation per reservation (including the operator who approved each outbound reply via the loose join from #208).

## Notable decisions

- **Inline tab UI, not a new shadcn `Tabs` primitive.** The drawer needs two tabs only; a new `components/ui/tabs/` primitive would cost five files for one consumer. Two `<button role="tab">` elements with `aria-selected` give us the same UX with no infrastructure introduction. Continues the project's "no new patterns" rule.
- **Lazy prop + first-activation reload, not eager.** Loading the messages on every dashboard render would burn a query per row in the index even when no drawer is open. Loading on every History click would burn a query per tab toggle. Per-cycle once is the cheapest correct behavior.
- **Component tested in isolation, not via the full Dashboard.** Mounting Dashboard.vue would pull in Inertia/Ziggy/Layout — same trade-off as the existing `useRowSelection.component.test.ts`. The Pest feature test covers the controller + Inertia payload contract.

## Test plan

- [x] `php artisan test` — 548 tests / 1745 assertions, green
- [x] `npm run test` — 44 Vitest tests, green (3 new in `ReservationThreadHistory.test.ts`)
- [x] `npm run build` — TS check + Vite build, green
- [x] `./vendor/bin/pint --test` — pass
- [x] `npm run lint` / `npm run format:check` — clean

New cases:
- Pest `DashboardTest::test_thread_messages_prop_is_loaded_when_drawer_is_open` — asserts chronological order + direction values
- Pest `DashboardTest::test_thread_messages_prop_is_null_when_drawer_is_closed`
- Vitest `ReservationThreadHistory > renders the empty state when there are no messages`
- Vitest `ReservationThreadHistory > renders a chronological list of inbound and outbound messages` — asserts outbound shows approver, inbound does not
- Vitest `ReservationThreadHistory > renders the loading state when messages are null and loading is true`

Closes #209