### PR TITLE
Threading .eml fixtures + ThreadResolverFixtureTest (#210)

### DIFF
--- a/tests/Fixtures/emails/threading/reply-heuristic-match.eml
+++ b/tests/Fixtures/emails/threading/reply-heuristic-match.eml
@@ -1,0 +1,12 @@
+From: Anna Müller <anna.mueller@example.com>
+To: reservierung@restaurant.example
+Subject: Re: Reservierung am 12.05.
+Date: Wed, 29 Apr 2026 18:50:00 +0200
+Message-ID: <inbound-reply-heuristic-001@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Kein Threading-Header und kein Marker, aber der Subject passt zur letzten
+ausgehenden Mail dieser Reservierung und der Absender stimmt mit dem
+Gast-Mail überein.

--- a/tests/Fixtures/emails/threading/reply-no-match.eml
+++ b/tests/Fixtures/emails/threading/reply-no-match.eml
@@ -1,0 +1,11 @@
+From: Stranger <stranger@example.com>
+To: reservierung@restaurant.example
+Subject: Anfrage zur Speisekarte
+Date: Wed, 29 Apr 2026 18:55:00 +0200
+Message-ID: <inbound-no-match-001@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Hallo, ich hätte gerne ein paar Informationen zu Ihrer Speisekarte. Das
+ist keine Reservierungsanfrage und sollte keinen bestehenden Thread treffen.

--- a/tests/Fixtures/emails/threading/reply-spoofed-in-reply-to.eml
+++ b/tests/Fixtures/emails/threading/reply-spoofed-in-reply-to.eml
@@ -1,0 +1,12 @@
+From: Attacker <attacker@example.com>
+To: reservierung@restaurant.example
+Subject: Re: Reservierung bei Le Bistro
+Date: Wed, 29 Apr 2026 18:45:00 +0200
+Message-ID: <inbound-reply-spoof-001@example.com>
+In-Reply-To: <outbound-thread-id-001@restaurant.example>
+References: <outbound-thread-id-001@restaurant.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Ich versuche den Thread einer fremden Reservierung zu kapern.

--- a/tests/Fixtures/emails/threading/reply-with-in-reply-to.eml
+++ b/tests/Fixtures/emails/threading/reply-with-in-reply-to.eml
@@ -1,0 +1,17 @@
+From: Anna Müller <anna.mueller@example.com>
+To: reservierung@restaurant.example
+Subject: Re: Reservierung bei Le Bistro [Res #1]
+Date: Wed, 29 Apr 2026 18:30:00 +0200
+Message-ID: <inbound-reply-irt-001@example.com>
+In-Reply-To: <outbound-thread-id-001@restaurant.example>
+References: <outbound-thread-id-001@restaurant.example>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Hallo,
+
+vielen Dank für die Bestätigung. Wir kommen wie geplant um 19:30.
+
+Gruß,
+Anna Müller

--- a/tests/Fixtures/emails/threading/reply-with-references-only.eml
+++ b/tests/Fixtures/emails/threading/reply-with-references-only.eml
@@ -1,0 +1,13 @@
+From: Anna Müller <anna.mueller@example.com>
+To: reservierung@restaurant.example
+Subject: Re: Reservierung bei Le Bistro [Res #1]
+Date: Wed, 29 Apr 2026 18:35:00 +0200
+Message-ID: <inbound-reply-refs-001@example.com>
+In-Reply-To: <unknown-deadbeef@somewhere.example>
+References: <root-of-thread@example.com> <outbound-thread-id-001@restaurant.example> <unrelated@example.org>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Mein Mailclient hat die In-Reply-To-Kette verloren, aber der References-Header
+sollte noch reichen, um die Reservierung wiederzufinden.

--- a/tests/Fixtures/emails/threading/reply-with-subject-marker-only.eml
+++ b/tests/Fixtures/emails/threading/reply-with-subject-marker-only.eml
@@ -1,0 +1,10 @@
+From: Anna Müller <anna.mueller@example.com>
+To: reservierung@restaurant.example
+Subject: Re: [Res #1] Frage zur Reservierung
+Date: Wed, 29 Apr 2026 18:40:00 +0200
+Message-ID: <inbound-reply-marker-001@example.com>
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Mein Mailclient verwirft Threading-Header, aber der Subject-Marker bleibt.

--- a/tests/Unit/Services/Email/ThreadResolverFixtureTest.php
+++ b/tests/Unit/Services/Email/ThreadResolverFixtureTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Email;
+
+use App\Models\ReservationMessage;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Email\DTO\FetchedEmail;
+use App\Services\Email\ThreadResolver;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Tests\TestCase;
+use Webklex\PHPIMAP\Message;
+
+/**
+ * Fixture-driven counterpart to ThreadResolverTest. Loads real RFC-2822 .eml
+ * files from tests/Fixtures/emails/threading/ via Webklex's Message::fromFile,
+ * lifts them into the FetchedEmail DTO the resolver consumes (matching the
+ * conversion done by WebklexImapMailbox in production), and runs the same
+ * cascade against a per-test factory seed.
+ */
+class ThreadResolverFixtureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const FIXTURE_DIR = __DIR__.'/../../../Fixtures/emails/threading';
+
+    // Stored without angle brackets — matches the convention used everywhere
+    // else in the codebase (WebklexImapMailbox writes the bare id from the
+    // Webklex Message API, and SendReservationReplyJob does the same).
+    private const KNOWN_OUTBOUND_ID = 'outbound-thread-id-001@restaurant.example';
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    public function test_it_resolves_by_in_reply_to_header(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+
+        $resolved = $this->resolver()
+            ->resolveForIncoming($this->loadFixtureAsEmail('reply-with-in-reply-to.eml'), $request->restaurant_id);
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_it_resolves_by_references_chain(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+
+        $resolved = $this->resolver()
+            ->resolveForIncoming($this->loadFixtureAsEmail('reply-with-references-only.eml'), $request->restaurant_id);
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_it_resolves_by_subject_marker(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+
+        $resolved = $this->resolver()
+            ->resolveForIncoming($this->loadFixtureAsEmail('reply-with-subject-marker-only.eml'), $request->restaurant_id);
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_it_resolves_by_heuristic_when_within_30_days(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+        ReservationMessage::factory()->outbound()->forReservationRequest($request)->create([
+            'subject' => 'Reservierung am 12.05.',
+            'sent_at' => now()->subDays(3),
+        ]);
+
+        $resolved = $this->resolver()
+            ->resolveForIncoming($this->loadFixtureAsEmail('reply-heuristic-match.eml'), $request->restaurant_id);
+
+        $this->assertNotNull($resolved);
+        $this->assertSame($request->id, $resolved->id);
+    }
+
+    public function test_it_does_not_resolve_by_heuristic_when_older_than_30_days(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+        ReservationMessage::factory()->outbound()->forReservationRequest($request)->create([
+            'subject' => 'Reservierung am 12.05.',
+            'sent_at' => now()->subDays(45),
+        ]);
+
+        $resolved = $this->resolver()
+            ->resolveForIncoming($this->loadFixtureAsEmail('reply-heuristic-match.eml'), $request->restaurant_id);
+
+        $this->assertNull(
+            $resolved,
+            'Heuristic must not match an outbound mail older than the 30-day window.',
+        );
+    }
+
+    public function test_it_rejects_spoofed_in_reply_to_when_sender_does_not_match(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+
+        $logger = Mockery::mock(LoggerInterface::class);
+        $logger->shouldReceive('warning')->once();
+
+        $resolver = new ThreadResolver($logger);
+
+        $resolved = $resolver->resolveForIncoming(
+            $this->loadFixtureAsEmail('reply-spoofed-in-reply-to.eml'),
+            $request->restaurant_id,
+        );
+
+        $this->assertNull($resolved, 'A spoofed In-Reply-To from the wrong sender must not yield a thread match.');
+    }
+
+    public function test_it_returns_null_when_no_strategy_matches(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+
+        $resolved = $this->resolver()
+            ->resolveForIncoming($this->loadFixtureAsEmail('reply-no-match.eml'), $request->restaurant_id);
+
+        $this->assertNull($resolved);
+    }
+
+    public function test_it_does_not_match_across_restaurants(): void
+    {
+        $request = $this->seedReservationWithOutboundMessage();
+        $otherRestaurant = Restaurant::factory()->create();
+
+        $resolved = $this->resolver()
+            ->resolveForIncoming($this->loadFixtureAsEmail('reply-with-in-reply-to.eml'), $otherRestaurant->id);
+
+        $this->assertNull(
+            $resolved,
+            'A thread match against restaurant A must not resolve when the inbound mail targets restaurant B.',
+        );
+    }
+
+    private function resolver(): ThreadResolver
+    {
+        return new ThreadResolver(new NullLogger);
+    }
+
+    private function seedReservationWithOutboundMessage(): ReservationRequest
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'anna.mueller@example.com',
+            'id' => 1,
+        ]);
+
+        ReservationMessage::factory()
+            ->outbound()
+            ->forReservationRequest($request)
+            ->create([
+                'message_id' => self::KNOWN_OUTBOUND_ID,
+                'sent_at' => now()->subHour(),
+            ]);
+
+        return $request;
+    }
+
+    private function loadFixtureAsEmail(string $filename): FetchedEmail
+    {
+        $path = self::FIXTURE_DIR.'/'.$filename;
+
+        $this->assertFileExists($path, "Missing fixture: {$filename}");
+
+        $message = Message::fromFile($path);
+
+        $from = $message->getFrom()[0] ?? null;
+
+        return new FetchedEmail(
+            messageId: trim((string) $message->getMessageId()),
+            body: trim($message->hasTextBody() ? $message->getTextBody() : ''),
+            senderEmail: $from?->mail ?? '',
+            senderName: $from?->personal !== '' ? ($from?->personal ?? null) : null,
+            rawHeaders: (string) $message->getHeader()->raw,
+            rawBody: trim($message->hasTextBody() ? $message->getTextBody() : ''),
+            inReplyTo: trim((string) $message->getInReplyTo()),
+            references: trim((string) $message->getReferences()),
+            subject: trim((string) $message->getSubject()),
+            toAddress: '',
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Six RFC-2822 \`.eml\` fixtures land in \`tests/Fixtures/emails/threading/\`:

- \`reply-with-in-reply-to.eml\` — header-based match
- \`reply-with-references-only.eml\` — In-Reply-To unknown, References hits
- \`reply-with-subject-marker-only.eml\` — header-less, marker present
- \`reply-spoofed-in-reply-to.eml\` — header points at a known id, sender differs
- \`reply-heuristic-match.eml\` — Re: prefix + recent outbound subject + matching sender
- \`reply-no-match.eml\` — control case

A new \`ThreadResolverFixtureTest\` loads each fixture via Webklex's \`Message::fromFile\`, lifts the relevant headers into a \`FetchedEmail\` DTO (mirroring the \`WebklexImapMailbox\` conversion in production), and runs the eight cases the PRD lists in PRD-006 § Tests.

## Why

The existing \`ThreadResolverTest\` covers the cascade with hand-built DTOs. This PR proves the same behavior holds when the inbound side is real RFC-2822 text — including the bracket-stripping behavior of Webklex's header accessors. That last point is load-bearing: storage convention is bare ids (no angle brackets), and the fixture suite makes the convention regression-proof.

## Notable decisions

- **Tests live at \`tests/Unit/Services/Email/ThreadResolverFixtureTest.php\`** rather than the issue's suggested \`tests/Unit/Email/\` to match the established repo convention (sibling: \`EmailReservationParserFixtureTest\`).
- **Bare Message-IDs in the seed**: \`KNOWN_OUTBOUND_ID = 'outbound-thread-id-001@restaurant.example'\` (no \`<>\`). Documented inline. The .eml files use proper RFC \`<...>\` framing; Webklex strips it on read; storage is bare both in production (\`WebklexImapMailbox\`, \`SendReservationReplyJob\`) and in this fixture seed.

## Test plan

- [x] \`php artisan test --filter=ThreadResolverFixtureTest\` — 8 cases / 20 assertions, green
- [x] \`php artisan test\` — 556 tests / 1765 assertions, green
- [x] \`./vendor/bin/pint --test\` — pass
- [x] \`npm run lint\` / \`npm run format:check\` — clean

Closes #210