### PR TITLE
End-to-end ThreadingFlow test using .eml fixture (#211)

### DIFF
--- a/tests/Feature/Email/ThreadingFlowTest.php
+++ b/tests/Feature/Email/ThreadingFlowTest.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Mail;
 use Tests\Support\Email\FakeImapMailboxFactory;
 use Tests\TestCase;
+use Webklex\PHPIMAP\Message;
 
 class ThreadingFlowTest extends TestCase
 {
@@ -417,5 +418,75 @@ class ThreadingFlowTest extends TestCase
         $response->assertOk();
         $response->assertJsonMissingPath('data.0.raw_headers');
         $this->assertStringNotContainsString($secret, $response->getContent() ?: '');
+    }
+
+    public function test_fetch_job_threads_an_inbound_eml_fixture_via_in_reply_to_header_end_to_end(): void
+    {
+        // Reuses the .eml fixture from #210. The flow under test:
+        //   .eml → Webklex Message → FetchedEmail (via the same conversion
+        //   the production WebklexImapMailbox does) → fed through the fake
+        //   mailbox factory → FetchReservationEmailsJob → ThreadResolver →
+        //   ReservationMessage row appended on the existing reservation,
+        //   no new ReservationRequest created.
+        $restaurant = Restaurant::factory()->create([
+            'imap_host' => 'mail.example.com',
+            'imap_username' => 'mailbox@example.com',
+            'imap_password' => 'secret',
+        ]);
+        $request = ReservationRequest::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'guest_email' => 'anna.mueller@example.com',
+        ]);
+        ReservationMessage::factory()
+            ->outbound()
+            ->forReservationRequest($request)
+            ->create([
+                'message_id' => 'outbound-thread-id-001@restaurant.example',
+                'sent_at' => now()->subHour(),
+            ]);
+
+        $email = $this->loadFixtureAsEmail(__DIR__.'/../../Fixtures/emails/threading/reply-with-in-reply-to.eml');
+
+        $this->runJobWith($restaurant->id, [$email]);
+
+        $this->assertSame(
+            1,
+            ReservationRequest::query()->where('restaurant_id', $restaurant->id)->count(),
+            'Fixture-driven inbound reply must thread, not create a new reservation.',
+        );
+        $this->assertSame(
+            1,
+            ReservationMessage::query()
+                ->where('reservation_request_id', $request->id)
+                ->where('direction', MessageDirection::In)
+                ->count(),
+            'Fixture-driven reply must be appended as an inbound ReservationMessage.',
+        );
+        $this->assertDatabaseHas('reservation_messages', [
+            'reservation_request_id' => $request->id,
+            'direction' => MessageDirection::In->value,
+            'message_id' => 'inbound-reply-irt-001@example.com',
+        ]);
+    }
+
+    private function loadFixtureAsEmail(string $path): FetchedEmail
+    {
+        $this->assertFileExists($path, "Missing fixture: {$path}");
+
+        $message = Message::fromFile($path);
+        $from = $message->getFrom()[0] ?? null;
+
+        return new FetchedEmail(
+            messageId: trim((string) $message->getMessageId()),
+            body: trim($message->hasTextBody() ? $message->getTextBody() : ''),
+            senderEmail: $from?->mail ?? '',
+            senderName: $from?->personal !== '' ? ($from?->personal ?? null) : null,
+            rawHeaders: (string) $message->getHeader()->raw,
+            rawBody: trim($message->hasTextBody() ? $message->getTextBody() : ''),
+            inReplyTo: trim((string) $message->getInReplyTo()),
+            references: trim((string) $message->getReferences()),
+            subject: trim((string) $message->getSubject()),
+            toAddress: 'mailbox@example.com',
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes the PRD-006 feature suite. The seven cases the issue lists were already shipped piecewise across #205, #206, #207, and #208 — all live in \`tests/Feature/Email/ThreadingFlowTest\`. This PR adds the missing "reuse the .eml fixtures" case the issue note explicitly asks for.

| AC case | Where it lives |
|---|---|
| \`it appends reply as thread message instead of creating new reservation\` | #205 (PR #257) |
| \`it falls back to new reservation when sender does not match\` | #205 (PR #257) |
| \`it generates stable message id for outbound mail\` | #206 (PR #258) |
| \`it inserts subject marker for outbound mail\` | #206 (PR #258) |
| \`it builds references chain on second outbound mail\` | #207 (PR #259) |
| \`it dedupes by message id even with thread fallback\` | #205 (PR #257) |
| \`it lists thread messages in detail drawer chronologically\` | #208 (PR #260) |

## Why

The note "Reuse the fixtures from the sister issue" required a fixture-driven Feature path. The new test runs a real RFC-2822 fixture from \`tests/Fixtures/emails/threading/\` (added in #210) all the way through:

\`.eml → Webklex Message → FetchedEmail → FakeImapMailboxFactory → FetchReservationEmailsJob → ThreadResolver → ReservationMessage row\`

This catches any regression in the bracket-stripping + storage convention chain that the in-memory DTO tests would miss.

## Test plan

- [x] \`php artisan test --filter=ThreadingFlowTest\` — 17 cases / 43 assertions, green
- [x] \`php artisan test\` — 557 tests / 1769 assertions, green
- [x] \`./vendor/bin/pint --test\` — pass
- [x] \`npm run lint\` / \`npm run format:check\` — clean

Closes #211