### PR TITLE
PRD-007 schema: send-mode columns + auto_send_audits (#212)

### DIFF
--- a/database/migrations/2026_04_30_000001_add_send_mode_to_restaurants_table.php
+++ b/database/migrations/2026_04_30_000001_add_send_mode_to_restaurants_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->string('send_mode')->default('manual')->after('imap_password');
+            $table->unsignedInteger('auto_send_party_size_max')->default(10)->after('send_mode');
+            $table->unsignedInteger('auto_send_min_lead_time_minutes')->default(90)->after('auto_send_party_size_max');
+            $table->dateTime('send_mode_changed_at')->nullable()->after('auto_send_min_lead_time_minutes');
+            $table->foreignId('send_mode_changed_by')
+                ->nullable()
+                ->after('send_mode_changed_at')
+                ->constrained('users')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->dropForeign(['send_mode_changed_by']);
+            $table->dropColumn([
+                'send_mode',
+                'auto_send_party_size_max',
+                'auto_send_min_lead_time_minutes',
+                'send_mode_changed_at',
+                'send_mode_changed_by',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_04_30_000002_add_send_mode_snapshot_to_reservation_replies_table.php
+++ b/database/migrations/2026_04_30_000002_add_send_mode_snapshot_to_reservation_replies_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->string('send_mode_at_creation')->nullable()->after('outbound_message_id');
+            $table->dateTime('shadow_compared_at')->nullable()->after('send_mode_at_creation');
+            $table->boolean('shadow_was_modified')->default(false)->after('shadow_compared_at');
+            $table->json('auto_send_decision')->nullable()->after('shadow_was_modified');
+            $table->dateTime('auto_send_scheduled_for')->nullable()->after('auto_send_decision');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->dropColumn([
+                'send_mode_at_creation',
+                'shadow_compared_at',
+                'shadow_was_modified',
+                'auto_send_decision',
+                'auto_send_scheduled_for',
+            ]);
+        });
+    }
+};

--- a/database/migrations/2026_04_30_000003_create_auto_send_audits_table.php
+++ b/database/migrations/2026_04_30_000003_create_auto_send_audits_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('auto_send_audits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reservation_reply_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('send_mode');
+            $table->string('decision');
+            $table->string('reason');
+            $table->foreignId('triggered_by_user_id')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            // Append-only: only created_at, no updated_at, no soft-deletes.
+            $table->dateTime('created_at')->useCurrent();
+
+            $table->index(['restaurant_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('auto_send_audits');
+    }
+};

--- a/tests/Feature/Database/AutoSendSchemaTest.php
+++ b/tests/Feature/Database/AutoSendSchemaTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Database;
+
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class AutoSendSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_restaurants_carry_the_send_mode_columns_with_documented_defaults(): void
+    {
+        $restaurant = Restaurant::factory()->create()->refresh();
+
+        $this->assertSame('manual', $restaurant->send_mode);
+        $this->assertSame(10, (int) $restaurant->auto_send_party_size_max);
+        $this->assertSame(90, (int) $restaurant->auto_send_min_lead_time_minutes);
+        $this->assertNull($restaurant->send_mode_changed_at);
+        $this->assertNull($restaurant->send_mode_changed_by);
+    }
+
+    public function test_send_mode_changed_by_nulls_out_when_the_referenced_user_is_deleted(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        DB::table('restaurants')
+            ->where('id', $restaurant->id)
+            ->update(['send_mode_changed_by' => $user->id, 'send_mode_changed_at' => now()]);
+
+        $user->delete();
+
+        $this->assertNull(DB::table('restaurants')->where('id', $restaurant->id)->value('send_mode_changed_by'));
+    }
+
+    public function test_reservation_replies_carry_the_send_mode_snapshot_columns(): void
+    {
+        $request = ReservationRequest::factory()->create();
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+        ])->refresh();
+
+        $this->assertNull($reply->send_mode_at_creation);
+        $this->assertNull($reply->shadow_compared_at);
+        $this->assertSame(0, (int) $reply->shadow_was_modified);
+        $this->assertNull($reply->auto_send_decision);
+        $this->assertNull($reply->auto_send_scheduled_for);
+    }
+
+    public function test_auto_send_audits_table_is_append_only_and_indexed_for_analytics(): void
+    {
+        $this->assertTrue(Schema::hasTable('auto_send_audits'));
+
+        $columns = Schema::getColumnListing('auto_send_audits');
+
+        // Append-only: created_at present, updated_at absent.
+        $this->assertContains('created_at', $columns);
+        $this->assertNotContains('updated_at', $columns);
+
+        foreach (['reservation_reply_id', 'restaurant_id', 'send_mode', 'decision', 'reason', 'triggered_by_user_id'] as $column) {
+            $this->assertContains($column, $columns, "Missing column: {$column}");
+        }
+
+        // PRD-008 analytics relies on the (restaurant_id, created_at) index.
+        $indexes = collect(Schema::getIndexes('auto_send_audits'));
+        $hasCompositeIndex = $indexes->contains(fn ($index) => $index['columns'] === ['restaurant_id', 'created_at']);
+
+        $this->assertTrue($hasCompositeIndex, 'auto_send_audits needs a composite (restaurant_id, created_at) index for PRD-008 analytics.');
+    }
+
+    public function test_auto_send_audits_cascade_when_the_parent_reply_is_deleted(): void
+    {
+        $request = ReservationRequest::factory()->create();
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+        ]);
+
+        DB::table('auto_send_audits')->insert([
+            'reservation_reply_id' => $reply->id,
+            'restaurant_id' => $request->restaurant_id,
+            'send_mode' => 'manual',
+            'decision' => 'allowed',
+            'reason' => 'manual mode short-circuits decider',
+            'created_at' => now(),
+        ]);
+
+        DB::table('reservation_replies')->where('id', $reply->id)->delete();
+
+        $this->assertSame(0, DB::table('auto_send_audits')->count());
+    }
+}


### PR DESCRIPTION
## Summary

Three migrations land the data-model foundation for auto-send modes (PRD-007):

- \`restaurants\`: \`send_mode\` (default \`manual\`), \`auto_send_party_size_max\` (default 10), \`auto_send_min_lead_time_minutes\` (default 90), \`send_mode_changed_at\` (nullable), \`send_mode_changed_by\` (FK to \`users\`, \`nullOnDelete\`).
- \`reservation_replies\`: \`send_mode_at_creation\` (intentional snapshot), \`shadow_compared_at\`, \`shadow_was_modified\` (default false), \`auto_send_decision\` (json), \`auto_send_scheduled_for\`.
- \`auto_send_audits\`: append-only table with \`reservation_reply_id\` + \`restaurant_id\` (both cascade), \`send_mode\` / \`decision\` / \`reason\` strings, \`triggered_by_user_id\` (nullable — null = system actor), \`created_at\` only (no \`updated_at\`), composite \`(restaurant_id, created_at)\` index for PRD-008 analytics.

## Why

This is the foundation issue for the PRD-007 chain (#213–#223). Splitting the schema into three coherent migrations keeps each one's intent narrow and the rollback boundary clean.

## Notable decisions

- **\`send_mode_at_creation\` is intentionally a snapshot**, not a join target — the restaurant's mode can change after a reply is drafted, and the audit trail needs to know what the mode was when the decision was made. Documented in the issue notes and worth preserving when the writer code lands in #214.
- **\`auto_send_audits\` is append-only** — \`created_at\` only, no \`updated_at\`, no soft-deletes. Tested explicitly via column-listing assertion.
- **\`nullOnDelete\` on \`send_mode_changed_by\` and \`triggered_by_user_id\`** so deleting an operator (e.g. staff offboarding) doesn't break the audit trail or the restaurant row — the action's history survives but the actor reference clears.

## Test plan

- [x] \`php artisan test\` — 562 tests / 1791 assertions, green
- [x] \`php artisan migrate:fresh --env=testing\` — all migrations apply cleanly
- [x] \`./vendor/bin/pint --test\` — pass
- [x] \`npm run lint\` / \`npm run format:check\` — clean

New \`AutoSendSchemaTest\`:
- \`restaurants_carry_the_send_mode_columns_with_documented_defaults\`
- \`send_mode_changed_by_nulls_out_when_the_referenced_user_is_deleted\`
- \`reservation_replies_carry_the_send_mode_snapshot_columns\`
- \`auto_send_audits_table_is_append_only_and_indexed_for_analytics\`
- \`auto_send_audits_cascade_when_the_parent_reply_is_deleted\`

Closes #212