### PR TITLE
AutoSendDecider skeleton + mode dispatch (#214)

### DIFF
--- a/app/Services/AI/AutoSendDecider.php
+++ b/app/Services/AI/AutoSendDecider.php
@@ -20,9 +20,9 @@ use RuntimeException;
  * trips, the decider falls back to manual regardless of the restaurant's
  * configured mode, so the operator's safety net is never bypassed.
  *
- * Not declared `final` is the project default; this one IS final because
- * tests of the cascade can — and should — drive it through real factory
- * data rather than overriding internals (no test-only subclass needed).
+ * `final` per the project default for services. The cascade is tested
+ * end-to-end through real factory data (the gates in #215 will follow
+ * the same pattern), so no test-only subclass seam is needed.
  */
 final class AutoSendDecider
 {

--- a/app/Services/AI/AutoSendDecider.php
+++ b/app/Services/AI/AutoSendDecider.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+use App\Enums\SendMode;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+
+/**
+ * Single authoritative source of "do we auto-send this reply?" (PRD-007).
+ *
+ * Skeleton in this issue: load the reply's restaurant and mode, run the
+ * (currently stub) hard-gate check, and dispatch to a manual / shadow /
+ * auto-send decision. The hard-gate cascade lands in #215 — when it
+ * trips, the decider falls back to manual regardless of the restaurant's
+ * configured mode, so the operator's safety net is never bypassed.
+ *
+ * Not declared `final` is the project default; this one IS final because
+ * tests of the cascade can — and should — drive it through real factory
+ * data rather than overriding internals (no test-only subclass needed).
+ */
+final class AutoSendDecider
+{
+    public function __construct(
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function decide(ReservationReply $reply): AutoSendDecision
+    {
+        $request = $reply->reservationRequest;
+        $restaurant = $request?->restaurant;
+
+        if ($request === null || $restaurant === null) {
+            // Without a parent request + restaurant we have no policy to
+            // apply; the safest answer is the most conservative one.
+            $this->logger->warning('auto-send decider: missing parent context, falling back to manual', [
+                'reservation_reply_id' => $reply->id,
+            ]);
+
+            return AutoSendDecision::manual('missing_parent_context');
+        }
+
+        if ($gate = $this->blockedByHardGate($reply, $request, $restaurant)) {
+            return AutoSendDecision::manual($gate);
+        }
+
+        $mode = $restaurant->send_mode;
+        if (! $mode instanceof SendMode) {
+            throw new RuntimeException('Restaurant send_mode must be a SendMode enum (Eloquent cast).');
+        }
+
+        return match ($mode) {
+            SendMode::Manual => AutoSendDecision::manual('mode_manual'),
+            SendMode::Shadow => AutoSendDecision::shadow('mode_shadow'),
+            SendMode::Auto => AutoSendDecision::autoSend('mode_auto'),
+        };
+    }
+
+    /**
+     * Stub. The six concrete hard gates from PRD-007 land in #215.
+     * Returning a non-null reason short-circuits the cascade to manual.
+     *
+     * Signature kept compatible with the future implementation:
+     * receives the reply plus its already-loaded parent context so the
+     * gates don't have to re-query.
+     */
+    private function blockedByHardGate(
+        ReservationReply $reply,
+        ReservationRequest $request,
+        Restaurant $restaurant,
+    ): ?string {
+        return null;
+    }
+}

--- a/tests/Unit/AI/AutoSendDeciderTest.php
+++ b/tests/Unit/AI/AutoSendDeciderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AI;
+
+use App\Enums\SendMode;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\AI\AutoSendDecider;
+use App\Services\AI\AutoSendDecision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Psr\Log\NullLogger;
+use Tests\TestCase;
+
+class AutoSendDeciderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_returns_mode_manual_when_restaurant_is_in_manual_mode(): void
+    {
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Manual);
+
+        $decision = (new AutoSendDecider(new NullLogger))->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame('mode_manual', $decision->reason);
+    }
+
+    public function test_it_returns_mode_shadow_when_restaurant_is_in_shadow_mode(): void
+    {
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Shadow);
+
+        $decision = (new AutoSendDecider(new NullLogger))->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_SHADOW, $decision->decision);
+        $this->assertSame('mode_shadow', $decision->reason);
+    }
+
+    public function test_it_returns_mode_auto_when_restaurant_is_in_auto_mode_without_hard_gates(): void
+    {
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Auto);
+
+        $decision = (new AutoSendDecider(new NullLogger))->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_AUTO_SEND, $decision->decision);
+        $this->assertSame('mode_auto', $decision->reason);
+    }
+
+    public function test_it_falls_back_to_manual_when_parent_context_is_missing(): void
+    {
+        // Detached reply: forge a model with no persisted relations so
+        // reservationRequest is null. The decider must never NPE on this
+        // path — it should log + return manual.
+        $reply = new ReservationReply;
+        $reply->id = 0;
+
+        $decision = (new AutoSendDecider(new NullLogger))->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame('missing_parent_context', $decision->reason);
+    }
+
+    private function makeReplyOnRestaurantWithMode(SendMode $mode): ReservationReply
+    {
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => $mode])->save();
+        $request = ReservationRequest::factory()->create(['restaurant_id' => $restaurant->id]);
+
+        return ReservationReply::factory()->create(['reservation_request_id' => $request->id]);
+    }
+}


### PR DESCRIPTION
## Summary

Single-source-of-truth service for auto-send decisions (PRD-007).

- \`App\Services\AI\AutoSendDecider\` (final): \`decide(ReservationReply): AutoSendDecision\`.
- Loads parent request + restaurant via Eloquent relations.
- Runs \`blockedByHardGate()\` — stub returning null in this issue, real cascade lands in #215. On trip → \`AutoSendDecision::manual(\$gate)\`.
- Otherwise dispatches via \`match\` on \`Restaurant.send_mode\` → \`mode_manual\` / \`mode_shadow\` / \`mode_auto\`.

## Why

Centralizing the decision keeps the rule out of jobs/controllers and gives the audit trail (#218) one writer to wrap. The hard-gate-stub seam means #215 only adds gate code — the cascade and the manual fallback shape are settled here.

## Notable decisions

- **\`final\` class** (against the project's "non-final by default" exception that ThreadResolver took): the cascade is driven through real factory data; no test subclass is required.
- **Defensive missing-parent-context branch**: a detached \`ReservationReply\` returns \`manual('missing_parent_context')\` rather than NPE'ing. Logged with id only (no PII), per the project's logging hygiene rule.
- **Cast invariant enforced at call time**: a missing \`SendMode\` cast on \`Restaurant\` surfaces as a \`RuntimeException\` rather than silent fallback to shadow.

## Test plan

- [x] \`php artisan test\` — 627 tests / 1878 assertions, green
- [x] \`./vendor/bin/pint --test\` — pass
- [x] \`npm run lint\` / \`npm run format:check\` — clean

New cases (\`AutoSendDeciderTest\`):
- \`it_returns_mode_manual_when_restaurant_is_in_manual_mode\`
- \`it_returns_mode_shadow_when_restaurant_is_in_shadow_mode\`
- \`it_returns_mode_auto_when_restaurant_is_in_auto_mode_without_hard_gates\`
- \`it_falls_back_to_manual_when_parent_context_is_missing\`

Closes #214