### PR TITLE
Implement six hard-gate cascade in AutoSendDecider (#215)

### DIFF
--- a/app/Services/AI/AutoSendDecider.php
+++ b/app/Services/AI/AutoSendDecider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\AI;
 
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
 use App\Enums\SendMode;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
@@ -14,18 +16,34 @@ use RuntimeException;
 /**
  * Single authoritative source of "do we auto-send this reply?" (PRD-007).
  *
- * Skeleton in this issue: load the reply's restaurant and mode, run the
- * (currently stub) hard-gate check, and dispatch to a manual / shadow /
- * auto-send decision. The hard-gate cascade lands in #215 — when it
- * trips, the decider falls back to manual regardless of the restaurant's
- * configured mode, so the operator's safety net is never bypassed.
+ * The hard-gate cascade lands here: when a gate trips, the decider falls
+ * back to manual regardless of the restaurant's configured mode, so the
+ * operator's safety net is never bypassed. Gate order is significant —
+ * the first matching gate wins and short-circuits later checks.
  *
  * `final` per the project default for services. The cascade is tested
- * end-to-end through real factory data (the gates in #215 will follow
- * the same pattern), so no test-only subclass seam is needed.
+ * end-to-end through real factory data.
  */
 final class AutoSendDecider
 {
+    public const string REASON_NEEDS_MANUAL_REVIEW = 'needs_manual_review';
+
+    public const string REASON_FALLBACK_TEXT = 'fallback_text';
+
+    public const string REASON_PARTY_SIZE_OVER_LIMIT = 'party_size_over_limit';
+
+    public const string REASON_SHORT_NOTICE = 'short_notice';
+
+    public const string REASON_FIRST_TIME_GUEST = 'first_time_guest';
+
+    public const string REASON_LOW_CONFIDENCE_EMAIL = 'low_confidence_email';
+
+    /**
+     * Email-source confidence threshold below which the decider falls
+     * back to manual. Mirrors the PRD-003/PRD-007 contract.
+     */
+    private const float EMAIL_CONFIDENCE_THRESHOLD = 0.9;
+
     public function __construct(
         private readonly LoggerInterface $logger,
     ) {}
@@ -62,18 +80,107 @@ final class AutoSendDecider
     }
 
     /**
-     * Stub. The six concrete hard gates from PRD-007 land in #215.
-     * Returning a non-null reason short-circuits the cascade to manual.
+     * Run the six hard gates in cascade order. The first matching gate
+     * wins; no plugin architecture, V2.0 keeps the order hard-coded so
+     * the audit trail is deterministic.
      *
-     * Signature kept compatible with the future implementation:
-     * receives the reply plus its already-loaded parent context so the
-     * gates don't have to re-query.
+     * The reply, request and restaurant are passed in already-loaded so
+     * gates avoid re-querying parents.
      */
     private function blockedByHardGate(
         ReservationReply $reply,
         ReservationRequest $request,
         Restaurant $restaurant,
     ): ?string {
+        if ($request->needs_manual_review) {
+            return self::REASON_NEEDS_MANUAL_REVIEW;
+        }
+
+        if ($this->isFallbackText($reply)) {
+            return self::REASON_FALLBACK_TEXT;
+        }
+
+        if ($request->party_size > $restaurant->auto_send_party_size_max) {
+            return self::REASON_PARTY_SIZE_OVER_LIMIT;
+        }
+
+        if ($this->isShortNotice($request, $restaurant)) {
+            return self::REASON_SHORT_NOTICE;
+        }
+
+        if ($this->isFirstTimeGuest($request)) {
+            return self::REASON_FIRST_TIME_GUEST;
+        }
+
+        if ($this->isLowConfidenceEmail($request)) {
+            return self::REASON_LOW_CONFIDENCE_EMAIL;
+        }
+
         return null;
+    }
+
+    /**
+     * Match against the PRD-005 fallback constant. PRD-007 risk note
+     * acknowledges the brittleness of string matching; #216 introduces
+     * a dedicated `is_fallback` flag that will replace this check.
+     */
+    private function isFallbackText(ReservationReply $reply): bool
+    {
+        return $reply->body === OpenAiReplyGenerator::FALLBACK_TEXT;
+    }
+
+    /**
+     * True when the requested time is closer than the restaurant's
+     * configured minimum lead time (also true if `desired_at` already
+     * lies in the past — those need an operator regardless).
+     */
+    private function isShortNotice(ReservationRequest $request, Restaurant $restaurant): bool
+    {
+        if ($request->desired_at === null) {
+            return false;
+        }
+
+        $minutesUntilDesired = now()->diffInMinutes($request->desired_at, false);
+
+        return $minutesUntilDesired < $restaurant->auto_send_min_lead_time_minutes;
+    }
+
+    /**
+     * Trust requires a prior **confirmed** reservation under the same
+     * guest email at the same restaurant. Declined / replied / cancelled
+     * histories don't qualify — those signal trouble or attrition, not
+     * a returning guest. Anonymous requests (no email) are treated as
+     * first-time on purpose.
+     */
+    private function isFirstTimeGuest(ReservationRequest $request): bool
+    {
+        if ($request->guest_email === null || $request->guest_email === '') {
+            return true;
+        }
+
+        return ReservationRequest::query()
+            ->where('restaurant_id', $request->restaurant_id)
+            ->where('guest_email', $request->guest_email)
+            ->where('id', '!=', $request->id)
+            ->where('status', ReservationStatus::Confirmed)
+            ->doesntExist();
+    }
+
+    /**
+     * Email-sourced requests carry a parser confidence in `raw_payload`
+     * (PRD-003). Below 0.9 the parse is too uncertain to trust for an
+     * automated send. Web-form requests bypass this gate entirely —
+     * structured input has no parsing step.
+     */
+    private function isLowConfidenceEmail(ReservationRequest $request): bool
+    {
+        if ($request->source !== ReservationSource::Email) {
+            return false;
+        }
+
+        $payload = $request->raw_payload;
+        $confidence = is_array($payload) ? ($payload['confidence'] ?? 0) : 0;
+
+        return (float) $confidence < self::EMAIL_CONFIDENCE_THRESHOLD;
     }
 }

--- a/tests/Unit/AI/AutoSendDeciderTest.php
+++ b/tests/Unit/AI/AutoSendDeciderTest.php
@@ -4,13 +4,17 @@ declare(strict_types=1);
 
 namespace Tests\Unit\AI;
 
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
 use App\Enums\SendMode;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Services\AI\AutoSendDecider;
 use App\Services\AI\AutoSendDecision;
+use App\Services\AI\OpenAiReplyGenerator;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
 use Psr\Log\NullLogger;
 use Tests\TestCase;
 
@@ -62,12 +66,166 @@ class AutoSendDeciderTest extends TestCase
         $this->assertSame('missing_parent_context', $decision->reason);
     }
 
-    private function makeReplyOnRestaurantWithMode(SendMode $mode): ReservationReply
+    public function test_it_blocks_auto_send_when_needs_manual_review_is_true(): void
     {
-        $restaurant = Restaurant::factory()->create();
-        $restaurant->forceFill(['send_mode' => $mode])->save();
-        $request = ReservationRequest::factory()->create(['restaurant_id' => $restaurant->id]);
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Auto, requestOverrides: [
+            'needs_manual_review' => true,
+        ]);
 
-        return ReservationReply::factory()->create(['reservation_request_id' => $request->id]);
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_NEEDS_MANUAL_REVIEW, $decision->reason);
+    }
+
+    public function test_it_blocks_auto_send_for_fallback_text(): void
+    {
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Auto, replyOverrides: [
+            'body' => OpenAiReplyGenerator::FALLBACK_TEXT,
+        ]);
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_FALLBACK_TEXT, $decision->reason);
+    }
+
+    public function test_it_blocks_auto_send_when_party_size_exceeds_limit(): void
+    {
+        $reply = $this->makeReplyOnRestaurantWithMode(
+            SendMode::Auto,
+            restaurantOverrides: ['auto_send_party_size_max' => 6],
+            requestOverrides: ['party_size' => 7],
+        );
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_PARTY_SIZE_OVER_LIMIT, $decision->reason);
+    }
+
+    public function test_it_blocks_auto_send_for_short_notice_requests(): void
+    {
+        Carbon::setTestNow('2026-04-30 18:00:00');
+
+        $reply = $this->makeReplyOnRestaurantWithMode(
+            SendMode::Auto,
+            restaurantOverrides: ['auto_send_min_lead_time_minutes' => 90],
+            requestOverrides: ['desired_at' => Carbon::parse('2026-04-30 19:00:00')], // 60 min away
+        );
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_SHORT_NOTICE, $decision->reason);
+    }
+
+    public function test_it_blocks_auto_send_for_first_time_guests(): void
+    {
+        $reply = $this->makeReplyOnRestaurantWithMode(
+            SendMode::Auto,
+            requestOverrides: ['guest_email' => 'newcomer@example.com'],
+            seedPriorConfirmed: false,
+        );
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_FIRST_TIME_GUEST, $decision->reason);
+    }
+
+    public function test_it_blocks_auto_send_for_low_confidence_email_parses(): void
+    {
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Auto, requestOverrides: [
+            'source' => ReservationSource::Email,
+            'raw_payload' => ['confidence' => 0.7],
+        ]);
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_LOW_CONFIDENCE_EMAIL, $decision->reason);
+    }
+
+    public function test_it_considers_a_guest_with_prior_confirmed_reservation_as_returning(): void
+    {
+        // Default helper already seeds a prior confirmed reservation for
+        // the guest's email — that's exactly the scenario this test
+        // documents. We still assert it explicitly.
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Auto);
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_AUTO_SEND, $decision->decision);
+        $this->assertSame('mode_auto', $decision->reason);
+    }
+
+    public function test_it_counts_a_guest_with_only_declined_prior_reservations_as_first_time(): void
+    {
+        // Decline doesn't build trust — operator declined for a reason.
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => SendMode::Auto])->save();
+
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'guest_email' => 'declined@example.com',
+            'status' => ReservationStatus::Declined,
+        ]);
+
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'guest_email' => 'declined@example.com',
+            'status' => ReservationStatus::New,
+        ]);
+        $reply = ReservationReply::factory()->create(['reservation_request_id' => $request->id]);
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_FIRST_TIME_GUEST, $decision->reason);
+    }
+
+    private function decide(ReservationReply $reply): AutoSendDecision
+    {
+        return (new AutoSendDecider(new NullLogger))->decide($reply);
+    }
+
+    /**
+     * Build a reply on a configurable restaurant. Mode lives on the
+     * restaurant, but each hard-gate test cares about specific request /
+     * reply / restaurant fields, so they all flow through here as
+     * structured overrides.
+     *
+     * By default the helper seeds a prior `confirmed` reservation for
+     * the guest's email so the `first_time_guest` gate doesn't trip on
+     * unrelated tests. Pass `seedPriorConfirmed: false` to test the
+     * first-time-guest gate explicitly.
+     *
+     * @param  array<string, mixed>  $restaurantOverrides
+     * @param  array<string, mixed>  $requestOverrides
+     * @param  array<string, mixed>  $replyOverrides
+     */
+    private function makeReplyOnRestaurantWithMode(
+        SendMode $mode,
+        array $restaurantOverrides = [],
+        array $requestOverrides = [],
+        array $replyOverrides = [],
+        bool $seedPriorConfirmed = true,
+    ): ReservationReply {
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => $mode] + $restaurantOverrides)->save();
+
+        $request = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create($requestOverrides);
+
+        if ($seedPriorConfirmed && $request->guest_email !== null) {
+            ReservationRequest::factory()->forRestaurant($restaurant)->create([
+                'guest_email' => $request->guest_email,
+                'status' => ReservationStatus::Confirmed,
+            ]);
+        }
+
+        return ReservationReply::factory()->create(
+            ['reservation_request_id' => $request->id] + $replyOverrides
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Replaces the `AutoSendDecider::blockedByHardGate` stub with the full PRD-007 cascade in canonical order: `needs_manual_review`, `fallback_text`, `party_size_over_limit`, `short_notice`, `first_time_guest`, `low_confidence_email`.
- First match wins; later gates short-circuit so each decision carries a single deterministic reason for the audit trail.
- Reason codes are exposed as `AutoSendDecider::REASON_*` constants and referenced from tests, eliminating magic strings.

## Why

PRD-007 (#197) treats the hard-gate cascade as the safety net that fires regardless of the configured send mode. Until now the cascade was a stub: an `auto`-mode restaurant would have auto-sent every reply, including ones for first-time guests, oversized parties, low-confidence email parses, etc. This PR closes that gap so subsequent PRD-007 work (scheduled job, audit writer, killswitch) can build on a real decision source.

## Test plan

- `php artisan test --filter=AutoSendDeciderTest` — 12 tests, including one per hard gate plus the `declined ≠ trust` edge case.
- `php artisan test` — full suite, 635 tests / 1894 assertions green.
- `./vendor/bin/pint --test` — pass.
- `npm run lint` / `npm run format:check` — pass.

Closes #215