### PR TITLE
Add is_fallback flag for robust fallback detection (#216)

### DIFF
--- a/app/Jobs/GenerateReservationReplyJob.php
+++ b/app/Jobs/GenerateReservationReplyJob.php
@@ -124,6 +124,7 @@ class GenerateReservationReplyJob implements ShouldQueue
             'status' => ReservationReplyStatus::Draft,
             'body' => OpenAiReplyGenerator::FALLBACK_TEXT,
             'ai_prompt_snapshot' => $context,
+            'is_fallback' => true,
         ]);
     }
 }

--- a/app/Models/ReservationReply.php
+++ b/app/Models/ReservationReply.php
@@ -31,6 +31,7 @@ class ReservationReply extends Model
         'sent_at',
         'error_message',
         'outbound_message_id',
+        'is_fallback',
     ];
 
     /**
@@ -45,6 +46,7 @@ class ReservationReply extends Model
             'ai_prompt_snapshot' => 'array',
             'approved_at' => 'datetime',
             'sent_at' => 'datetime',
+            'is_fallback' => 'boolean',
         ];
     }
 

--- a/app/Services/AI/AutoSendDecider.php
+++ b/app/Services/AI/AutoSendDecider.php
@@ -120,12 +120,18 @@ final class AutoSendDecider
     }
 
     /**
-     * Match against the PRD-005 fallback constant. PRD-007 risk note
-     * acknowledges the brittleness of string matching; #216 introduces
-     * a dedicated `is_fallback` flag that will replace this check.
+     * The persisted `is_fallback` flag is the authoritative signal — set
+     * by `GenerateReservationReplyJob` on every error path that lands on
+     * the neutral fallback text. The string-equality check stays as
+     * defense-in-depth so a flag-less legacy row (or a future code path
+     * that forgets to flip the flag) is still caught.
      */
     private function isFallbackText(ReservationReply $reply): bool
     {
+        if ($reply->is_fallback === true) {
+            return true;
+        }
+
         return $reply->body === OpenAiReplyGenerator::FALLBACK_TEXT;
     }
 

--- a/database/migrations/2026_04_30_000004_add_is_fallback_to_reservation_replies_table.php
+++ b/database/migrations/2026_04_30_000004_add_is_fallback_to_reservation_replies_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->boolean('is_fallback')->default(false)->after('auto_send_scheduled_for');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->dropColumn('is_fallback');
+        });
+    }
+};

--- a/tests/Feature/Jobs/GenerateReservationReplyJobErrorMatrixTest.php
+++ b/tests/Feature/Jobs/GenerateReservationReplyJobErrorMatrixTest.php
@@ -103,6 +103,7 @@ class GenerateReservationReplyJobErrorMatrixTest extends TestCase
         $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
         $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
         $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+        $this->assertTrue($reply->is_fallback, '401 fallback must set is_fallback flag for the auto-send hard gate.');
     }
 
     public function test_http_429_first_attempt_releases_with_60_seconds_and_writes_no_draft(): void
@@ -132,6 +133,7 @@ class GenerateReservationReplyJobErrorMatrixTest extends TestCase
         /** @var ReservationReply $reply */
         $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
         $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+        $this->assertTrue($reply->is_fallback, '429-after-retry fallback must set is_fallback flag.');
     }
 
     public function test_5xx_or_timeout_falls_back_immediately_with_no_retry(): void
@@ -151,5 +153,25 @@ class GenerateReservationReplyJobErrorMatrixTest extends TestCase
         /** @var ReservationReply $reply */
         $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
         $this->assertSame(OpenAiReplyGenerator::FALLBACK_TEXT, $reply->body);
+        $this->assertTrue($reply->is_fallback, 'timeout / 5xx fallback must set is_fallback flag.');
+    }
+
+    public function test_happy_path_does_not_set_is_fallback_flag(): void
+    {
+        $request = $this->makeRequest();
+        $this->app->bind(ReplyGenerator::class, fn () => new class implements ReplyGenerator
+        {
+            public function generate(array $context): string
+            {
+                return 'Generierter Antworttext.';
+            }
+        });
+
+        $job = $this->makeJob($request->id, attempts: 1);
+        $job->handle();
+
+        /** @var ReservationReply $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
+        $this->assertFalse($reply->is_fallback, 'Successful generation must leave is_fallback at false.');
     }
 }

--- a/tests/Unit/AI/AutoSendDeciderTest.php
+++ b/tests/Unit/AI/AutoSendDeciderTest.php
@@ -90,6 +90,22 @@ class AutoSendDeciderTest extends TestCase
         $this->assertSame(AutoSendDecider::REASON_FALLBACK_TEXT, $decision->reason);
     }
 
+    public function test_it_blocks_auto_send_when_is_fallback_flag_is_true_regardless_of_body(): void
+    {
+        // Body is a normal-looking reply — only the flag distinguishes
+        // it as a fallback. The decider must trust the persisted flag
+        // ahead of the brittle string match.
+        $reply = $this->makeReplyOnRestaurantWithMode(SendMode::Auto, replyOverrides: [
+            'body' => 'Vielen Dank für Ihre Reservierungsanfrage. Gerne erwarten wir Sie.',
+            'is_fallback' => true,
+        ]);
+
+        $decision = $this->decide($reply);
+
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decision->decision);
+        $this->assertSame(AutoSendDecider::REASON_FALLBACK_TEXT, $decision->reason);
+    }
+
     public function test_it_blocks_auto_send_when_party_size_exceeds_limit(): void
     {
         $reply = $this->makeReplyOnRestaurantWithMode(


### PR DESCRIPTION
## Summary

- New migration adds `reservation_replies.is_fallback` (boolean, default `false`).
- `GenerateReservationReplyJob::storeFallbackDraft` now sets `is_fallback => true` on every error path (401, 429-after-retry, 5xx, timeout, dependency / context / persistence errors).
- `AutoSendDecider::isFallbackText` checks the persisted flag first; the prior string-equality match against `OpenAiReplyGenerator::FALLBACK_TEXT` stays in place as defense-in-depth for legacy rows or future code paths that forget to set the flag.
- Tests cover the flag on 401, 429-after-retry and timeout/5xx paths, plus the happy path (flag stays `false`) and a dedicated AutoSendDecider test that asserts the flag wins independent of body content.

## Why

PRD-007 risk note flags `isFallbackText`'s string match as brittle: the moment `FALLBACK_TEXT` is translated, restaurant-personalised, or whitespace-trimmed differently, the gate stops firing and bad replies could auto-send. The persisted flag is the authoritative signal, set at the only source of fallback writes. Defense-in-depth on the body match remains so a flag-less row still trips the gate.

## Test plan

- `php artisan test --filter="AutoSendDecider|GenerateReservationReplyJobErrorMatrix"` — 18 tests / 45 assertions green.
- `php artisan test` — full suite, 637 tests / 1900 assertions green.
- `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check` — all green.

Closes #216