### PR TITLE
Add ScheduledAutoSendJob with cancel-window re-evaluation (#217)

### DIFF
--- a/app/Jobs/ScheduledAutoSendJob.php
+++ b/app/Jobs/ScheduledAutoSendJob.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\SendMode;
+use App\Models\AutoSendAudit;
+use App\Models\ReservationReply;
+use App\Services\AI\AutoSendDecider;
+use App\Services\AI\AutoSendDecision;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+/**
+ * Sends an auto-mode reply after the 60-second cancel window (PRD-007).
+ *
+ * Three things have to still hold by the time the job runs:
+ *
+ *   1. The reply is still in `scheduled_auto_send` — i.e., the operator
+ *      hasn't cancelled or manually approved during the window.
+ *   2. The restaurant is still in `auto` mode — killswitch hasn't fired.
+ *   3. The hard-gate cascade still permits auto-send — state may have
+ *      shifted (e.g., the requested time slipped under the lead-time
+ *      threshold while we were waiting).
+ *
+ * Each of these is re-evaluated on `handle()`. Only when all three pass
+ * do we delegate to `SendReservationReplyJob`. Any cancellation path
+ * writes an `auto_send_audits` row so the operator dashboard can explain
+ * why a scheduled send didn't go out.
+ *
+ * The cancel-window length (60 s) is set by the dispatcher (sister
+ * issue #218) via `dispatch()->delay(...)`; this job carries no copy of
+ * the constant.
+ */
+final class ScheduledAutoSendJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(public int $replyId) {}
+
+    public function handle(AutoSendDecider $decider): void
+    {
+        /** @var ReservationReply|null $reply */
+        $reply = ReservationReply::withoutGlobalScopes()->find($this->replyId);
+        if ($reply === null) {
+            return;
+        }
+
+        // Race-condition guard. The status check is the very first thing
+        // we do — if the operator cancelled or approved manually during
+        // the window, the reply has already moved on and we must not
+        // touch it.
+        if ($reply->status !== ReservationReplyStatus::ScheduledAutoSend) {
+            return;
+        }
+
+        $request = $reply->reservationRequest;
+        $restaurant = $request?->restaurant;
+
+        if ($restaurant === null || $restaurant->send_mode !== SendMode::Auto) {
+            // Killswitch (or context loss) — cancel the schedule and
+            // record why. No send goes out.
+            $reply->forceFill(['status' => ReservationReplyStatus::CancelledAuto])->save();
+            $this->writeAudit(
+                $reply,
+                AutoSendAudit::DECISION_CANCELLED_AUTO,
+                AutoSendAudit::REASON_KILLSWITCH_DURING_WINDOW,
+            );
+
+            return;
+        }
+
+        $decision = $decider->decide($reply);
+        if ($decision->decision !== AutoSendDecision::DECISION_AUTO_SEND) {
+            // Hard-gate fires late. Drop back to draft so the operator
+            // can take over via the V1.0 manual flow; the reason from
+            // the decider is preserved in the audit.
+            $reply->forceFill(['status' => ReservationReplyStatus::Draft])->save();
+            $this->writeAudit(
+                $reply,
+                AutoSendAudit::DECISION_CANCELLED_AUTO,
+                AutoSendAudit::REASON_HARD_GATE_LATE_PREFIX.$decision->reason,
+            );
+
+            return;
+        }
+
+        SendReservationReplyJob::dispatchSync($reply->id);
+    }
+
+    private function writeAudit(ReservationReply $reply, string $decision, string $reason): void
+    {
+        $request = $reply->reservationRequest;
+        if ($request === null) {
+            return;
+        }
+
+        AutoSendAudit::create([
+            'reservation_reply_id' => $reply->id,
+            'restaurant_id' => $request->restaurant_id,
+            'send_mode' => SendMode::Auto->value,
+            'decision' => $decision,
+            'reason' => $reason,
+            'triggered_by_user_id' => null,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Models/AutoSendAudit.php
+++ b/app/Models/AutoSendAudit.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Append-only audit row for every auto-send decision (PRD-007).
+ *
+ * The table has no `updated_at` and no soft-delete: audits are either
+ * written or absent. `decision` is the string-literal outcome (`manual`
+ * | `shadow` | `auto_send` | `cancelled_auto`); the in-flight value
+ * object `AutoSendDecision` covers the first three, while
+ * `cancelled_auto` is reserved for late cancellations (killswitch
+ * during cancel-window, hard-gate slipping in late) where no actual
+ * send happens.
+ */
+class AutoSendAudit extends Model
+{
+    public const string DECISION_MANUAL = 'manual';
+
+    public const string DECISION_SHADOW = 'shadow';
+
+    public const string DECISION_AUTO_SEND = 'auto_send';
+
+    public const string DECISION_CANCELLED_AUTO = 'cancelled_auto';
+
+    public const string REASON_KILLSWITCH_DURING_WINDOW = 'killswitch_during_window';
+
+    /** Prefix combined with the late hard-gate reason, e.g. `hard_gate_late:short_notice`. */
+    public const string REASON_HARD_GATE_LATE_PREFIX = 'hard_gate_late:';
+
+    public $timestamps = false;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'reservation_reply_id',
+        'restaurant_id',
+        'send_mode',
+        'decision',
+        'reason',
+        'triggered_by_user_id',
+        'created_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<ReservationReply, $this>
+     */
+    public function reservationReply(): BelongsTo
+    {
+        return $this->belongsTo(ReservationReply::class);
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
+    }
+}

--- a/tests/Feature/AutoSend/SendModeFlowTest.php
+++ b/tests/Feature/AutoSend/SendModeFlowTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\MessageDirection;
+use App\Enums\ReservationReplyStatus;
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Enums\SendMode;
+use App\Jobs\ScheduledAutoSendJob;
+use App\Mail\ReservationReplyMail;
+use App\Models\AutoSendAudit;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\AI\AutoSendDecider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class SendModeFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_sends_mail_after_cancel_window_in_auto_mode(): void
+    {
+        Mail::fake();
+
+        $reply = $this->scheduledReplyOnAutoRestaurant();
+
+        (new ScheduledAutoSendJob($reply->id))->handle(app(AutoSendDecider::class));
+
+        Mail::assertSent(ReservationReplyMail::class);
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::Sent, $reply->status);
+        $this->assertNotNull($reply->sent_at);
+
+        // Outbound message row must exist so the dashboard timeline is consistent.
+        $this->assertDatabaseHas('reservation_messages', [
+            'reservation_request_id' => $reply->reservation_request_id,
+            'direction' => MessageDirection::Out->value,
+        ]);
+
+        // Successful send writes no audit row in this job (audits live on
+        // cancellation paths and on the dispatch decision in #218).
+        $this->assertSame(0, AutoSendAudit::count());
+    }
+
+    public function test_it_silently_returns_when_status_changed_during_cancel_window(): void
+    {
+        Mail::fake();
+
+        // Owner clicked "Approve" during the 60s window → status went
+        // to Approved before the scheduled job ran.
+        $reply = $this->scheduledReplyOnAutoRestaurant();
+        $reply->forceFill(['status' => ReservationReplyStatus::Approved])->save();
+
+        (new ScheduledAutoSendJob($reply->id))->handle(app(AutoSendDecider::class));
+
+        Mail::assertNothingSent();
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::Approved, $reply->status);
+        $this->assertSame(0, AutoSendAudit::count());
+    }
+
+    public function test_it_silently_returns_when_reply_no_longer_exists(): void
+    {
+        Mail::fake();
+
+        (new ScheduledAutoSendJob(999_999))->handle(app(AutoSendDecider::class));
+
+        Mail::assertNothingSent();
+        $this->assertSame(0, AutoSendAudit::count());
+    }
+
+    public function test_it_cancels_when_killswitch_flipped_mode_to_manual_during_window(): void
+    {
+        Mail::fake();
+
+        $reply = $this->scheduledReplyOnAutoRestaurant();
+
+        // Killswitch fires while we wait — restaurant flips to manual.
+        $reply->reservationRequest->restaurant
+            ->forceFill(['send_mode' => SendMode::Manual])
+            ->save();
+
+        (new ScheduledAutoSendJob($reply->id))->handle(app(AutoSendDecider::class));
+
+        Mail::assertNothingSent();
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::CancelledAuto, $reply->status);
+
+        $this->assertDatabaseHas('auto_send_audits', [
+            'reservation_reply_id' => $reply->id,
+            'decision' => AutoSendAudit::DECISION_CANCELLED_AUTO,
+            'reason' => AutoSendAudit::REASON_KILLSWITCH_DURING_WINDOW,
+        ]);
+    }
+
+    public function test_it_re_evaluates_hard_gates_in_scheduled_job_before_sending(): void
+    {
+        Mail::fake();
+
+        $reply = $this->scheduledReplyOnAutoRestaurant();
+
+        // While we waited, party size grew over the limit → short_notice
+        // gate is harder to engineer deterministically without time travel,
+        // so we use party_size which is also a hard gate.
+        $reply->reservationRequest
+            ->forceFill(['party_size' => 99])
+            ->save();
+        $reply->reservationRequest->restaurant
+            ->forceFill(['auto_send_party_size_max' => 10])
+            ->save();
+
+        (new ScheduledAutoSendJob($reply->id))->handle(app(AutoSendDecider::class));
+
+        Mail::assertNothingSent();
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+
+        $this->assertDatabaseHas('auto_send_audits', [
+            'reservation_reply_id' => $reply->id,
+            'decision' => AutoSendAudit::DECISION_CANCELLED_AUTO,
+            'reason' => AutoSendAudit::REASON_HARD_GATE_LATE_PREFIX.AutoSendDecider::REASON_PARTY_SIZE_OVER_LIMIT,
+        ]);
+    }
+
+    /**
+     * Build a fresh reply already in `scheduled_auto_send` on an
+     * Auto-mode restaurant, with a returning guest so the hard-gate
+     * cascade lets it through cleanly.
+     */
+    private function scheduledReplyOnAutoRestaurant(): ReservationReply
+    {
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => SendMode::Auto])->save();
+
+        // Prior confirmed reservation under the same email so the
+        // first_time_guest gate doesn't trip.
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'guest_email' => 'regular@example.com',
+            'status' => ReservationStatus::Confirmed,
+        ]);
+
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'guest_email' => 'regular@example.com',
+            'source' => ReservationSource::WebForm,
+            'desired_at' => now()->addDays(3),
+            'party_size' => 4,
+            'status' => ReservationStatus::New,
+            'needs_manual_review' => false,
+        ]);
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::ScheduledAutoSend,
+            'body' => 'Vielen Dank für Ihre Anfrage – wir bestätigen Ihren Tisch gerne.',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- New `App\Jobs\ScheduledAutoSendJob` runs after the dispatcher's 60-second delay (introduced in sister issue #218) and re-checks three guardrails before delegating to `SendReservationReplyJob`:
  - the reply is still in `scheduled_auto_send` (operator didn't cancel or approve manually);
  - the restaurant is still in `auto` mode (killswitch hasn't flipped during the window);
  - the hard-gate cascade still permits auto-send (state may have shifted, e.g. `desired_at` slipping under the lead-time threshold).
- New `App\Models\AutoSendAudit` Eloquent model with `DECISION_*` and `REASON_*` constants. Append-only — `$timestamps = false` and only the existing migrated `created_at` column is set.
- Cancellation paths (`killswitch_during_window`, `hard_gate_late:<reason>`) write an audit row so the dashboard can explain why a scheduled send didn't go out.

## Why

PRD-007 § Trigger-Kette explicitly calls out that hard gates must run a **second time** at execution, because state can shift inside the cancel window. Without this re-check the safety net only protects the planning moment, not the actual send. The killswitch is intentionally not a job-cancelling action — the operator can flip the mode at any time and the job picks it up on its next tick.

## Test plan

- New `tests/Feature/AutoSend/SendModeFlowTest.php` covers:
  - happy path (mail sent, status → Sent, no audit row in this job),
  - status changed in window (silent return, no audit),
  - reply no longer exists (silent return),
  - killswitch flipped mode to manual (status → CancelledAuto, audit `killswitch_during_window`),
  - late hard gate (status → Draft, audit `hard_gate_late:party_size_over_limit`).
- `php artisan test` — 642 / 1916 assertions green.
- Pint, ESLint, Prettier — all green.

## Out of scope

- Dispatching the job with a 60-second delay from the generator pipeline lives in #218 (`Integrate AutoSendDecider into GenerateReservationReplyJob + AutoSendAudit writer`).
- Cancel button + manual-approve-in-window flows arrive with #221 (dashboard banner / drawer) and #220 (settings UI).

Closes #217