### PR TITLE
Integrate AutoSendDecider into the generator pipeline (#218)

### DIFF
--- a/app/Jobs/GenerateReservationReplyJob.php
+++ b/app/Jobs/GenerateReservationReplyJob.php
@@ -8,8 +8,11 @@ use App\Enums\ReservationReplyStatus;
 use App\Events\OpenAiAuthenticationFailed;
 use App\Exceptions\AI\OpenAiAuthenticationException;
 use App\Exceptions\AI\OpenAiRateLimitException;
+use App\Models\AutoSendAudit;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
+use App\Services\AI\AutoSendDecider;
+use App\Services\AI\AutoSendDecision;
 use App\Services\AI\Contracts\ReplyGenerator;
 use App\Services\AI\OpenAiReplyGenerator;
 use App\Services\AI\ReservationContextBuilder;
@@ -49,6 +52,12 @@ class GenerateReservationReplyJob implements ShouldQueue
     /** Delay before re-attempting after a 429 (PRD-005). */
     public const int RATE_LIMIT_RETRY_DELAY_SECONDS = 60;
 
+    /**
+     * Length of the cancel-window before an auto-send actually goes out
+     * (PRD-007). Architectural constant — not UI-configurable.
+     */
+    public const int AUTO_SEND_CANCEL_WINDOW_SECONDS = 60;
+
     public function __construct(public int $reservationRequestId) {}
 
     public function handle(): void
@@ -69,12 +78,14 @@ class GenerateReservationReplyJob implements ShouldQueue
             $context = $builder->build($request);
             $body = $generator->generate($context);
 
-            ReservationReply::create([
+            $reply = ReservationReply::create([
                 'reservation_request_id' => $request->id,
                 'status' => ReservationReplyStatus::Draft,
                 'body' => $body,
                 'ai_prompt_snapshot' => $context,
             ]);
+
+            $this->applyAutoSendDecision($reply);
         } catch (OpenAiRateLimitException $e) {
             // First 429 → release back to queue with the configured delay.
             // Second 429 falls through to the generic-fallback path.
@@ -119,12 +130,77 @@ class GenerateReservationReplyJob implements ShouldQueue
 
         $request->forceFill(['needs_manual_review' => true])->save();
 
-        ReservationReply::create([
+        $reply = ReservationReply::create([
             'reservation_request_id' => $request->id,
             'status' => ReservationReplyStatus::Draft,
             'body' => OpenAiReplyGenerator::FALLBACK_TEXT,
             'ai_prompt_snapshot' => $context,
             'is_fallback' => true,
         ]);
+
+        $this->applyAutoSendDecision($reply);
+    }
+
+    /**
+     * Run the AutoSendDecider on a freshly-created draft reply, persist
+     * the snapshot fields, write an audit row, and route the reply into
+     * the manual / shadow / scheduled-auto-send branch dictated by the
+     * decision (PRD-007 § Trigger-Kette).
+     *
+     * The decider is the single authoritative source — even on the
+     * fallback path, where hard gates are guaranteed to block, we still
+     * call through here so the audit trail records *why* manual is
+     * forced (e.g. `fallback_text`, `needs_manual_review`).
+     */
+    private function applyAutoSendDecision(ReservationReply $reply): void
+    {
+        $reply->refresh();
+
+        $request = $reply->reservationRequest;
+        $restaurant = $request?->restaurant;
+
+        if ($restaurant === null) {
+            // Unreachable in production (the reply was just created on
+            // top of a hydrated request) but the decider has its own
+            // missing-context fallback, so we let it record that.
+            return;
+        }
+
+        $decider = app(AutoSendDecider::class);
+        $decision = $decider->decide($reply);
+
+        $reply->forceFill([
+            'send_mode_at_creation' => $restaurant->send_mode,
+            'auto_send_decision' => $decision->toArray(),
+        ])->save();
+
+        AutoSendAudit::write($reply, $decision->decision, $decision->reason);
+
+        match ($decision->decision) {
+            AutoSendDecision::DECISION_MANUAL => null, // V1.0 path: status stays Draft.
+            AutoSendDecision::DECISION_SHADOW => $reply->forceFill([
+                'status' => ReservationReplyStatus::Shadow,
+            ])->save(),
+            AutoSendDecision::DECISION_AUTO_SEND => $this->scheduleAutoSend($reply),
+        };
+    }
+
+    /**
+     * Promote the reply into `scheduled_auto_send` and dispatch the
+     * cancel-window job. The 60-second delay is set here — the canonical
+     * source of the cancel-window length — and the scheduled job carries
+     * no copy of the constant.
+     */
+    private function scheduleAutoSend(ReservationReply $reply): void
+    {
+        $scheduledFor = now()->addSeconds(self::AUTO_SEND_CANCEL_WINDOW_SECONDS);
+
+        $reply->forceFill([
+            'status' => ReservationReplyStatus::ScheduledAutoSend,
+            'auto_send_scheduled_for' => $scheduledFor,
+        ])->save();
+
+        ScheduledAutoSendJob::dispatch($reply->id)
+            ->delay(self::AUTO_SEND_CANCEL_WINDOW_SECONDS);
     }
 }

--- a/app/Jobs/ScheduledAutoSendJob.php
+++ b/app/Jobs/ScheduledAutoSendJob.php
@@ -63,7 +63,7 @@ final class ScheduledAutoSendJob implements ShouldQueue
             // Killswitch (or context loss) — cancel the schedule and
             // record why. No send goes out.
             $reply->forceFill(['status' => ReservationReplyStatus::CancelledAuto])->save();
-            $this->writeAudit(
+            AutoSendAudit::write(
                 $reply,
                 AutoSendAudit::DECISION_CANCELLED_AUTO,
                 AutoSendAudit::REASON_KILLSWITCH_DURING_WINDOW,
@@ -78,7 +78,7 @@ final class ScheduledAutoSendJob implements ShouldQueue
             // can take over via the V1.0 manual flow; the reason from
             // the decider is preserved in the audit.
             $reply->forceFill(['status' => ReservationReplyStatus::Draft])->save();
-            $this->writeAudit(
+            AutoSendAudit::write(
                 $reply,
                 AutoSendAudit::DECISION_CANCELLED_AUTO,
                 AutoSendAudit::REASON_HARD_GATE_LATE_PREFIX.$decision->reason,
@@ -88,23 +88,5 @@ final class ScheduledAutoSendJob implements ShouldQueue
         }
 
         SendReservationReplyJob::dispatchSync($reply->id);
-    }
-
-    private function writeAudit(ReservationReply $reply, string $decision, string $reason): void
-    {
-        $request = $reply->reservationRequest;
-        if ($request === null) {
-            return;
-        }
-
-        AutoSendAudit::create([
-            'reservation_reply_id' => $reply->id,
-            'restaurant_id' => $request->restaurant_id,
-            'send_mode' => SendMode::Auto->value,
-            'decision' => $decision,
-            'reason' => $reason,
-            'triggered_by_user_id' => null,
-            'created_at' => now(),
-        ]);
     }
 }

--- a/app/Models/AutoSendAudit.php
+++ b/app/Models/AutoSendAudit.php
@@ -6,6 +6,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use RuntimeException;
 
 /**
  * Append-only audit row for every auto-send decision (PRD-007).
@@ -72,5 +73,43 @@ class AutoSendAudit extends Model
     public function restaurant(): BelongsTo
     {
         return $this->belongsTo(Restaurant::class);
+    }
+
+    /**
+     * Single writer for audit rows. The reply's parent context (request +
+     * restaurant) supplies `restaurant_id` and `send_mode`, so call sites
+     * don't have to pass them explicitly. `triggered_by_user_id` is null
+     * for system decisions (the generator pipeline) and populated for
+     * operator-driven actions (killswitch, manual cancel).
+     *
+     * Fields written here are intentionally narrow: ids, enum strings,
+     * and a reason code. Guest emails, reply bodies, and any other mail
+     * content are NOT recorded — the audit trail proves the decision was
+     * made, not the content involved.
+     */
+    public static function write(
+        ReservationReply $reply,
+        string $decision,
+        string $reason,
+        ?int $triggeredByUserId = null,
+    ): self {
+        $request = $reply->reservationRequest;
+        $restaurant = $request?->restaurant;
+
+        if ($request === null || $restaurant === null) {
+            throw new RuntimeException(
+                'AutoSendAudit::write requires a reply with a loadable request + restaurant.'
+            );
+        }
+
+        return self::create([
+            'reservation_reply_id' => $reply->id,
+            'restaurant_id' => $request->restaurant_id,
+            'send_mode' => $restaurant->send_mode->value,
+            'decision' => $decision,
+            'reason' => $reason,
+            'triggered_by_user_id' => $triggeredByUserId,
+            'created_at' => now(),
+        ]);
     }
 }

--- a/app/Models/ReservationReply.php
+++ b/app/Models/ReservationReply.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\ReservationReplyStatus;
+use App\Enums\SendMode;
 use App\Models\Scopes\RestaurantScope;
 use Database\Factories\ReservationReplyFactory;
 use Illuminate\Database\Eloquent\Attributes\ScopedBy;
@@ -32,6 +33,9 @@ class ReservationReply extends Model
         'error_message',
         'outbound_message_id',
         'is_fallback',
+        'send_mode_at_creation',
+        'auto_send_decision',
+        'auto_send_scheduled_for',
     ];
 
     /**
@@ -47,6 +51,9 @@ class ReservationReply extends Model
             'approved_at' => 'datetime',
             'sent_at' => 'datetime',
             'is_fallback' => 'boolean',
+            'send_mode_at_creation' => SendMode::class,
+            'auto_send_decision' => 'array',
+            'auto_send_scheduled_for' => 'datetime',
         ];
     }
 

--- a/tests/Feature/AutoSend/AuditTrailTest.php
+++ b/tests/Feature/AutoSend/AuditTrailTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\ReservationStatus;
+use App\Enums\SendMode;
+use App\Jobs\GenerateReservationReplyJob;
+use App\Jobs\ScheduledAutoSendJob;
+use App\Mail\ReservationReplyMail;
+use App\Models\AutoSendAudit;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\AI\AutoSendDecision;
+use App\Services\AI\Contracts\ReplyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class AuditTrailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_writes_audit_entry_on_every_auto_send_decision(): void
+    {
+        // Manual mode → expect a single audit row recording `manual / mode_manual`.
+        Mail::fake();
+        $request = $this->makeRequestForRestaurantWithMode(SendMode::Manual);
+        $this->bindReplyGenerator('Generierter Text.');
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $reply = ReservationReply::withoutGlobalScopes()
+            ->where('reservation_request_id', $request->id)
+            ->sole();
+
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+        $this->assertSame(SendMode::Manual, $reply->send_mode_at_creation);
+
+        /** @var array{decision: string, reason: string} $decisionSnapshot */
+        $decisionSnapshot = $reply->auto_send_decision;
+        $this->assertSame(AutoSendDecision::DECISION_MANUAL, $decisionSnapshot['decision']);
+        $this->assertSame('mode_manual', $decisionSnapshot['reason']);
+
+        $this->assertDatabaseHas('auto_send_audits', [
+            'reservation_reply_id' => $reply->id,
+            'send_mode' => SendMode::Manual->value,
+            'decision' => AutoSendAudit::DECISION_MANUAL,
+            'reason' => 'mode_manual',
+            'triggered_by_user_id' => null,
+        ]);
+    }
+
+    public function test_it_does_not_send_mail_in_shadow_mode(): void
+    {
+        Mail::fake();
+        Queue::fake();
+
+        $request = $this->makeRequestForRestaurantWithMode(SendMode::Shadow);
+        $this->bindReplyGenerator('Schatten-Antwort.');
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        Mail::assertNothingSent();
+        Mail::assertNotQueued(ReservationReplyMail::class);
+
+        $reply = ReservationReply::withoutGlobalScopes()
+            ->where('reservation_request_id', $request->id)
+            ->sole();
+
+        $this->assertSame(ReservationReplyStatus::Shadow, $reply->status);
+        $this->assertDatabaseHas('auto_send_audits', [
+            'reservation_reply_id' => $reply->id,
+            'decision' => AutoSendAudit::DECISION_SHADOW,
+            'reason' => 'mode_shadow',
+        ]);
+    }
+
+    public function test_it_dispatches_scheduled_auto_send_with_60_second_delay_in_auto_mode(): void
+    {
+        Queue::fake();
+
+        $request = $this->makeRequestForRestaurantWithMode(SendMode::Auto, returningGuest: true);
+        $this->bindReplyGenerator('Auto-Antwort.');
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $reply = ReservationReply::withoutGlobalScopes()
+            ->where('reservation_request_id', $request->id)
+            ->sole();
+
+        $this->assertSame(ReservationReplyStatus::ScheduledAutoSend, $reply->status);
+        $this->assertNotNull($reply->auto_send_scheduled_for);
+        $this->assertEqualsWithDelta(
+            now()->addSeconds(GenerateReservationReplyJob::AUTO_SEND_CANCEL_WINDOW_SECONDS)->timestamp,
+            $reply->auto_send_scheduled_for->timestamp,
+            5,
+            'Scheduled-for should be ~now() + 60s.'
+        );
+
+        Queue::assertPushed(ScheduledAutoSendJob::class, function ($job) use ($reply) {
+            return $job->replyId === $reply->id
+                && $job->delay === GenerateReservationReplyJob::AUTO_SEND_CANCEL_WINDOW_SECONDS;
+        });
+
+        $this->assertDatabaseHas('auto_send_audits', [
+            'reservation_reply_id' => $reply->id,
+            'decision' => AutoSendAudit::DECISION_AUTO_SEND,
+            'reason' => 'mode_auto',
+        ]);
+    }
+
+    public function test_it_never_logs_guest_email_or_reply_body_in_audits(): void
+    {
+        Mail::fake();
+
+        $email = 'guest-with-pii@example.test';
+        $request = $this->makeRequestForRestaurantWithMode(SendMode::Manual, guestEmail: $email);
+        $this->bindReplyGenerator('Vertraulicher Antworttext mit Gästedetails.');
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $audit = AutoSendAudit::query()->sole();
+
+        $serialized = json_encode($audit->getAttributes(), JSON_UNESCAPED_UNICODE);
+        $this->assertNotFalse($serialized);
+        $this->assertStringNotContainsString($email, $serialized, 'Audit row must not contain the guest email.');
+        $this->assertStringNotContainsString('Vertraulicher Antworttext', $serialized, 'Audit row must not contain the reply body.');
+    }
+
+    public function test_existing_v1_manual_default_remains_compatible(): void
+    {
+        // Brand-new restaurant — default send_mode is `manual` per migration.
+        // The pipeline must produce the same Draft output PRD-005 expects,
+        // with the new audit/snapshot fields filled in but not changing the
+        // V1.0 behaviour (no mail, status = Draft).
+        Mail::fake();
+
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'desired_at' => now()->addDays(5),
+        ]);
+        $this->bindReplyGenerator('V1-konformer Antworttext.');
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $reply = ReservationReply::withoutGlobalScopes()
+            ->where('reservation_request_id', $request->id)
+            ->sole();
+
+        $this->assertSame(ReservationReplyStatus::Draft, $reply->status);
+        $this->assertSame(SendMode::Manual, $reply->send_mode_at_creation);
+        Mail::assertNothingSent();
+    }
+
+    private function makeRequestForRestaurantWithMode(
+        SendMode $mode,
+        bool $returningGuest = true,
+        ?string $guestEmail = null,
+    ): ReservationRequest {
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => $mode])->save();
+
+        $email = $guestEmail ?? 'guest@example.com';
+
+        if ($returningGuest) {
+            // Hard-gate `first_time_guest` would otherwise short-circuit
+            // even Manual / Shadow modes (gates run before mode dispatch),
+            // making the audit reason `first_time_guest` instead of the
+            // expected `mode_*`. We seed a confirmed prior reservation so
+            // the gate passes and we exercise the mode-dispatch arm.
+            ReservationRequest::factory()->forRestaurant($restaurant)->create([
+                'guest_email' => $email,
+                'status' => ReservationStatus::Confirmed,
+            ]);
+        }
+
+        return ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'guest_email' => $email,
+            'desired_at' => now()->addDays(5),
+            'party_size' => 4,
+            'needs_manual_review' => false,
+        ]);
+    }
+
+    private function bindReplyGenerator(string $body): void
+    {
+        $this->app->bind(ReplyGenerator::class, fn () => new class($body) implements ReplyGenerator
+        {
+            public function __construct(private readonly string $body) {}
+
+            public function generate(array $context): string
+            {
+                return $this->body;
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary

- `GenerateReservationReplyJob` now calls `AutoSendDecider::decide()` on every newly-created draft (happy path and fallback path), persists the decision JSON to `reservation_replies.auto_send_decision`, snapshots the live `send_mode` to `send_mode_at_creation`, and writes an `AutoSendAudit` row through the new shared writer.
- Decision branches:
  - `manual` → status stays `Draft` (V1.0 behaviour preserved).
  - `shadow` → status flips to `Shadow`, no mail dispatched.
  - `auto_send` → status flips to `ScheduledAutoSend`, `auto_send_scheduled_for = now()+60s`, and `ScheduledAutoSendJob::dispatch($reply->id)->delay(60)` is queued.
- New `AutoSendAudit::write($reply, $decision, $reason, $userId = null)` static helper. `ScheduledAutoSendJob` is refactored to use it (the private `writeAudit` block is gone), so all PRD-007 audits flow through one path.
- `ReservationReply` gains `is_fallback` (already added), `send_mode_at_creation` (`SendMode` enum cast), `auto_send_decision` (array cast over the json column), and `auto_send_scheduled_for` (datetime cast) in `$fillable` + `casts()`.
- New cancel-window constant `GenerateReservationReplyJob::AUTO_SEND_CANCEL_WINDOW_SECONDS = 60` is the canonical source of the 60s delay.

## Why

PRD-007 § Trigger-Kette names the generator job as the dispatch point: it owns the moment of decision (mode at creation, the JSON snapshot, the audit row). Without this PR an Auto-mode restaurant produced Draft replies that no one ever auto-sent. With the integration, the existing PRD-005 happy-path tests stay green (Manual is the migration default), and Shadow/Auto pilots can flow end-to-end through the pipeline scoped in #217.

## Test plan

- `tests/Feature/AutoSend/AuditTrailTest.php` (new, 5 tests):
  - audit row written on every decision (Manual / Shadow / Auto),
  - Shadow does not send mail and does not queue mail,
  - Auto enqueues `ScheduledAutoSendJob` with `delay = 60` and snapshots `auto_send_scheduled_for`,
  - audit row never contains guest email or reply body,
  - V1.0 default (Manual) keeps PRD-005 behaviour unchanged.
- `php artisan test` — full suite, 647 / 1936 assertions green.
- Pint, ESLint, Prettier — green.

Closes #218