### PR TITLE
Add killswitch endpoint for instant auto-send stop (#219)

### DIFF
--- a/app/Http/Controllers/SendModeKillswitchController.php
+++ b/app/Http/Controllers/SendModeKillswitchController.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\SendMode;
+use App\Models\AutoSendAudit;
+use App\Models\ReservationReply;
+use App\Models\Restaurant;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Owner-driven instant-stop for the auto-send pipeline (PRD-007 §
+ * Killswitch). Flips the restaurant back to `manual` and cancels every
+ * reply that's still inside the cancel window in a single transaction
+ * — so a stale `ScheduledAutoSendJob` waking up after the click cannot
+ * find a reply to send.
+ *
+ * The cancel pass writes one `auto_send_audits` row per reply with
+ * `triggered_by_user_id = auth()->id()` so the dashboard can attribute
+ * the action; the lurking `ScheduledAutoSendJob` race is covered by
+ * that job's own re-check of `restaurant->send_mode` (#217).
+ */
+class SendModeKillswitchController extends Controller
+{
+    public function __invoke(Restaurant $restaurant): RedirectResponse
+    {
+        DB::transaction(function () use ($restaurant): void {
+            $restaurant->update([
+                'send_mode' => SendMode::Manual,
+                'send_mode_changed_at' => now(),
+                'send_mode_changed_by' => Auth::id(),
+            ]);
+
+            $scheduled = ReservationReply::query()
+                ->whereHas(
+                    'reservationRequest',
+                    fn ($query) => $query->where('restaurant_id', $restaurant->id),
+                )
+                ->where('status', ReservationReplyStatus::ScheduledAutoSend)
+                ->get();
+
+            foreach ($scheduled as $reply) {
+                $reply->forceFill(['status' => ReservationReplyStatus::CancelledAuto])->save();
+
+                AutoSendAudit::write(
+                    $reply,
+                    AutoSendAudit::DECISION_CANCELLED_AUTO,
+                    'killswitch',
+                    Auth::id(),
+                );
+            }
+        });
+
+        return back()->with(
+            'success',
+            'Auto-Versand sofort gestoppt. Alle ausstehenden Versandvorgänge wurden abgebrochen.'
+        );
+    }
+}

--- a/app/Policies/RestaurantPolicy.php
+++ b/app/Policies/RestaurantPolicy.php
@@ -25,4 +25,16 @@ final class RestaurantPolicy
         return $user->restaurant_id === $restaurant->id
             && $user->role === UserRole::Owner;
     }
+
+    /**
+     * Send-mode changes (manual ↔ shadow ↔ auto and the killswitch) are
+     * security-relevant: in `auto` mode the system mails guests without
+     * operator confirmation. PRD-007 reserves this surface for owners —
+     * staff users get a 403 even on their own restaurant.
+     */
+    public function manageSendMode(User $user, Restaurant $restaurant): bool
+    {
+        return $user->restaurant_id === $restaurant->id
+            && $user->role === UserRole::Owner;
+    }
 }

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -23,6 +23,13 @@ declare module 'ziggy-js' {
             "binding": "id"
         }
     ],
+    "restaurants.send-mode.killswitch": [
+        {
+            "name": "restaurant",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "public.reservations.create": [
         {
             "name": "restaurant",

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\ReservationMessagesController;
 use App\Http\Controllers\ReservationReplyController;
 use App\Http\Controllers\ReservationRequestController;
+use App\Http\Controllers\SendModeKillswitchController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -33,6 +34,10 @@ Route::post('reservations/bulk-status', [ReservationRequestController::class, 'b
 Route::post('reservation-replies/{reply}/approve', [ReservationReplyController::class, 'approve'])
     ->middleware(['auth', 'verified', 'can:approve,reply'])
     ->name('reservation-replies.approve');
+
+Route::post('restaurants/{restaurant}/send-mode/killswitch', SendModeKillswitchController::class)
+    ->middleware(['auth', 'verified', 'can:manageSendMode,restaurant'])
+    ->name('restaurants.send-mode.killswitch');
 
 Route::get('r/{restaurant:slug}/reservations', [PublicReservationController::class, 'create'])
     ->name('public.reservations.create');

--- a/tests/Feature/AutoSend/KillswitchTest.php
+++ b/tests/Feature/AutoSend/KillswitchTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\SendMode;
+use App\Enums\UserRole;
+use App\Models\AutoSendAudit;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class KillswitchTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_resets_mode_to_manual_on_killswitch(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Auto);
+        $owner = $this->makeOwner($restaurant);
+
+        $response = $this->actingAs($owner)
+            ->post(route('restaurants.send-mode.killswitch', $restaurant));
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+
+        $restaurant->refresh();
+        $this->assertSame(SendMode::Manual, $restaurant->send_mode);
+        $this->assertNotNull($restaurant->send_mode_changed_at);
+        $this->assertSame($owner->id, $restaurant->send_mode_changed_by);
+    }
+
+    public function test_it_cancels_all_scheduled_auto_sends_within_killswitch_transaction(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Auto);
+        $owner = $this->makeOwner($restaurant);
+
+        $scheduled = $this->scheduledReply($restaurant);
+        $alsoScheduled = $this->scheduledReply($restaurant);
+
+        // Replies in unrelated states must not be touched.
+        $draft = ReservationReply::factory()->create([
+            'reservation_request_id' => ReservationRequest::factory()->forRestaurant($restaurant)->create()->id,
+            'status' => ReservationReplyStatus::Draft,
+        ]);
+
+        $this->actingAs($owner)
+            ->post(route('restaurants.send-mode.killswitch', $restaurant))
+            ->assertRedirect();
+
+        $this->assertSame(ReservationReplyStatus::CancelledAuto, $scheduled->fresh()->status);
+        $this->assertSame(ReservationReplyStatus::CancelledAuto, $alsoScheduled->fresh()->status);
+        $this->assertSame(ReservationReplyStatus::Draft, $draft->fresh()->status, 'Drafts must not be cancelled.');
+    }
+
+    public function test_it_writes_audit_entry_for_each_cancelled_reply(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Auto);
+        $owner = $this->makeOwner($restaurant);
+
+        $first = $this->scheduledReply($restaurant);
+        $second = $this->scheduledReply($restaurant);
+
+        $this->actingAs($owner)
+            ->post(route('restaurants.send-mode.killswitch', $restaurant))
+            ->assertRedirect();
+
+        foreach ([$first, $second] as $reply) {
+            $this->assertDatabaseHas('auto_send_audits', [
+                'reservation_reply_id' => $reply->id,
+                'restaurant_id' => $restaurant->id,
+                'decision' => AutoSendAudit::DECISION_CANCELLED_AUTO,
+                'reason' => 'killswitch',
+                'triggered_by_user_id' => $owner->id,
+            ]);
+        }
+
+        $this->assertSame(2, AutoSendAudit::query()->count());
+    }
+
+    public function test_it_works_when_active_mode_is_shadow(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Shadow);
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->post(route('restaurants.send-mode.killswitch', $restaurant))
+            ->assertRedirect();
+
+        $this->assertSame(SendMode::Manual, $restaurant->fresh()->send_mode);
+    }
+
+    public function test_it_forbids_killswitch_for_staff_users(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Auto);
+        $staff = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Staff,
+        ]);
+
+        $scheduled = $this->scheduledReply($restaurant);
+
+        $this->actingAs($staff)
+            ->post(route('restaurants.send-mode.killswitch', $restaurant))
+            ->assertForbidden();
+
+        $this->assertSame(SendMode::Auto, $restaurant->fresh()->send_mode);
+        $this->assertSame(ReservationReplyStatus::ScheduledAutoSend, $scheduled->fresh()->status);
+        $this->assertSame(0, AutoSendAudit::query()->count());
+    }
+
+    public function test_it_forbids_killswitch_from_owner_of_a_different_restaurant(): void
+    {
+        $targetRestaurant = $this->makeRestaurantWithMode(SendMode::Auto);
+        $otherRestaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $foreignOwner = $this->makeOwner($otherRestaurant);
+
+        $this->actingAs($foreignOwner)
+            ->post(route('restaurants.send-mode.killswitch', $targetRestaurant))
+            ->assertForbidden();
+
+        $this->assertSame(SendMode::Auto, $targetRestaurant->fresh()->send_mode);
+    }
+
+    private function makeRestaurantWithMode(SendMode $mode): Restaurant
+    {
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => $mode])->save();
+
+        return $restaurant;
+    }
+
+    private function makeOwner(Restaurant $restaurant): User
+    {
+        return User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Owner,
+        ]);
+    }
+
+    private function scheduledReply(Restaurant $restaurant): ReservationReply
+    {
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::ScheduledAutoSend,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary

- New `POST /restaurants/{restaurant}/send-mode/killswitch` (route name `restaurants.send-mode.killswitch`).
- New `RestaurantPolicy::manageSendMode` ability — only owners of the restaurant pass; staff and foreign-tenant owners get 403.
- New `SendModeKillswitchController` (single-action, `__invoke`). The action wraps a `DB::transaction`:
  1. flips `restaurants.send_mode` to `Manual`, snapshots `send_mode_changed_at` / `send_mode_changed_by`,
  2. loads every reply still in `scheduled_auto_send` for the restaurant, force-fills it to `cancelled_auto`,
  3. writes one `auto_send_audits` row per reply with reason `killswitch` and `triggered_by_user_id = auth()->id()`.
- Flash message on success matches PRD-007 wording (German). Killswitch also works when the active mode is `shadow`.
- Tenant scoping via `whereHas('reservationRequest', ...)` so foreign-restaurant scheduled replies aren't touched.

## Why

PRD-007 § Killswitch makes the instant-stop a load-bearing operator action: the moment auto-send is misbehaving (or just feels off), the owner needs a one-click escape that *also* cancels everything still inside the cancel window. Without this endpoint, `ScheduledAutoSendJob` instances waking up after the click would still find scheduled replies and could send them. The transactional cancel + the job's own re-check (#217) close that race.

## Test plan

- New `tests/Feature/AutoSend/KillswitchTest.php` (6 tests):
  - mode reset to Manual + `send_mode_changed_at/by` set,
  - all `scheduled_auto_send` replies of the restaurant cancelled, drafts untouched,
  - one audit row per cancelled reply with the operator's id,
  - shadow → manual works,
  - staff users get 403,
  - foreign-tenant owners get 403.
- `php artisan test` — 653 / 1957 assertions green.
- `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check` — green.
- `php artisan ziggy:generate --types-only` re-run; route appears in `resources/js/ziggy.d.ts`.

Closes #219