### PR TITLE
Add Settings/SendMode page with three-card layout + shadow stats (#220)

### DIFF
--- a/app/Http/Controllers/Settings/SendModeSettingsController.php
+++ b/app/Http/Controllers/Settings/SendModeSettingsController.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Enums\SendMode;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\SendModeSettingsUpdateRequest;
+use App\Models\ReservationReply;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Owner-only settings surface for the auto-send pipeline (PRD-007).
+ *
+ * `edit` renders the three-card SendMode page with the current
+ * configuration plus shadow-mode takeover statistics over the last 30
+ * days, so the confirmation dialog for `shadow → auto` can show the
+ * real takeover-rate figure the operator built up.
+ *
+ * `update` validates and persists the new mode and the hard-gate
+ * thresholds in a single transaction-friendly model save. Mode flips
+ * snapshot the actor and timestamp; the killswitch endpoint
+ * (`SendModeKillswitchController`) handles the panic-stop case
+ * separately so this surface stays focused on configuration.
+ */
+class SendModeSettingsController extends Controller
+{
+    /**
+     * Window the dashboard summarises in the confirmation dialog.
+     */
+    private const int SHADOW_STATS_WINDOW_DAYS = 30;
+
+    public function edit(): Response
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $restaurant = $user->restaurant;
+        if ($restaurant === null) {
+            abort(403);
+        }
+
+        Gate::authorize('manageSendMode', $restaurant);
+
+        return Inertia::render('settings/SendMode', [
+            'restaurantId' => $restaurant->id,
+            'sendMode' => $restaurant->send_mode->value,
+            'partySizeMax' => $restaurant->auto_send_party_size_max,
+            'minLeadTimeMinutes' => $restaurant->auto_send_min_lead_time_minutes,
+            'sendModeChangedAt' => $restaurant->send_mode_changed_at?->toIso8601String(),
+            'shadowStats' => $this->shadowStats($restaurant),
+        ]);
+    }
+
+    public function update(SendModeSettingsUpdateRequest $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $restaurant = $user->restaurant;
+        if ($restaurant === null) {
+            abort(403);
+        }
+
+        Gate::authorize('manageSendMode', $restaurant);
+
+        $newMode = SendMode::from($request->validated('send_mode'));
+        $modeChanged = $restaurant->send_mode !== $newMode;
+
+        $payload = [
+            'send_mode' => $newMode,
+            'auto_send_party_size_max' => $request->validated('auto_send_party_size_max'),
+            'auto_send_min_lead_time_minutes' => $request->validated('auto_send_min_lead_time_minutes'),
+        ];
+
+        if ($modeChanged) {
+            $payload['send_mode_changed_at'] = now();
+            $payload['send_mode_changed_by'] = $user->id;
+        }
+
+        $restaurant->update($payload);
+
+        return back()->with('success', 'Versand-Einstellungen gespeichert.');
+    }
+
+    /**
+     * Aggregate the last 30 days of shadow-mode replies into the figures
+     * the confirmation dialog displays before the operator commits to
+     * `auto`. `taken_over` counts replies the operator promoted from
+     * `shadow → approved` without editing the body, i.e., where the AI
+     * draft was good enough to ship verbatim.
+     *
+     * @return array{total: int, takenOver: int, takeoverRate: float|null, hasData: bool}
+     */
+    private function shadowStats(Restaurant $restaurant): array
+    {
+        $since = Carbon::now()->subDays(self::SHADOW_STATS_WINDOW_DAYS);
+
+        $shadowReplies = ReservationReply::query()
+            ->whereHas(
+                'reservationRequest',
+                fn ($query) => $query->where('restaurant_id', $restaurant->id),
+            )
+            ->where('send_mode_at_creation', SendMode::Shadow->value)
+            ->where('created_at', '>=', $since);
+
+        $total = (clone $shadowReplies)->count();
+        $takenOver = (clone $shadowReplies)->where('shadow_was_modified', false)
+            ->whereNotNull('shadow_compared_at')
+            ->count();
+
+        return [
+            'total' => $total,
+            'takenOver' => $takenOver,
+            'takeoverRate' => $total > 0 ? round($takenOver / $total, 4) : null,
+            'hasData' => $total > 0,
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/SendModeSettingsUpdateRequest.php
+++ b/app/Http/Requests/Settings/SendModeSettingsUpdateRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use App\Enums\SendMode;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates the owner-driven send-mode + hard-gate configuration form
+ * (PRD-007 § Settings-UI). Authorization happens upstream via the
+ * `manageSendMode` policy on the route, so `authorize()` returns true.
+ */
+class SendModeSettingsUpdateRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'send_mode' => ['required', 'string', Rule::enum(SendMode::class)],
+            'auto_send_party_size_max' => ['required', 'integer', 'min:1', 'max:50'],
+            'auto_send_min_lead_time_minutes' => ['required', 'integer', 'min:0', 'max:1440'],
+        ];
+    }
+}

--- a/resources/js/pages/settings/SendMode.vue
+++ b/resources/js/pages/settings/SendMode.vue
@@ -1,0 +1,222 @@
+<script setup lang="ts">
+import { Head, router, useForm } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+import { type BreadcrumbItem } from '@/types';
+
+type SendMode = 'manual' | 'shadow' | 'auto';
+
+interface ShadowStats {
+    total: number;
+    takenOver: number;
+    takeoverRate: number | null;
+    hasData: boolean;
+}
+
+interface Props {
+    restaurantId: number;
+    sendMode: SendMode;
+    partySizeMax: number;
+    minLeadTimeMinutes: number;
+    sendModeChangedAt: string | null;
+    shadowStats: ShadowStats;
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'Versand-Modus', href: '/settings/send-mode' }];
+
+const form = useForm({
+    send_mode: props.sendMode,
+    auto_send_party_size_max: props.partySizeMax,
+    auto_send_min_lead_time_minutes: props.minLeadTimeMinutes,
+});
+
+const pendingMode = ref<SendMode | null>(null);
+
+const modeCards: ReadonlyArray<{
+    value: SendMode;
+    title: string;
+    description: string;
+    risk: 'Low' | 'Medium' | 'High';
+}> = [
+    {
+        value: 'manual',
+        title: 'Manuelle Freigabe',
+        description: 'Jede KI-Antwort wartet auf Ihre Freigabe (V1.0-Verhalten). Sicherster Modus.',
+        risk: 'Low',
+    },
+    {
+        value: 'shadow',
+        title: 'Shadow-Modus (Test)',
+        description:
+            'Antworten werden generiert und markiert "wäre versendet worden", aber NICHT versendet. Wir messen Ihre Übernahme-Rate, damit Sie informiert auf Auto wechseln können.',
+        risk: 'Medium',
+    },
+    {
+        value: 'auto',
+        title: 'Automatischer Versand',
+        description:
+            'Antworten gehen 60 Sekunden nach Generierung automatisch raus, sofern keine Sicherheitsregel greift. In dieser Zeit können Sie sie noch abbrechen.',
+        risk: 'High',
+    },
+];
+
+const riskBadgeClass = (risk: 'Low' | 'Medium' | 'High') =>
+    risk === 'Low'
+        ? 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200'
+        : risk === 'Medium'
+          ? 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-200'
+          : 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-200';
+
+const showsKillswitch = computed(() => props.sendMode !== 'manual');
+
+const isShadowToAuto = computed(() => pendingMode.value === 'auto' && props.sendMode === 'shadow');
+
+const takeoverRatePercent = computed(() => (props.shadowStats.takeoverRate !== null ? Math.round(props.shadowStats.takeoverRate * 100) : null));
+
+const requestModeChange = (mode: SendMode) => {
+    if (mode === props.sendMode) {
+        return;
+    }
+    pendingMode.value = mode;
+};
+
+const cancelModeChange = () => {
+    pendingMode.value = null;
+};
+
+const confirmModeChange = () => {
+    if (pendingMode.value === null) {
+        return;
+    }
+    form.send_mode = pendingMode.value;
+    submit(() => {
+        pendingMode.value = null;
+    });
+};
+
+const submit = (onSuccess?: () => void) => {
+    form.patch(route('settings.send-mode.update'), {
+        preserveScroll: true,
+        onSuccess,
+    });
+};
+
+const triggerKillswitch = () => {
+    if (!window.confirm('Auto-Versand sofort stoppen? Alle ausstehenden Versandvorgänge werden abgebrochen.')) {
+        return;
+    }
+    router.post(
+        route('restaurants.send-mode.killswitch', {
+            restaurant: props.restaurantId,
+        }),
+        {},
+        { preserveScroll: true },
+    );
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="Versand-Modus" />
+
+        <SettingsLayout>
+            <div class="flex flex-col space-y-6">
+                <HeadingSmall
+                    title="Versand-Modus"
+                    description="Wählen Sie, wie Antwortvorschläge an Gäste herausgehen. Hard-Gates greifen unabhängig vom Modus."
+                />
+
+                <div class="grid gap-4 md:grid-cols-3">
+                    <div
+                        v-for="card in modeCards"
+                        :key="card.value"
+                        :class="[
+                            'flex flex-col rounded-lg border p-4 shadow-sm',
+                            card.value === sendMode ? 'border-primary ring-2 ring-primary/40' : 'border-border',
+                        ]"
+                        :data-mode="card.value"
+                        :data-active="card.value === sendMode"
+                    >
+                        <div class="flex items-center justify-between">
+                            <h3 class="text-lg font-semibold">{{ card.title }}</h3>
+                            <span :class="['rounded-full px-2 py-0.5 text-xs font-medium', riskBadgeClass(card.risk)]">
+                                Risiko: {{ card.risk }}
+                            </span>
+                        </div>
+                        <p class="mt-2 flex-1 text-sm text-muted-foreground">
+                            {{ card.description }}
+                        </p>
+                        <Button class="mt-4" :disabled="card.value === sendMode || form.processing" @click="requestModeChange(card.value)">
+                            {{ card.value === sendMode ? 'Aktiv' : 'Aktivieren' }}
+                        </Button>
+                    </div>
+                </div>
+
+                <p v-if="sendMode !== 'manual'" class="rounded-md bg-amber-50 p-4 text-sm text-amber-900 dark:bg-amber-900/20 dark:text-amber-200">
+                    Datenschutz-Hinweis: Auto-Versand muss in der Datenschutzerklärung des Restaurants erwähnt werden.
+                </p>
+
+                <form @submit.prevent="submit()" class="grid gap-6 md:grid-cols-2">
+                    <div class="grid gap-2">
+                        <Label for="party-size-max"> Max. Personenzahl für Auto-Versand </Label>
+                        <Input id="party-size-max" type="number" min="1" max="50" v-model="form.auto_send_party_size_max" />
+                        <InputError :message="form.errors.auto_send_party_size_max" />
+                    </div>
+
+                    <div class="grid gap-2">
+                        <Label for="min-lead-time"> Mindest-Vorlauf in Minuten </Label>
+                        <Input id="min-lead-time" type="number" min="0" max="1440" v-model="form.auto_send_min_lead_time_minutes" />
+                        <InputError :message="form.errors.auto_send_min_lead_time_minutes" />
+                    </div>
+
+                    <div class="md:col-span-2">
+                        <Button type="submit" :disabled="form.processing"> Einstellungen speichern </Button>
+                    </div>
+                </form>
+
+                <section v-if="showsKillswitch" class="rounded-md border border-red-300 bg-red-50 p-4 dark:border-red-900/50 dark:bg-red-900/20">
+                    <h3 class="text-base font-semibold text-red-900 dark:text-red-200">Killswitch</h3>
+                    <p class="mt-1 text-sm text-red-900/80 dark:text-red-200/80">
+                        Stoppt Auto-Versand sofort und bricht alle ausstehenden Versandvorgänge ab.
+                    </p>
+                    <Button class="mt-3" variant="destructive" @click="triggerKillswitch"> Auto-Versand sofort stoppen </Button>
+                </section>
+            </div>
+
+            <Dialog :open="pendingMode !== null" @update:open="(open) => !open && cancelModeChange()">
+                <DialogContent>
+                    <DialogHeader>
+                        <DialogTitle>
+                            Modus wechseln zu
+                            {{ pendingMode === 'auto' ? 'Automatischer Versand' : pendingMode === 'shadow' ? 'Shadow-Modus' : 'Manuelle Freigabe' }}
+                            ?
+                        </DialogTitle>
+                        <DialogDescription v-if="isShadowToAuto && shadowStats.hasData">
+                            In den letzten 30 Tagen wurden {{ shadowStats.takenOver }} von {{ shadowStats.total }} Shadow-Antworten ohne Änderung
+                            übernommen ({{ takeoverRatePercent }}%). Auto-Versand bedeutet: ab jetzt gehen Antworten automatisch an Gäste, sofern
+                            keine Sicherheitsregel greift.
+                        </DialogDescription>
+                        <DialogDescription v-else-if="isShadowToAuto">
+                            Es liegen noch keine Shadow-Daten vor. Wir empfehlen mindestens 30 Tage Shadow-Modus, bevor Sie auf Auto wechseln.
+                        </DialogDescription>
+                        <DialogDescription v-else> Sind Sie sicher, dass Sie den Modus jetzt wechseln möchten? </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                        <Button variant="ghost" @click="cancelModeChange">Abbrechen</Button>
+                        <Button @click="confirmModeChange" :disabled="form.processing"> Bestätigen </Button>
+                    </DialogFooter>
+                </DialogContent>
+            </Dialog>
+        </SettingsLayout>
+    </AppLayout>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -57,6 +57,8 @@ declare module 'ziggy-js' {
     "password.edit": [],
     "password.update": [],
     "appearance": [],
+    "settings.send-mode.edit": [],
+    "settings.send-mode.update": [],
     "register": [],
     "login": [],
     "password.request": [],

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
+use App\Http\Controllers\Settings\SendModeSettingsController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -18,4 +19,9 @@ Route::middleware('auth')->group(function () {
     Route::get('settings/appearance', function () {
         return Inertia::render('settings/Appearance');
     })->name('appearance');
+
+    Route::get('settings/send-mode', [SendModeSettingsController::class, 'edit'])
+        ->name('settings.send-mode.edit');
+    Route::patch('settings/send-mode', [SendModeSettingsController::class, 'update'])
+        ->name('settings.send-mode.update');
 });

--- a/tests/Feature/AutoSend/SendModeSettingsTest.php
+++ b/tests/Feature/AutoSend/SendModeSettingsTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\SendMode;
+use App\Enums\UserRole;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class SendModeSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_allows_owner_to_switch_from_manual_to_shadow(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Shadow->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $restaurant->refresh();
+        $this->assertSame(SendMode::Shadow, $restaurant->send_mode);
+        $this->assertNotNull($restaurant->send_mode_changed_at);
+        $this->assertSame($owner->id, $restaurant->send_mode_changed_by);
+    }
+
+    public function test_it_shows_takeover_stats_on_settings_page_when_in_shadow_mode(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Shadow);
+        $owner = $this->makeOwner($restaurant);
+
+        // 4 shadow replies in the window: 3 taken over verbatim, 1 modified.
+        $this->seedShadowReplies($restaurant, takenOver: 3, modified: 1);
+
+        $this->actingAs($owner)
+            ->get(route('settings.send-mode.edit'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('settings/SendMode')
+                ->where('sendMode', SendMode::Shadow->value)
+                ->where('shadowStats.total', 4)
+                ->where('shadowStats.takenOver', 3)
+                ->where('shadowStats.takeoverRate', 0.75)
+                ->where('shadowStats.hasData', true)
+            );
+    }
+
+    public function test_it_shows_no_data_state_when_no_shadow_replies_exist(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Shadow);
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->get(route('settings.send-mode.edit'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('shadowStats.total', 0)
+                ->where('shadowStats.hasData', false)
+                ->where('shadowStats.takeoverRate', null)
+            );
+    }
+
+    public function test_it_persists_party_size_limit_and_min_lead_time_changes(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Auto);
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Auto->value,
+                'auto_send_party_size_max' => 6,
+                'auto_send_min_lead_time_minutes' => 180,
+            ])
+            ->assertRedirect();
+
+        $restaurant->refresh();
+        $this->assertSame(6, $restaurant->auto_send_party_size_max);
+        $this->assertSame(180, $restaurant->auto_send_min_lead_time_minutes);
+    }
+
+    public function test_it_does_not_touch_send_mode_changed_when_only_thresholds_change(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Auto);
+        $restaurant->forceFill([
+            'send_mode_changed_at' => now()->subDays(7),
+            'send_mode_changed_by' => null,
+        ])->save();
+        $oldChangedAt = $restaurant->send_mode_changed_at->toIso8601String();
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Auto->value,
+                'auto_send_party_size_max' => 7,
+                'auto_send_min_lead_time_minutes' => 120,
+            ])
+            ->assertRedirect();
+
+        $this->assertSame($oldChangedAt, $restaurant->fresh()->send_mode_changed_at->toIso8601String());
+    }
+
+    public function test_it_forbids_staff_from_changing_send_mode(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $staff = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Staff,
+        ]);
+
+        $this->actingAs($staff)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Auto->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+            ])
+            ->assertForbidden();
+
+        $this->assertSame(SendMode::Manual, $restaurant->fresh()->send_mode);
+    }
+
+    public function test_it_forbids_staff_from_viewing_send_mode_settings(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $staff = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Staff,
+        ]);
+
+        $this->actingAs($staff)
+            ->get(route('settings.send-mode.edit'))
+            ->assertForbidden();
+    }
+
+    public function test_it_validates_send_mode_value(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => 'rocket-launch',
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+            ])
+            ->assertSessionHasErrors('send_mode');
+    }
+
+    private function makeRestaurantWithMode(SendMode $mode): Restaurant
+    {
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => $mode])->save();
+
+        return $restaurant;
+    }
+
+    private function makeOwner(Restaurant $restaurant): User
+    {
+        return User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Owner,
+        ]);
+    }
+
+    private function seedShadowReplies(Restaurant $restaurant, int $takenOver, int $modified): void
+    {
+        for ($i = 0; $i < $takenOver; $i++) {
+            $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+            ReservationReply::factory()->create([
+                'reservation_request_id' => $request->id,
+                'status' => ReservationReplyStatus::Shadow,
+                'send_mode_at_creation' => SendMode::Shadow->value,
+                'shadow_compared_at' => now()->subDays(2),
+                'shadow_was_modified' => false,
+            ]);
+        }
+
+        for ($i = 0; $i < $modified; $i++) {
+            $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+            ReservationReply::factory()->create([
+                'reservation_request_id' => $request->id,
+                'status' => ReservationReplyStatus::Shadow,
+                'send_mode_at_creation' => SendMode::Shadow->value,
+                'shadow_compared_at' => now()->subDays(2),
+                'shadow_was_modified' => true,
+            ]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- New routes `GET/PATCH /settings/send-mode` (`settings.send-mode.edit` / `settings.send-mode.update`).
- New `App\Http\Controllers\Settings\SendModeSettingsController` (`edit` + `update`) and `App\Http\Requests\Settings\SendModeSettingsUpdateRequest` (FormRequest validates mode enum + threshold ranges).
- Stats helper aggregates the last 30 days of shadow replies into `{total, takenOver, takeoverRate, hasData}` so the shadow→auto confirmation dialog can show the real takeover-rate figure the operator built up.
- New Inertia page `resources/js/pages/settings/SendMode.vue`:
  - three Reka-UI cards (Manual / Shadow / Auto), each with title, description, risk badge and Aktivieren button (disabled for the active mode);
  - confirmation dialog before every mode change; the shadow→auto dialog renders the real "X von Y wurden verbatim übernommen (Z%)" figure or a no-data fallback;
  - hard-gate thresholds (party-size-max, min-lead-time-minutes) as number inputs in the same form;
  - red killswitch CTA, only rendered when mode ≠ manual; it POSTs through the existing #219 endpoint;
  - Datenschutz-Hinweis appears when mode ≠ manual.
- Authorization enforced through `RestaurantPolicy::manageSendMode` via `Gate::authorize` in the controller — staff and foreign-tenant users get 403.

## Why

PRD-007 § Settings-UI made this page the single place where the owner moves a restaurant up the trust ladder, with the shadow takeover-rate as the load-bearing decision-support figure for the `shadow → auto` jump. Without the stats the dialog is generic; with the stats the operator can see (and the audit later confirm) that the jump was data-driven.

## Test plan

- New `tests/Feature/AutoSend/SendModeSettingsTest.php` (8 tests):
  - manual → shadow flip + snapshot fields,
  - takeover stats rendered when shadow data exists,
  - no-data state when no shadow replies exist,
  - threshold persistence (party-size-max + min-lead-time),
  - threshold-only edit does NOT touch `send_mode_changed_at`,
  - staff cannot PATCH (403),
  - staff cannot GET (403),
  - validation error on bogus mode value.
- `php artisan test` — 661 / 2006 assertions green.
- `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check` — green.
- `npm run build` succeeds; `php artisan ziggy:generate --types-only` re-run.

Closes #220