### PR TITLE
Dashboard mode banner + cancel-auto-send + countdown composable (partial #221)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -56,6 +56,11 @@ final class DashboardController extends Controller
             'openaiKeyRejectedAt' => $request->user()?->role === UserRole::Owner
                 ? OpenAiKeyHealth::rejectedAt()
                 : null,
+            // PRD-007 mode banner. Surfaces the active send-mode at the
+            // top of the dashboard whenever it deviates from the V1.0
+            // default — so the operator always sees that auto-send is
+            // armed and where to flip the killswitch.
+            'sendMode' => $request->user()?->restaurant?->send_mode->value,
         ]);
     }
 

--- a/app/Http/Controllers/ReservationReplyController.php
+++ b/app/Http/Controllers/ReservationReplyController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 use App\Enums\ReservationReplyStatus;
 use App\Http\Requests\ApproveReservationReplyRequest;
 use App\Jobs\SendReservationReplyJob;
+use App\Models\AutoSendAudit;
 use App\Models\ReservationReply;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -40,5 +41,29 @@ class ReservationReplyController extends Controller
         SendReservationReplyJob::dispatch($reply->id);
 
         return back()->with('success', 'Antwort freigegeben — sie wird gleich versendet.');
+    }
+
+    /**
+     * Cancel a still-scheduled auto-send during its 60-second cancel
+     * window (PRD-007). The actual send hasn't gone out yet — the
+     * `ScheduledAutoSendJob` will see the status flip when it wakes up
+     * and silently no-op (race-condition guard in #217).
+     */
+    public function cancelAutoSend(ReservationReply $reply): RedirectResponse
+    {
+        if ($reply->status !== ReservationReplyStatus::ScheduledAutoSend) {
+            return back()->with('error', 'Diese Antwort ist nicht im Auto-Versand-Fenster.');
+        }
+
+        $reply->forceFill(['status' => ReservationReplyStatus::CancelledAuto])->save();
+
+        AutoSendAudit::write(
+            $reply,
+            AutoSendAudit::DECISION_CANCELLED_AUTO,
+            'cancelled_by_owner',
+            Auth::id(),
+        );
+
+        return back()->with('success', 'Versand abgebrochen.');
     }
 }

--- a/app/Policies/ReservationReplyPolicy.php
+++ b/app/Policies/ReservationReplyPolicy.php
@@ -19,4 +19,15 @@ final class ReservationReplyPolicy
     {
         return $this->view($user, $reply);
     }
+
+    /**
+     * Cancelling a scheduled auto-send is operator-level — the same
+     * tenancy check `view`/`approve` use applies. We don't gate by
+     * role here: any operator (Owner or Staff) on the right restaurant
+     * can hit the cancel button while the cancel window is open.
+     */
+    public function cancelAutoSend(User $user, ReservationReply $reply): bool
+    {
+        return $this->view($user, $reply);
+    }
 }

--- a/resources/js/composables/useCountdown.test.ts
+++ b/resources/js/composables/useCountdown.test.ts
@@ -1,0 +1,103 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, h, ref, type Ref } from 'vue';
+import { useCountdown } from './useCountdown';
+
+/**
+ * Pins the PRD-007 cancel-window countdown contract: ticks down once a
+ * second from a deadline timestamp, clamps at zero, resets when the
+ * deadline changes, and cleans up its interval on dispose.
+ */
+describe('useCountdown', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-04-30T12:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    function mountCountdown(deadline: Ref<string | null>) {
+        const captured: { secondsLeft: Ref<number>; isExpired: Ref<boolean> } = {
+            secondsLeft: ref(0),
+            isExpired: ref(false),
+        };
+
+        const Component = defineComponent({
+            setup() {
+                const handle = useCountdown(deadline);
+                captured.secondsLeft = handle.secondsLeft;
+                captured.isExpired = handle.isExpired;
+                return () => h('div');
+            },
+        });
+
+        const wrapper = mount(Component);
+        return { wrapper, captured };
+    }
+
+    it('starts at the difference between deadline and now in whole seconds', () => {
+        const deadline = ref<string | null>('2026-04-30T12:00:45Z');
+        const { captured } = mountCountdown(deadline);
+
+        expect(captured.secondsLeft.value).toBe(45);
+        expect(captured.isExpired.value).toBe(false);
+    });
+
+    it('ticks down once per second until it reaches zero', async () => {
+        const deadline = ref<string | null>('2026-04-30T12:00:03Z');
+        const { captured } = mountCountdown(deadline);
+
+        expect(captured.secondsLeft.value).toBe(3);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(captured.secondsLeft.value).toBe(2);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(captured.secondsLeft.value).toBe(1);
+
+        await vi.advanceTimersByTimeAsync(1_000);
+        expect(captured.secondsLeft.value).toBe(0);
+        expect(captured.isExpired.value).toBe(true);
+    });
+
+    it('clamps to zero when the deadline is already in the past', () => {
+        const deadline = ref<string | null>('2026-04-30T11:59:00Z');
+        const { captured } = mountCountdown(deadline);
+
+        expect(captured.secondsLeft.value).toBe(0);
+        expect(captured.isExpired.value).toBe(true);
+    });
+
+    it('resets when the deadline ref changes', async () => {
+        const deadline = ref<string | null>('2026-04-30T12:00:05Z');
+        const { captured } = mountCountdown(deadline);
+
+        expect(captured.secondsLeft.value).toBe(5);
+
+        deadline.value = '2026-04-30T12:00:42Z';
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(captured.secondsLeft.value).toBe(42);
+    });
+
+    it('returns zero when the deadline is null', () => {
+        const deadline = ref<string | null>(null);
+        const { captured } = mountCountdown(deadline);
+
+        expect(captured.secondsLeft.value).toBe(0);
+        expect(captured.isExpired.value).toBe(true);
+    });
+
+    it('stops the interval on unmount so background timers do not leak', async () => {
+        const deadline = ref<string | null>('2026-04-30T12:00:10Z');
+        const { wrapper, captured } = mountCountdown(deadline);
+
+        expect(captured.secondsLeft.value).toBe(10);
+        wrapper.unmount();
+
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(captured.secondsLeft.value).toBe(10); // Frozen at last value.
+    });
+});

--- a/resources/js/composables/useCountdown.ts
+++ b/resources/js/composables/useCountdown.ts
@@ -1,0 +1,80 @@
+import { computed, onScopeDispose, ref, watchEffect, type Ref } from 'vue';
+
+export interface UseCountdownOptions {
+    /**
+     * Provide a deterministic clock for tests (must return the current
+     * timestamp in milliseconds since the epoch). Falls back to
+     * `Date.now` in production.
+     */
+    now?: () => number;
+}
+
+export interface UseCountdownHandle {
+    /**
+     * Remaining seconds, clamped to zero. Reactive: it ticks down every
+     * second while the deadline is in the future.
+     */
+    secondsLeft: Ref<number>;
+
+    /**
+     * `true` once the countdown reaches zero. Stays `true` afterwards.
+     */
+    isExpired: Ref<boolean>;
+}
+
+/**
+ * Tick-down composable for the PRD-007 cancel-window banner. Pass a
+ * reactive ISO-8601 timestamp; `secondsLeft` updates once a second and
+ * clamps at zero so callers can render `…in {seconds}s` without doing
+ * the math themselves. When the deadline changes (the operator picks a
+ * different reply in the drawer), the timer resets cleanly.
+ *
+ * Cleans up its interval on scope dispose.
+ */
+export function useCountdown(deadline: Ref<string | Date | null | undefined>, options: UseCountdownOptions = {}): UseCountdownHandle {
+    const now = options.now ?? Date.now;
+    const secondsLeft = ref(0);
+    let timer: ReturnType<typeof setInterval> | null = null;
+
+    const stop = () => {
+        if (timer !== null) {
+            clearInterval(timer);
+            timer = null;
+        }
+    };
+
+    const tick = (deadlineMs: number) => {
+        const remaining = Math.max(0, Math.ceil((deadlineMs - now()) / 1000));
+        secondsLeft.value = remaining;
+        if (remaining === 0) {
+            stop();
+        }
+    };
+
+    watchEffect(() => {
+        stop();
+
+        const value = deadline.value;
+        if (value === null || value === undefined) {
+            secondsLeft.value = 0;
+            return;
+        }
+
+        const deadlineMs = value instanceof Date ? value.getTime() : new Date(value).getTime();
+        if (Number.isNaN(deadlineMs)) {
+            secondsLeft.value = 0;
+            return;
+        }
+
+        tick(deadlineMs);
+        if (secondsLeft.value > 0) {
+            timer = setInterval(() => tick(deadlineMs), 1000);
+        }
+    });
+
+    onScopeDispose(stop);
+
+    const isExpired = computed(() => secondsLeft.value === 0);
+
+    return { secondsLeft, isExpired };
+}

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -35,6 +35,7 @@ interface DashboardProps {
     selectedRequest?: ReservationRequestDetail | null;
     threadMessages?: ThreadMessage[] | null;
     openaiKeyRejectedAt?: string | null;
+    sendMode?: 'manual' | 'shadow' | 'auto' | null;
 }
 
 const props = defineProps<DashboardProps>();
@@ -44,6 +45,28 @@ const breadcrumbs: BreadcrumbItem[] = [{ title: 'Dashboard', href: '/dashboard' 
 const page = usePage<SharedData>();
 const restaurantName = computed(() => page.props.restaurant?.name ?? '');
 const restaurantTimezone = computed(() => page.props.restaurant?.timezone);
+
+// PRD-007 mode banner. Shows yellow for shadow (test mode, no risk to
+// guests yet) and red for auto (mail flows without operator approval),
+// so the operator always knows what their dashboard is wired up to do
+// and where the killswitch lives.
+const sendModeBanner = computed(() => {
+    if (props.sendMode === 'shadow') {
+        return {
+            kind: 'shadow' as const,
+            title: 'Shadow-Modus aktiv',
+            body: 'KI-Antworten werden generiert und als „wäre versendet worden" markiert, gehen aber NICHT an Gäste.',
+        };
+    }
+    if (props.sendMode === 'auto') {
+        return {
+            kind: 'auto' as const,
+            title: 'Automatischer Versand aktiv',
+            body: 'KI-Antworten gehen 60 Sekunden nach Generierung automatisch an Gäste, sofern keine Sicherheitsregel greift.',
+        };
+    }
+    return null;
+});
 
 const STATUS_OPTIONS: { value: ReservationStatus; label: string }[] = [
     { value: 'new', label: 'Neu' },
@@ -389,6 +412,24 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                         die nächste Antwort erfolgreich generiert wird, verschwindet dieser Hinweis automatisch.
                     </p>
                 </div>
+            </div>
+
+            <div
+                v-if="sendModeBanner"
+                :class="[
+                    'flex items-start gap-3 rounded-md border px-4 py-3 text-sm',
+                    sendModeBanner.kind === 'auto'
+                        ? 'border-red-300 bg-red-50 text-red-900 dark:border-red-700/60 dark:bg-red-950/40 dark:text-red-100'
+                        : 'border-amber-300 bg-amber-50 text-amber-900 dark:border-amber-700/60 dark:bg-amber-950/40 dark:text-amber-100',
+                ]"
+                data-testid="send-mode-banner"
+            >
+                <Info class="mt-0.5 size-5 shrink-0" />
+                <div class="flex-1">
+                    <strong class="font-medium">{{ sendModeBanner.title }}</strong>
+                    <p class="leading-relaxed">{{ sendModeBanner.body }}</p>
+                </div>
+                <Link :href="route('settings.send-mode.edit')" class="shrink-0 text-sm font-medium underline"> Einstellungen </Link>
             </div>
 
             <header class="flex flex-wrap items-end justify-between gap-4" data-testid="restaurant-header">

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -23,6 +23,13 @@ declare module 'ziggy-js' {
             "binding": "id"
         }
     ],
+    "reservation-replies.cancel-auto-send": [
+        {
+            "name": "reply",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "restaurants.send-mode.killswitch": [
         {
             "name": "restaurant",

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,10 @@ Route::post('reservation-replies/{reply}/approve', [ReservationReplyController::
     ->middleware(['auth', 'verified', 'can:approve,reply'])
     ->name('reservation-replies.approve');
 
+Route::post('reservation-replies/{reply}/cancel-auto-send', [ReservationReplyController::class, 'cancelAutoSend'])
+    ->middleware(['auth', 'verified', 'can:cancelAutoSend,reply'])
+    ->name('reservation-replies.cancel-auto-send');
+
 Route::post('restaurants/{restaurant}/send-mode/killswitch', SendModeKillswitchController::class)
     ->middleware(['auth', 'verified', 'can:manageSendMode,restaurant'])
     ->name('restaurants.send-mode.killswitch');

--- a/tests/Feature/AutoSend/CancelAutoSendTest.php
+++ b/tests/Feature/AutoSend/CancelAutoSendTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\UserRole;
+use App\Models\AutoSendAudit;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CancelAutoSendTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_cancels_scheduled_send_when_owner_clicks_cancel(): void
+    {
+        $reply = $this->scheduledReply();
+        $owner = User::factory()->create([
+            'restaurant_id' => $reply->reservationRequest->restaurant_id,
+            'role' => UserRole::Owner,
+        ]);
+
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.cancel-auto-send', $reply))
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::CancelledAuto, $reply->status);
+
+        $this->assertDatabaseHas('auto_send_audits', [
+            'reservation_reply_id' => $reply->id,
+            'decision' => AutoSendAudit::DECISION_CANCELLED_AUTO,
+            'reason' => 'cancelled_by_owner',
+            'triggered_by_user_id' => $owner->id,
+        ]);
+    }
+
+    public function test_it_no_ops_when_reply_is_not_in_the_cancel_window(): void
+    {
+        $request = ReservationRequest::factory()->forRestaurant(Restaurant::factory()->create())->create();
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Sent,
+        ]);
+
+        $owner = User::factory()->create([
+            'restaurant_id' => $request->restaurant_id,
+            'role' => UserRole::Owner,
+        ]);
+
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.cancel-auto-send', $reply))
+            ->assertRedirect()
+            ->assertSessionHas('error');
+
+        $this->assertSame(ReservationReplyStatus::Sent, $reply->fresh()->status);
+        $this->assertSame(0, AutoSendAudit::query()->count());
+    }
+
+    public function test_it_blocks_a_user_from_cancelling_a_foreign_tenants_reply(): void
+    {
+        $reply = $this->scheduledReply();
+
+        $foreignUser = User::factory()->create([
+            'restaurant_id' => Restaurant::factory()->create()->id,
+            'role' => UserRole::Owner,
+        ]);
+
+        // The global RestaurantScope on ReservationReply hides cross-tenant
+        // rows entirely, so route-model binding 404s before the policy gets
+        // a chance to 403. Either response means "not your reply" — both
+        // protect the cancel-window from cross-tenant abuse.
+        $this->actingAs($foreignUser)
+            ->post(route('reservation-replies.cancel-auto-send', $reply))
+            ->assertNotFound();
+
+        $this->assertSame(ReservationReplyStatus::ScheduledAutoSend, $reply->fresh()->status);
+    }
+
+    private function scheduledReply(): ReservationReply
+    {
+        $request = ReservationRequest::factory()
+            ->forRestaurant(Restaurant::factory()->create())
+            ->create();
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::ScheduledAutoSend,
+            'auto_send_scheduled_for' => now()->addSeconds(60),
+        ]);
+    }
+}

--- a/tests/Feature/AutoSend/DashboardModeBannerTest.php
+++ b/tests/Feature/AutoSend/DashboardModeBannerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\SendMode;
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class DashboardModeBannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_shows_send_mode_on_dashboard_when_not_manual(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $restaurant->forceFill(['send_mode' => SendMode::Auto])->save();
+
+        $owner = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Owner,
+        ]);
+
+        $this->actingAs($owner)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->where('sendMode', SendMode::Auto->value)
+            );
+    }
+
+    public function test_it_passes_manual_send_mode_in_v1_default(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Owner,
+        ]);
+
+        $this->actingAs($owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('sendMode', SendMode::Manual->value)
+            );
+    }
+}


### PR DESCRIPTION
## Summary

Three deliverable pieces of PRD-007's dashboard surface, sized so they can land cleanly in one PR. The remaining detail-drawer integration is deferred to a follow-up.

**Dashboard banner (delivered)**
- `DashboardController` passes `sendMode` (the active restaurant mode) as an Inertia prop.
- `Dashboard.vue` renders a banner above the existing OpenAI-key banner when `sendMode !== 'manual'` — yellow for shadow, red for auto. Banner links to `/settings/send-mode`.

**Cancel-auto-send endpoint (delivered)**
- New route `POST /reservation-replies/{reply}/cancel-auto-send` (route name `reservation-replies.cancel-auto-send`), gated by `auth + verified + can:cancelAutoSend,reply`.
- New `ReservationReplyPolicy::cancelAutoSend` (operator-level — Owner or Staff on the same restaurant).
- Controller action sets the reply to `cancelled_auto` and writes one `auto_send_audits` row with reason `cancelled_by_owner` and `triggered_by_user_id = auth()->id()`. Idempotent: replies that aren't in the cancel window get a flash error and no audit row.
- Foreign-tenant attempts 404 via the global `RestaurantScope` on `ReservationReply`.

**`useCountdown` composable (delivered)**
- New `resources/js/composables/useCountdown.ts` ticks down once a second from a reactive ISO-8601 deadline, clamps at zero, resets when the deadline ref changes, cleans up on dispose. Optional `now` injection for deterministic tests.
- Six Vitest cases cover the contract (initial value, ticking, past-deadline clamp, deadline change reset, null deadline, unmount cleanup).

## Out of scope (follow-up)

The detail-drawer redesign sits on top of a fairly complex `Dashboard.vue` and warrants its own PR:
- Shadow-mode banner inside the drawer + read-only diff block + "Doch manuell freigeben & versenden" button (promotes Shadow → Approved through the existing approve flow).
- Setting `shadow_compared_at` when the operator opens the drawer for a shadow reply, and `shadow_was_modified` when the body is edited (these feed the takeover-rate stats #220 already exposes).
- Live cancel-window countdown banner inside the drawer, wiring the new `useCountdown` composable to `auto_send_scheduled_for` and the cancel button.

The cancel endpoint + composable are deliberately landed first so the drawer follow-up only deals with UI plumbing.

## Test plan

- New `tests/Feature/AutoSend/CancelAutoSendTest.php` (3 tests): owner cancels → status flips + audit row; non-scheduled reply → no-op + flash error; foreign tenant → 404.
- New `tests/Feature/AutoSend/DashboardModeBannerTest.php` (2 tests): `sendMode` prop is `'auto'` when restaurant is in Auto, `'manual'` for V1 default.
- New `resources/js/composables/useCountdown.test.ts` (6 vitest cases).
- `php artisan test` — 666 / 2038 assertions green.
- `npm run test` — 50 / 50 vitest cases green.
- Pint, ESLint, Prettier, `npm run build`, ziggy regen — green.

Refs #221