### PR TITLE
PRD-007 test consolidation: cancel + manual-approve race scenarios (#223)

### DIFF
--- a/tests/Feature/AutoSend/SendModeFlowTest.php
+++ b/tests/Feature/AutoSend/SendModeFlowTest.php
@@ -9,12 +9,14 @@ use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
 use App\Enums\SendMode;
+use App\Enums\UserRole;
 use App\Jobs\ScheduledAutoSendJob;
 use App\Mail\ReservationReplyMail;
 use App\Models\AutoSendAudit;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
+use App\Models\User;
 use App\Services\AI\AutoSendDecider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Mail;
@@ -126,6 +128,64 @@ class SendModeFlowTest extends TestCase
             'decision' => AutoSendAudit::DECISION_CANCELLED_AUTO,
             'reason' => AutoSendAudit::REASON_HARD_GATE_LATE_PREFIX.AutoSendDecider::REASON_PARTY_SIZE_OVER_LIMIT,
         ]);
+    }
+
+    public function test_it_cancels_scheduled_send_when_owner_clicks_cancel(): void
+    {
+        Mail::fake();
+
+        $reply = $this->scheduledReplyOnAutoRestaurant();
+        $owner = User::factory()->create([
+            'restaurant_id' => $reply->reservationRequest->restaurant_id,
+            'role' => UserRole::Owner,
+        ]);
+
+        // Operator clicks Cancel inside the cancel window.
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.cancel-auto-send', $reply))
+            ->assertRedirect();
+
+        $this->assertSame(ReservationReplyStatus::CancelledAuto, $reply->fresh()->status);
+
+        // The delayed job fires after the window — must no-op cleanly.
+        (new ScheduledAutoSendJob($reply->id))->handle(app(AutoSendDecider::class));
+
+        Mail::assertNothingSent();
+        $this->assertSame(ReservationReplyStatus::CancelledAuto, $reply->fresh()->status);
+
+        // Single audit row from the cancel click; the post-cancel job
+        // run must not write a second one.
+        $this->assertSame(
+            1,
+            AutoSendAudit::query()->where('reservation_reply_id', $reply->id)->count(),
+        );
+    }
+
+    public function test_it_short_circuits_scheduled_send_when_owner_approves_manually_within_window(): void
+    {
+        Mail::fake();
+
+        $reply = $this->scheduledReplyOnAutoRestaurant();
+        $owner = User::factory()->create([
+            'restaurant_id' => $reply->reservationRequest->restaurant_id,
+            'role' => UserRole::Owner,
+        ]);
+
+        // Operator approves manually before the 60s delay elapses.
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.approve', $reply), ['body' => $reply->body])
+            ->assertRedirect();
+
+        // Approve dispatches SendReservationReplyJob synchronously enough
+        // for our `sync` queue, so the mail goes out via that path…
+        Mail::assertSent(ReservationReplyMail::class, 1);
+
+        // …and when the still-queued ScheduledAutoSendJob wakes up later,
+        // its first race-guard sees `status !== ScheduledAutoSend` and
+        // returns silently — no second send goes out.
+        (new ScheduledAutoSendJob($reply->id))->handle(app(AutoSendDecider::class));
+
+        Mail::assertSent(ReservationReplyMail::class, 1);
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds the two `SendModeFlowTest` scenarios called out by #223 that were not yet covered as end-to-end pairs:

- **`it_cancels_scheduled_send_when_owner_clicks_cancel`** — operator clicks Cancel inside the 60s window: status goes to `cancelled_auto`, one audit row is written, and the delayed `ScheduledAutoSendJob` no-ops cleanly on its first race-guard (no double audit, no mail).
- **`it_short_circuits_scheduled_send_when_owner_approves_manually_within_window`** — operator approves manually inside the 60s window: `SendReservationReplyJob` fires once via the V1.0 path, mail goes out, and the still-queued `ScheduledAutoSendJob` no-ops when it wakes up (no second mail).

## Why

The race-guard pair (cancel endpoint flips status before `ScheduledAutoSendJob` wakes; the job's first check is `status !== ScheduledAutoSend`) was already implemented across #269 / #273, but the integration tests were spread across two files. These two new tests give #223 its single, named, end-to-end pair so the consolidation issue can close cleanly.

## What was already covered (by prior PRs in the chain)

- Hard-gate matrix per gate + returning/declined-guest distinctions → `AutoSendDeciderTest` (#267, #268, 12 tests).
- `it_does_not_send_mail_in_shadow_mode`, `it_dispatches_scheduled_auto_send_with_60_second_delay`, audit-no-PII, V1.0 default compatibility → `AuditTrailTest` (#270).
- `it_sends_mail_after_cancel_window_in_auto_mode`, killswitch-during-window, hard-gate-late re-evaluation → `SendModeFlowTest` (#269).
- Killswitch + foreign-tenant + staff-403 → `KillswitchTest` (#271).
- Send-mode settings page + threshold persistence + 403 cases → `SendModeSettingsTest` (#272).
- Cancel-endpoint happy-path / wrong-status / foreign-tenant → `CancelAutoSendTest` (#273).
- Dashboard banner prop wiring → `DashboardModeBannerTest` (#273).

## Test plan

- `php artisan test --filter SendModeFlow` — 7 / 24 assertions green.
- `php artisan test` — full suite, 668 / 2046 assertions green.
- Pint, ESLint, Prettier — green.

Closes #223