### PR TITLE
Persist original_body + model + fallback meta in ai_prompt_snapshot (#224)

### DIFF
--- a/app/Jobs/GenerateReservationReplyJob.php
+++ b/app/Jobs/GenerateReservationReplyJob.php
@@ -82,7 +82,7 @@ class GenerateReservationReplyJob implements ShouldQueue
                 'reservation_request_id' => $request->id,
                 'status' => ReservationReplyStatus::Draft,
                 'body' => $body,
-                'ai_prompt_snapshot' => $context,
+                'ai_prompt_snapshot' => $this->buildSnapshot($context, $body, isFallback: false),
             ]);
 
             $this->applyAutoSendDecision($reply);
@@ -134,11 +134,44 @@ class GenerateReservationReplyJob implements ShouldQueue
             'reservation_request_id' => $request->id,
             'status' => ReservationReplyStatus::Draft,
             'body' => OpenAiReplyGenerator::FALLBACK_TEXT,
-            'ai_prompt_snapshot' => $context,
+            'ai_prompt_snapshot' => $this->buildSnapshot($context, OpenAiReplyGenerator::FALLBACK_TEXT, isFallback: true),
             'is_fallback' => true,
         ]);
 
         $this->applyAutoSendDecision($reply);
+    }
+
+    /**
+     * The `ai_prompt_snapshot` carries the deterministic context the
+     * builder produced, plus three meta fields that PRD-008 analytics
+     * (edit-rate, shadow takeover-rate, model-drift) read after the
+     * fact:
+     *
+     *   - `original_body`: the AI's *original* draft, before any
+     *     operator edit. Comparing it against the persisted `body`
+     *     reveals the edit-rate.
+     *   - `model`: which OpenAI model produced the draft, so model
+     *     swaps don't pollute the analytics.
+     *   - `fallback`: whether the body is the neutral fallback text
+     *     (401 / 429 / 5xx / timeout). Mirrors the `is_fallback`
+     *     column for consumers that only see the snapshot.
+     *
+     * Backwards-compatible with PRD-005 consumers: the context fields
+     * stay at the top level (e.g. `ai_prompt_snapshot['request']`),
+     * the new keys are siblings. Replies created before this change
+     * have no `original_body` and PRD-008 treats them as `not modified`
+     * (documented in the analytics PRD risks section).
+     *
+     * @param  array<string, mixed>|null  $context
+     * @return array<string, mixed>
+     */
+    private function buildSnapshot(?array $context, string $originalBody, bool $isFallback): array
+    {
+        return ($context ?? []) + [
+            'original_body' => $originalBody,
+            'model' => (string) config('reservations.ai.openai_model', 'gpt-4o-mini'),
+            'fallback' => $isFallback,
+        ];
     }
 
     /**

--- a/tests/Feature/Jobs/GenerateReservationReplySnapshotTest.php
+++ b/tests/Feature/Jobs/GenerateReservationReplySnapshotTest.php
@@ -9,6 +9,7 @@ use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Services\AI\Contracts\ReplyGenerator;
+use App\Services\AI\OpenAiReplyGenerator;
 use App\Services\AI\ReservationContextBuilder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -65,7 +66,7 @@ class GenerateReservationReplySnapshotTest extends TestCase
         });
     }
 
-    public function test_happy_path_snapshot_is_byte_identical_to_builder_output(): void
+    public function test_happy_path_snapshot_preserves_builder_context_alongside_meta_fields(): void
     {
         $request = $this->makeRequest();
         $expected = (new ReservationContextBuilder)->build($request);
@@ -77,7 +78,16 @@ class GenerateReservationReplySnapshotTest extends TestCase
         /** @var ReservationReply $reply */
         $reply = ReservationReply::withoutGlobalScopes()->where('reservation_request_id', $request->id)->sole();
         $this->assertNotNull($reply->ai_prompt_snapshot);
-        $this->assertSame($expected, $reply->ai_prompt_snapshot);
+
+        // Each builder-produced context key is preserved verbatim.
+        foreach ($expected as $key => $value) {
+            $this->assertSame($value, $reply->ai_prompt_snapshot[$key], "Context key `{$key}` must be preserved.");
+        }
+
+        // PRD-008 meta fields ride next to the context.
+        $this->assertSame('Guten Tag, gerne!', $reply->ai_prompt_snapshot['original_body']);
+        $this->assertArrayHasKey('model', $reply->ai_prompt_snapshot);
+        $this->assertFalse($reply->ai_prompt_snapshot['fallback']);
     }
 
     public function test_snapshot_contains_every_top_level_block(): void
@@ -116,6 +126,19 @@ class GenerateReservationReplySnapshotTest extends TestCase
             $reply->ai_prompt_snapshot,
             'Fallback draft must still carry the context that WOULD have been sent.'
         );
-        $this->assertSame($expected, $reply->ai_prompt_snapshot);
+
+        // Context is preserved next to the fallback meta.
+        foreach ($expected as $key => $value) {
+            $this->assertSame($value, $reply->ai_prompt_snapshot[$key]);
+        }
+
+        // PRD-008 risk: pre-V2 replies with no `original_body` count as
+        // "not modified". Replies on the fallback path carry the neutral
+        // fallback text as their original, plus a fallback flag.
+        $this->assertSame(
+            OpenAiReplyGenerator::FALLBACK_TEXT,
+            $reply->ai_prompt_snapshot['original_body'],
+        );
+        $this->assertTrue($reply->ai_prompt_snapshot['fallback']);
     }
 }


### PR DESCRIPTION
## Summary

`GenerateReservationReplyJob` now writes three sibling meta fields next to the deterministic builder context inside `reservation_replies.ai_prompt_snapshot`:

- `original_body` — the body the generator returned (or the fallback text on the error matrix). Comparing this against the persisted `body` gives PRD-008's edit-rate.
- `model` — which OpenAI model produced the draft, sourced from `config('reservations.ai.openai_model')`. Lets PRD-008 separate stats per model so a model swap doesn't pollute the trend.
- `fallback` — boolean mirror of the `is_fallback` column for consumers that only see the snapshot.

The new `buildSnapshot()` helper centralizes the layout for both the happy path and `storeFallbackDraft`, so the two paths can never drift.

## Why

PRD-008 § Edit-Rate needs the AI's *original* draft to count operator edits. PRD-008's shadow takeover-rate uses the same comparison. The snapshot column already exists (`json` type, no migration), so this is a pure data-shape change in the writer.

Replies created before this change have no `original_body`. PRD-008 treats them as "not modified" — acknowledged risk in the analytics PRD.

## Backwards-compatibility

The existing PRD-005 consumers read snapshot keys like `ai_prompt_snapshot['request']['guest_name']` (resource hidden from the dashboard, dump tooling, and some tests). Those keys stay at the top level — the new meta fields are siblings, not a wrapper. Existing snapshot tests were updated to assert `foreach key in expected: snapshot[key] === expected[key]` rather than full-array `assertSame`, plus an explicit assertion on the new fields.

## Test plan

- `tests/Feature/Jobs/GenerateReservationReplySnapshotTest.php` (3 tests): happy-path preserves context + sets `original_body`/`model`/`fallback=false`; fallback path preserves context + sets `original_body=FALLBACK_TEXT`/`fallback=true`; structural-keys check unchanged.
- `php artisan test` — 668 / 2055 assertions green (no test elsewhere in the suite cares about the byte-equality of the snapshot).
- Pint, ESLint, Prettier — green.

Closes #224