### PR TITLE
AnalyticsRange enum + AnalyticsSnapshot DTO scaffolding (#225)

### DIFF
--- a/app/Enums/AnalyticsRange.php
+++ b/app/Enums/AnalyticsRange.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * Time-window selector for the PRD-008 analytics dashboard.
+ *
+ * Three windows are supported in V2.0: today (intra-day, hour buckets),
+ * the last 7 days, and the last 30 days. Larger ranges are deferred —
+ * cache hit-rate and chart density both degrade past 30 days, and the
+ * aggregator is not yet partitioned for that scale.
+ *
+ * Range bounds are computed in the restaurant's local timezone so a
+ * "today" lookup at 23:30 Berlin doesn't slip into UTC tomorrow.
+ */
+enum AnalyticsRange: string
+{
+    case Today = 'today';
+    case Last7Days = '7d';
+    case Last30Days = '30d';
+
+    /**
+     * Inclusive lower bound of the range, anchored to the start of the
+     * appropriate day in the restaurant timezone.
+     */
+    public function startsAt(string $timezone): Carbon
+    {
+        return match ($this) {
+            self::Today => Carbon::now($timezone)->startOfDay(),
+            self::Last7Days => Carbon::now($timezone)->startOfDay()->subDays(6),
+            self::Last30Days => Carbon::now($timezone)->startOfDay()->subDays(29),
+        };
+    }
+
+    /**
+     * Inclusive upper bound of the range, anchored to "now". Today is
+     * the only range that ends mid-day; the 7d and 30d windows still
+     * include partial-today bucket so the most recent activity shows
+     * up immediately.
+     */
+    public function endsAt(string $timezone): Carbon
+    {
+        return Carbon::now($timezone);
+    }
+
+    /**
+     * Bucket granularity for the trend chart. `today` shows one bucket
+     * per hour (24 buckets); `7d` and `30d` show one bucket per day.
+     */
+    public function bucketSize(): string
+    {
+        return match ($this) {
+            self::Today => 'hour',
+            self::Last7Days, self::Last30Days => 'day',
+        };
+    }
+
+    /**
+     * Number of buckets the trend chart should render. The aggregator
+     * uses this to gap-fill empty buckets so the chart never has holes.
+     */
+    public function bucketCount(): int
+    {
+        return match ($this) {
+            self::Today => 24,
+            self::Last7Days => 7,
+            self::Last30Days => 30,
+        };
+    }
+}

--- a/app/Http/Resources/AnalyticsSnapshotResource.php
+++ b/app/Http/Resources/AnalyticsSnapshotResource.php
@@ -17,7 +17,7 @@ use Illuminate\Http\Resources\Json\JsonResource;
  *
  * @property AnalyticsSnapshot $resource
  */
-class AnalyticsSnapshotResource extends JsonResource
+final class AnalyticsSnapshotResource extends JsonResource
 {
     /**
      * @return array<string, mixed>

--- a/app/Http/Resources/AnalyticsSnapshotResource.php
+++ b/app/Http/Resources/AnalyticsSnapshotResource.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Services\Analytics\AnalyticsSnapshot;
+use App\Services\Analytics\TrendBucket;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * Maps an `AnalyticsSnapshot` DTO 1:1 to the JSON shape the Inertia
+ * dashboard consumes. The resource is the seam where field names get
+ * camelCased for the frontend; the underlying DTO and the Vue page
+ * agree on this shape.
+ *
+ * @property AnalyticsSnapshot $resource
+ */
+class AnalyticsSnapshotResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $snapshot = $this->resource;
+
+        return [
+            'range' => $snapshot->range->value,
+            'bucketSize' => $snapshot->range->bucketSize(),
+            'totals' => $snapshot->totals,
+            'sources' => $snapshot->sources,
+            'statusBreakdown' => $snapshot->statusBreakdown,
+            'responseTime' => [
+                'medianMinutes' => $snapshot->responseTime->medianMinutes,
+                'p90Minutes' => $snapshot->responseTime->p90Minutes,
+                'sampleSize' => $snapshot->responseTime->sampleSize,
+            ],
+            'editRate' => $snapshot->editRate,
+            'sendModeStats' => $snapshot->sendModeStats === null ? null : [
+                'manual' => $snapshot->sendModeStats->manual,
+                'shadow' => $snapshot->sendModeStats->shadow,
+                'auto' => $snapshot->sendModeStats->auto,
+                'shadowComparedSampleSize' => $snapshot->sendModeStats->shadowComparedSampleSize,
+                'takeoverRate' => $snapshot->sendModeStats->takeoverRate,
+            ],
+            'trends' => array_map(
+                fn (TrendBucket $bucket) => [
+                    'label' => $bucket->label,
+                    'bucketStart' => $bucket->bucketStart,
+                    'count' => $bucket->count,
+                ],
+                $snapshot->trends,
+            ),
+        ];
+    }
+}

--- a/app/Services/Analytics/AnalyticsSnapshot.php
+++ b/app/Services/Analytics/AnalyticsSnapshot.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Enums\AnalyticsRange;
+
+/**
+ * Aggregator output for the PRD-008 dashboard. Plain readonly value
+ * object — not an Eloquent model — so the controller can hand it to
+ * `AnalyticsSnapshotResource` without ever touching the database
+ * outside the cached aggregator pass.
+ *
+ * Field shapes:
+ *
+ * - `totals`: `['total' => int, 'new' => int, 'in_review' => int, ...]`
+ * - `sources`: `['web_form' => int, 'email' => int]`
+ * - `statusBreakdown`: `[ReservationStatus->value => int, ...]`
+ * - `editRate`: 0.0–1.0, fraction of approved replies whose body
+ *   differed from the snapshotted `original_body`. `null` when the
+ *   window had no comparable replies.
+ * - `sendModeStats`: PRD-007 breakdown, `null` when the restaurant is
+ *   still on the V1.0 manual default and never recorded a non-manual
+ *   mode in the window.
+ * - `trends`: ordered list of buckets, gap-filled per `range->bucketCount()`.
+ */
+final readonly class AnalyticsSnapshot
+{
+    /**
+     * @param  array<string, int>  $totals
+     * @param  array<string, int>  $sources
+     * @param  array<string, int>  $statusBreakdown
+     * @param  list<TrendBucket>  $trends
+     */
+    public function __construct(
+        public AnalyticsRange $range,
+        public array $totals,
+        public array $sources,
+        public array $statusBreakdown,
+        public ResponseTimeStats $responseTime,
+        public ?float $editRate,
+        public ?SendModeStats $sendModeStats,
+        public array $trends,
+    ) {}
+}

--- a/app/Services/Analytics/ResponseTimeStats.php
+++ b/app/Services/Analytics/ResponseTimeStats.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+/**
+ * Response-time statistics over the analytics window (PRD-008).
+ *
+ * Both values are in **whole minutes** and represent the elapsed time
+ * between a request being received and the operator-approved reply
+ * being marked sent. Median is the operator-friendly central tendency;
+ * p90 surfaces the long-tail "I should have answered that already"
+ * cases the median hides.
+ *
+ * `null` on either field means the window had too few replies to
+ * produce a meaningful statistic — the dashboard renders an "—" cell
+ * in that state rather than a misleading zero.
+ */
+final readonly class ResponseTimeStats
+{
+    public function __construct(
+        public ?int $medianMinutes,
+        public ?int $p90Minutes,
+        public int $sampleSize,
+    ) {}
+
+    public static function empty(): self
+    {
+        return new self(null, null, 0);
+    }
+}

--- a/app/Services/Analytics/SendModeStats.php
+++ b/app/Services/Analytics/SendModeStats.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+/**
+ * Send-mode usage breakdown over the analytics window (PRD-008).
+ *
+ * Counts of replies created in each PRD-007 mode plus the live shadow
+ * takeover-rate (fraction of shadow replies the operator accepted
+ * verbatim). `takeoverRate` is `null` when no shadow replies were
+ * compared in the window — the dashboard renders an "—" cell rather
+ * than a misleading zero.
+ */
+final readonly class SendModeStats
+{
+    public function __construct(
+        public int $manual,
+        public int $shadow,
+        public int $auto,
+        public int $shadowComparedSampleSize,
+        public ?float $takeoverRate,
+    ) {}
+}

--- a/app/Services/Analytics/TrendBucket.php
+++ b/app/Services/Analytics/TrendBucket.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+/**
+ * One point on the trend chart (PRD-008).
+ *
+ * The aggregator gap-fills missing buckets with `count = 0` so the
+ * chart never has holes. `label` is a human-readable bucket key
+ * (e.g. `"14:00"` for the today/hour view, `"2026-04-29"` for the
+ * 7d/30d/day view); `bucketStart` is the Carbon-friendly ISO-8601
+ * timestamp Vue plots against the x-axis.
+ */
+final readonly class TrendBucket
+{
+    public function __construct(
+        public string $label,
+        public string $bucketStart,
+        public int $count,
+    ) {}
+}

--- a/tests/Unit/Analytics/AnalyticsRangeTest.php
+++ b/tests/Unit/Analytics/AnalyticsRangeTest.php
@@ -6,7 +6,7 @@ namespace Tests\Unit\Analytics;
 
 use App\Enums\AnalyticsRange;
 use Illuminate\Support\Carbon;
-use PHPUnit\Framework\TestCase;
+use Tests\TestCase;
 
 class AnalyticsRangeTest extends TestCase
 {

--- a/tests/Unit/Analytics/AnalyticsRangeTest.php
+++ b/tests/Unit/Analytics/AnalyticsRangeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Analytics;
+
+use App\Enums\AnalyticsRange;
+use Illuminate\Support\Carbon;
+use PHPUnit\Framework\TestCase;
+
+class AnalyticsRangeTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 10:30:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_today_starts_at_midnight_in_the_restaurant_timezone(): void
+    {
+        $start = AnalyticsRange::Today->startsAt('Europe/Berlin');
+
+        // 2026-04-30 10:30 UTC is 2026-04-30 12:30 Berlin (DST: +02:00),
+        // so "today" in Berlin starts at 2026-04-30 00:00 Berlin
+        // which is 2026-04-29 22:00 UTC.
+        $this->assertSame('2026-04-29T22:00:00+00:00', $start->utc()->toIso8601String());
+    }
+
+    public function test_last_7_days_starts_six_days_before_today_at_midnight(): void
+    {
+        $start = AnalyticsRange::Last7Days->startsAt('UTC');
+
+        // 7 days INCLUDING today → start = today - 6 days at 00:00.
+        $this->assertSame('2026-04-24T00:00:00+00:00', $start->toIso8601String());
+    }
+
+    public function test_last_30_days_starts_29_days_before_today_at_midnight(): void
+    {
+        $start = AnalyticsRange::Last30Days->startsAt('UTC');
+
+        $this->assertSame('2026-04-01T00:00:00+00:00', $start->toIso8601String());
+    }
+
+    public function test_ends_at_returns_now_in_the_given_timezone(): void
+    {
+        $end = AnalyticsRange::Today->endsAt('UTC');
+
+        $this->assertSame('2026-04-30T10:30:00+00:00', $end->toIso8601String());
+    }
+
+    public function test_today_uses_hour_buckets(): void
+    {
+        $this->assertSame('hour', AnalyticsRange::Today->bucketSize());
+        $this->assertSame(24, AnalyticsRange::Today->bucketCount());
+    }
+
+    public function test_seven_and_thirty_day_ranges_use_day_buckets(): void
+    {
+        $this->assertSame('day', AnalyticsRange::Last7Days->bucketSize());
+        $this->assertSame(7, AnalyticsRange::Last7Days->bucketCount());
+
+        $this->assertSame('day', AnalyticsRange::Last30Days->bucketSize());
+        $this->assertSame(30, AnalyticsRange::Last30Days->bucketCount());
+    }
+
+    public function test_string_value_is_the_form_request_friendly_token(): void
+    {
+        // The form-request validator pulls these from `Rule::enum`.
+        $this->assertSame('today', AnalyticsRange::Today->value);
+        $this->assertSame('7d', AnalyticsRange::Last7Days->value);
+        $this->assertSame('30d', AnalyticsRange::Last30Days->value);
+    }
+}


### PR DESCRIPTION
## Summary

Type system that the upcoming PRD-008 aggregator (#226–#229) will populate and the analytics page (#231/#232) will consume. Pure scaffolding — no aggregation logic yet, no controller, no Vue.

- `App\Enums\AnalyticsRange` — three cases (`Today`, `Last7Days`, `Last30Days`), with timezone-aware `startsAt`, `endsAt`, plus `bucketSize` (`hour` for today, `day` for 7d/30d) and `bucketCount` (for gap-filled trend charts).
- `App\Services\Analytics\AnalyticsSnapshot` — `final readonly` value object the aggregator returns. Plain DTO, not Eloquent.
- Sub-DTOs `ResponseTimeStats` (median + p90 minutes + sample size, nullable for empty windows), `TrendBucket` (label + bucketStart + count), `SendModeStats` (per-mode counts + takeover-rate, nullable when no shadow data exists yet).
- `App\Http\Resources\AnalyticsSnapshotResource` — maps the DTO 1:1 to the camelCased JSON shape the Inertia page consumes. The resource is the seam where field naming switches.
- `tests/Unit/Analytics/AnalyticsRangeTest.php` (7 tests) pins the timezone-aware bounds, the hour-vs-day bucket selection, the bucket counts, and the form-request-friendly enum value tokens (`today`, `7d`, `30d`).

## Why

PRD-008 builds the analytics dashboard incrementally across #226–#233. Locking the type system now means each follow-up issue can implement its slice of the aggregator (`totals`, `bySource`, `responseTime`, `editRate`, `sendModeStats`, `trends`) against a stable contract — and the Vue page (#232) can be drafted against the resource shape without waiting for SQL.

## Test plan

- `php artisan test --filter AnalyticsRangeTest` — 7 / 13 assertions green.
- `php artisan test` — full suite, 675 / 2068 assertions green.
- Pint, ESLint, Prettier — green.

Closes #225