### PR TITLE
AnalyticsAggregator: response time median + p90 (#227)

### DIFF
--- a/app/Services/Analytics/AnalyticsAggregator.php
+++ b/app/Services/Analytics/AnalyticsAggregator.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace App\Services\Analytics;
 
 use App\Enums\AnalyticsRange;
+use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
+use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
@@ -28,9 +30,9 @@ use Illuminate\Database\Eloquent\Builder;
  * "auth user is null in jobs" trap and the "wrong tenant cached"
  * trap a global scope would invite.
  *
- * Issue #226 wires the totals / by-source / by-status branch.
- * Sibling issues fill `responseTime`, `editRate`, `sendModeStats`
- * and `trends`.
+ * Issue #226 wires the totals / by-source / by-status branch;
+ * issue #227 adds `responseTime`. Sibling issues still fill
+ * `editRate`, `sendModeStats` and `trends`.
  */
 final readonly class AnalyticsAggregator
 {
@@ -52,7 +54,7 @@ final readonly class AnalyticsAggregator
                 totals: $this->totals($restaurant, $range),
                 sources: $this->bySource($restaurant, $range),
                 statusBreakdown: $this->byStatus($restaurant, $range),
-                responseTime: ResponseTimeStats::empty(),
+                responseTime: $this->responseTime($restaurant, $range),
                 editRate: null,
                 sendModeStats: null,
                 trends: [],
@@ -106,6 +108,105 @@ final readonly class AnalyticsAggregator
         }
 
         return $result;
+    }
+
+    /**
+     * Median + p90 minutes between `request->created_at` and the
+     * **first** sent reply's `sent_at`.
+     *
+     * Only the `Sent` reply state counts: `Draft`, `Approved`,
+     * `Failed`, `Shadow`, `ScheduledAutoSend` and `CancelledAuto`
+     * are deliberately ignored — `Approved` exists in the schema
+     * but its `sent_at` is `null` until the SMTP send actually
+     * completes, and the shadow / auto-send branches are a
+     * different time-to-customer story (PRD-008 § Response-Time).
+     *
+     * Percentiles are computed in PHP because SQLite has no
+     * `PERCENTILE_CONT`. Up to ~10k rows per range that's well
+     * inside the 500 ms budget the performance benchmark issue
+     * defends; above that we'd swap this for an aggregation
+     * repository with DB-specific implementations.
+     */
+    private function responseTime(Restaurant $restaurant, AnalyticsRange $range): ResponseTimeStats
+    {
+        $timezone = $restaurant->timezone ?? config('app.timezone');
+
+        $replies = ReservationReply::query()
+            ->withoutGlobalScopes()
+            ->where('status', ReservationReplyStatus::Sent->value)
+            ->whereNotNull('sent_at')
+            ->whereHas(
+                'reservationRequest',
+                fn (Builder $query) => $query
+                    ->withoutGlobalScopes()
+                    ->where('restaurant_id', $restaurant->id)
+                    ->where('created_at', '>=', $range->startsAt($timezone))
+                    ->where('created_at', '<=', $range->endsAt($timezone)),
+            )
+            ->with([
+                'reservationRequest' => fn ($query) => $query->withoutGlobalScopes(),
+            ])
+            ->orderBy('sent_at')
+            ->get();
+
+        $deltas = $replies
+            ->groupBy('reservation_request_id')
+            ->map(fn ($group) => $group->first())
+            ->map(static fn (ReservationReply $reply): int => (int) max(
+                0,
+                $reply->reservationRequest->created_at->diffInMinutes($reply->sent_at),
+            ))
+            ->sort()
+            ->values()
+            ->all();
+
+        if ($deltas === []) {
+            return ResponseTimeStats::empty();
+        }
+
+        return new ResponseTimeStats(
+            medianMinutes: $this->percentile($deltas, 0.5),
+            p90Minutes: $this->percentile($deltas, 0.9),
+            sampleSize: count($deltas),
+        );
+    }
+
+    /**
+     * Linear-interpolated percentile over a pre-sorted ascending
+     * array of integers. Returns `null` for an empty list.
+     *
+     * Algorithm matches NumPy's `linear` interpolation:
+     *   rank = p * (n - 1)
+     *   value = a[floor(rank)] + (rank - floor(rank))
+     *           * (a[ceil(rank)] - a[floor(rank)])
+     *
+     * @param  list<int>  $sorted
+     */
+    private function percentile(array $sorted, float $p): ?int
+    {
+        $n = count($sorted);
+
+        if ($n === 0) {
+            return null;
+        }
+
+        if ($n === 1) {
+            return $sorted[0];
+        }
+
+        $rank = $p * ($n - 1);
+        $lower = (int) floor($rank);
+        $upper = (int) ceil($rank);
+
+        if ($lower === $upper) {
+            return $sorted[$lower];
+        }
+
+        $fraction = $rank - $lower;
+
+        return (int) round(
+            $sorted[$lower] + $fraction * ($sorted[$upper] - $sorted[$lower]),
+        );
     }
 
     /**

--- a/tests/Unit/Analytics/AnalyticsAggregatorResponseTimeTest.php
+++ b/tests/Unit/Analytics/AnalyticsAggregatorResponseTimeTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Analytics;
+
+use App\Enums\AnalyticsRange;
+use App\Enums\ReservationReplyStatus;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Analytics\AnalyticsAggregator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class AnalyticsAggregatorResponseTimeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function aggregator(): AnalyticsAggregator
+    {
+        return $this->app->make(AnalyticsAggregator::class);
+    }
+
+    private function makeRequest(Restaurant $restaurant, Carbon $createdAt): ReservationRequest
+    {
+        return ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['created_at' => $createdAt]);
+    }
+
+    private function attachReply(
+        ReservationRequest $request,
+        ReservationReplyStatus $status,
+        ?Carbon $sentAt,
+    ): ReservationReply {
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => $status,
+            'sent_at' => $sentAt,
+        ]);
+    }
+
+    public function test_it_computes_median_and_p90_response_time(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        // Five requests, response deltas (in minutes): 5, 10, 30, 60, 240.
+        // Sorted asc: 5, 10, 30, 60, 240.
+        // Median (50th percentile, linear interpolation) = 30.
+        // p90 → linear interpolation between index 3 (60) and index 4 (240)
+        //       at fraction 0.6 → 60 + 0.6 * (240 - 60) = 168.
+        $deltas = [5, 10, 30, 60, 240];
+
+        foreach ($deltas as $minutes) {
+            $createdAt = Carbon::now()->subDays(1);
+            $request = $this->makeRequest($restaurant, $createdAt);
+            $this->attachReply(
+                $request,
+                ReservationReplyStatus::Sent,
+                $createdAt->copy()->addMinutes($minutes),
+            );
+        }
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertSame(5, $snapshot->responseTime->sampleSize);
+        $this->assertSame(30, $snapshot->responseTime->medianMinutes);
+        $this->assertSame(168, $snapshot->responseTime->p90Minutes);
+    }
+
+    public function test_it_returns_null_when_no_replies_exist_in_range(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        // Two requests, no replies attached.
+        $this->makeRequest($restaurant, Carbon::now()->subDays(1));
+        $this->makeRequest($restaurant, Carbon::now()->subDays(2));
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertSame(0, $snapshot->responseTime->sampleSize);
+        $this->assertNull($snapshot->responseTime->medianMinutes);
+        $this->assertNull($snapshot->responseTime->p90Minutes);
+    }
+
+    public function test_it_ignores_replies_with_status_draft_or_shadow(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        // Sent reply: must be counted (delta = 20 min).
+        $sent = $this->makeRequest($restaurant, Carbon::now()->subDays(1));
+        $this->attachReply(
+            $sent,
+            ReservationReplyStatus::Sent,
+            $sent->created_at->copy()->addMinutes(20),
+        );
+
+        // Draft with sent_at set (irrealistic but defensive): must NOT count.
+        $draft = $this->makeRequest($restaurant, Carbon::now()->subDays(1));
+        $this->attachReply(
+            $draft,
+            ReservationReplyStatus::Draft,
+            $draft->created_at->copy()->addMinutes(5),
+        );
+
+        // Shadow reply: must NOT count toward time-to-reply.
+        $shadow = $this->makeRequest($restaurant, Carbon::now()->subDays(1));
+        $this->attachReply(
+            $shadow,
+            ReservationReplyStatus::Shadow,
+            $shadow->created_at->copy()->addMinutes(2),
+        );
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        // Only the sent reply counts → sample size 1, both percentiles 20.
+        $this->assertSame(1, $snapshot->responseTime->sampleSize);
+        $this->assertSame(20, $snapshot->responseTime->medianMinutes);
+        $this->assertSame(20, $snapshot->responseTime->p90Minutes);
+    }
+
+    public function test_it_uses_the_first_sent_reply_when_a_request_has_multiple(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $createdAt = Carbon::now()->subDays(1);
+        $request = $this->makeRequest($restaurant, $createdAt);
+
+        // First send (the one we should measure): +15 min.
+        $this->attachReply(
+            $request,
+            ReservationReplyStatus::Sent,
+            $createdAt->copy()->addMinutes(15),
+        );
+
+        // Second send (e.g. follow-up): +120 min — must not be picked.
+        $this->attachReply(
+            $request,
+            ReservationReplyStatus::Sent,
+            $createdAt->copy()->addMinutes(120),
+        );
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertSame(1, $snapshot->responseTime->sampleSize);
+        $this->assertSame(15, $snapshot->responseTime->medianMinutes);
+    }
+
+    public function test_it_scopes_response_time_to_the_given_restaurant(): void
+    {
+        $own = Restaurant::factory()->create();
+        $other = Restaurant::factory()->create();
+
+        // Own: 100-minute response.
+        $ownRequest = $this->makeRequest($own, Carbon::now()->subDays(1));
+        $this->attachReply(
+            $ownRequest,
+            ReservationReplyStatus::Sent,
+            $ownRequest->created_at->copy()->addMinutes(100),
+        );
+
+        // Other: 1-minute response — must not bleed into own snapshot.
+        $otherRequest = $this->makeRequest($other, Carbon::now()->subDays(1));
+        $this->attachReply(
+            $otherRequest,
+            ReservationReplyStatus::Sent,
+            $otherRequest->created_at->copy()->addMinutes(1),
+        );
+
+        $snapshot = $this->aggregator()->aggregate($own, AnalyticsRange::Last7Days);
+
+        $this->assertSame(1, $snapshot->responseTime->sampleSize);
+        $this->assertSame(100, $snapshot->responseTime->medianMinutes);
+    }
+}


### PR DESCRIPTION
## Summary

- New `responseTime()` private method on `AnalyticsAggregator` populates `AnalyticsSnapshot::$responseTime` (median + p90 minutes + sample size).
- Counts only replies with `status = sent` and a non-null `sent_at`. `Draft`, `Approved`, `Failed`, `Shadow`, `ScheduledAutoSend`, `CancelledAuto` are deliberately excluded.
- Per request, the **first** sent reply (earliest `sent_at`) is used; follow-up sends after a thread is already open do not skew the metric.
- Percentiles computed in PHP via linear interpolation (NumPy-style) — SQLite has no `PERCENTILE_CONT`.
- 0 replies → `medianMinutes = p90Minutes = null`, `sampleSize = 0`. No division by zero.
- Tenant scoping: `withoutGlobalScopes()` on both the reply query and the `whereHas('reservationRequest', ...)` predicate, with an explicit `where('restaurant_id', …)`.

## Why

Issue #227 — fills the `responseTime` slot of the PRD-008 dashboard snapshot. Hooks into the aggregator skeleton from #226.

Closes #227

## Test plan

- [x] `php artisan test --filter=AnalyticsAggregatorResponseTimeTest` (5 passed, 13 assertions)
- [x] `php artisan test` (688 passed)
- [x] `./vendor/bin/pint --test`
- [x] `npm run lint` + `npm run format:check`

Test cases:
- median + p90 over `[5, 10, 30, 60, 240]` → 30 / 168
- 0 replies → null / null / 0
- ignores `draft` and `shadow` replies even when `sent_at` is set
- picks the earliest sent reply when a request has multiple
- multi-tenant scoping: a sibling restaurant's reply does not bleed in