### PR TITLE
AnalyticsAggregator: edit-rate + send-mode stats (#228)

### DIFF
--- a/app/Http/Resources/AnalyticsSnapshotResource.php
+++ b/app/Http/Resources/AnalyticsSnapshotResource.php
@@ -44,6 +44,7 @@ final class AnalyticsSnapshotResource extends JsonResource
                 'auto' => $snapshot->sendModeStats->auto,
                 'shadowComparedSampleSize' => $snapshot->sendModeStats->shadowComparedSampleSize,
                 'takeoverRate' => $snapshot->sendModeStats->takeoverRate,
+                'topHardGateReasons' => $snapshot->sendModeStats->topHardGateReasons,
             ],
             'trends' => array_map(
                 fn (TrendBucket $bucket) => [

--- a/app/Models/ReservationReply.php
+++ b/app/Models/ReservationReply.php
@@ -34,6 +34,8 @@ class ReservationReply extends Model
         'outbound_message_id',
         'is_fallback',
         'send_mode_at_creation',
+        'shadow_compared_at',
+        'shadow_was_modified',
         'auto_send_decision',
         'auto_send_scheduled_for',
     ];
@@ -52,6 +54,8 @@ class ReservationReply extends Model
             'sent_at' => 'datetime',
             'is_fallback' => 'boolean',
             'send_mode_at_creation' => SendMode::class,
+            'shadow_compared_at' => 'datetime',
+            'shadow_was_modified' => 'boolean',
             'auto_send_decision' => 'array',
             'auto_send_scheduled_for' => 'datetime',
         ];

--- a/app/Services/Analytics/AnalyticsAggregator.php
+++ b/app/Services/Analytics/AnalyticsAggregator.php
@@ -8,11 +8,14 @@ use App\Enums\AnalyticsRange;
 use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
+use App\Enums\SendMode;
+use App\Models\AutoSendAudit;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Server-side aggregator for the PRD-008 dashboard.
@@ -31,8 +34,8 @@ use Illuminate\Database\Eloquent\Builder;
  * trap a global scope would invite.
  *
  * Issue #226 wires the totals / by-source / by-status branch;
- * issue #227 adds `responseTime`. Sibling issues still fill
- * `editRate`, `sendModeStats` and `trends`.
+ * issue #227 adds `responseTime`; issue #228 adds `editRate` and
+ * `sendModeStats`. Sibling issues still fill `trends`.
  */
 final readonly class AnalyticsAggregator
 {
@@ -55,8 +58,8 @@ final readonly class AnalyticsAggregator
                 sources: $this->bySource($restaurant, $range),
                 statusBreakdown: $this->byStatus($restaurant, $range),
                 responseTime: $this->responseTime($restaurant, $range),
-                editRate: null,
-                sendModeStats: null,
+                editRate: $this->editRate($restaurant, $range),
+                sendModeStats: $this->sendModeStats($restaurant, $range),
                 trends: [],
             ),
         );
@@ -207,6 +210,161 @@ final readonly class AnalyticsAggregator
         return (int) round(
             $sorted[$lower] + $fraction * ($sorted[$upper] - $sorted[$lower]),
         );
+    }
+
+    /**
+     * Edit-rate: fraction of `Sent` / `Approved` replies whose body
+     * was modified vs the AI's original draft snapshotted in
+     * `ai_prompt_snapshot.original_body`.
+     *
+     * Uses `json_extract` (SQLite + MySQL 8 compatible). Replies
+     * created before the original-body snapshot was introduced have
+     * no `original_body` key and are treated as **not modified**
+     * (PRD-008 risk note: pre-extension data should not skew the
+     * metric — they count toward the denominator but never as
+     * edits). Postgres would need an alternative `->>` expression;
+     * we'll wrap that behind a repository interface if Postgres
+     * becomes the prod target.
+     *
+     * `null` when no comparable reply exists in the window — the
+     * dashboard renders an "—" cell rather than a misleading 0 %.
+     */
+    private function editRate(Restaurant $restaurant, AnalyticsRange $range): ?float
+    {
+        $base = $this->repliesInRange($restaurant, $range)
+            ->whereIn('reservation_replies.status', [
+                ReservationReplyStatus::Sent->value,
+                ReservationReplyStatus::Approved->value,
+            ]);
+
+        $total = (clone $base)->count();
+
+        if ($total === 0) {
+            return null;
+        }
+
+        $modified = (clone $base)
+            ->whereColumn(
+                'reservation_replies.body',
+                '!=',
+                DB::raw("json_extract(reservation_replies.ai_prompt_snapshot, '$.original_body')"),
+            )
+            ->count();
+
+        return $modified / $total;
+    }
+
+    /**
+     * PRD-007 send-mode breakdown. Returns `null` when the
+     * restaurant is still on the V1.0 manual default — the
+     * dashboard hides the section entirely in that case rather
+     * than showing zeros that would suggest auto-send is wired up.
+     *
+     * `manual` / `shadow` counts come from `reservation_replies`
+     * (filtered by `send_mode_at_creation`); `auto` and the top
+     * hard-gate reasons come from `auto_send_audits`, which has
+     * its own `restaurant_id` column from PRD-007 — no join needed.
+     *
+     * `topHardGateReasons` is the top 3 `decision = manual`
+     * audit rows whose reason is NOT `mode_manual` (those are the
+     * baseline "we are configured manual" entries, not blockades).
+     */
+    private function sendModeStats(Restaurant $restaurant, AnalyticsRange $range): ?SendModeStats
+    {
+        // `null` happens when a freshly-created Restaurant model was
+        // never reloaded from the DB after insert — treated as the
+        // V1.0 manual default (the column default is `manual`).
+        if ($restaurant->send_mode === null || $restaurant->send_mode === SendMode::Manual) {
+            return null;
+        }
+
+        $timezone = $restaurant->timezone ?? config('app.timezone');
+        $start = $range->startsAt($timezone);
+        $end = $range->endsAt($timezone);
+
+        $manual = $this->repliesInRange($restaurant, $range)
+            ->where('reservation_replies.send_mode_at_creation', SendMode::Manual->value)
+            ->count();
+
+        $shadow = $this->repliesInRange($restaurant, $range)
+            ->where('reservation_replies.send_mode_at_creation', SendMode::Shadow->value)
+            ->count();
+
+        $shadowCompared = $this->repliesInRange($restaurant, $range)
+            ->where('reservation_replies.send_mode_at_creation', SendMode::Shadow->value)
+            ->whereNotNull('reservation_replies.shadow_compared_at')
+            ->count();
+
+        $shadowKept = $this->repliesInRange($restaurant, $range)
+            ->where('reservation_replies.send_mode_at_creation', SendMode::Shadow->value)
+            ->whereNotNull('reservation_replies.shadow_compared_at')
+            ->where('reservation_replies.shadow_was_modified', false)
+            ->count();
+
+        $takeoverRate = $shadowCompared === 0 ? null : $shadowKept / $shadowCompared;
+
+        $auto = AutoSendAudit::query()
+            ->where('restaurant_id', $restaurant->id)
+            ->where('decision', AutoSendAudit::DECISION_AUTO_SEND)
+            ->whereBetween('created_at', [$start, $end])
+            ->count();
+
+        /** @var list<array{reason: string, count: int}> $topHardGateReasons */
+        $topHardGateReasons = AutoSendAudit::query()
+            ->where('restaurant_id', $restaurant->id)
+            ->where('decision', AutoSendAudit::DECISION_MANUAL)
+            ->where('reason', '!=', 'mode_manual')
+            ->whereBetween('created_at', [$start, $end])
+            ->selectRaw('reason, COUNT(*) as count')
+            ->groupBy('reason')
+            ->orderByDesc('count')
+            ->limit(3)
+            ->get()
+            ->map(fn ($row) => [
+                'reason' => (string) $row->reason,
+                'count' => (int) $row->count,
+            ])
+            ->values()
+            ->all();
+
+        return new SendModeStats(
+            manual: $manual,
+            shadow: $shadow,
+            auto: $auto,
+            shadowComparedSampleSize: $shadowCompared,
+            takeoverRate: $takeoverRate,
+            topHardGateReasons: $topHardGateReasons,
+        );
+    }
+
+    /**
+     * Reply-side base query joined to the request table for tenant
+     * + range scoping. `reservation_replies` has no own
+     * `restaurant_id` column (PRD-001 schema), so the predicate sits
+     * on the joined `reservation_requests`. Both tables drop their
+     * global `RestaurantScope` so the aggregator runs cleanly in
+     * jobs, commands and tests without an authenticated user.
+     *
+     * Range filter is applied to `reservation_replies.created_at` —
+     * a reply created in the window is what the analytics need to
+     * count, regardless of when the original request was opened.
+     *
+     * @return Builder<ReservationReply>
+     */
+    private function repliesInRange(Restaurant $restaurant, AnalyticsRange $range): Builder
+    {
+        $timezone = $restaurant->timezone ?? config('app.timezone');
+
+        return ReservationReply::query()
+            ->withoutGlobalScopes()
+            ->whereHas(
+                'reservationRequest',
+                fn (Builder $query) => $query
+                    ->withoutGlobalScopes()
+                    ->where('restaurant_id', $restaurant->id),
+            )
+            ->where('reservation_replies.created_at', '>=', $range->startsAt($timezone))
+            ->where('reservation_replies.created_at', '<=', $range->endsAt($timezone));
     }
 
     /**

--- a/app/Services/Analytics/SendModeStats.php
+++ b/app/Services/Analytics/SendModeStats.php
@@ -12,14 +12,23 @@ namespace App\Services\Analytics;
  * verbatim). `takeoverRate` is `null` when no shadow replies were
  * compared in the window — the dashboard renders an "—" cell rather
  * than a misleading zero.
+ *
+ * `topHardGateReasons` lists the most frequent reasons the auto-send
+ * pipeline fell back to manual (`decision = manual` audit rows that
+ * are NOT `mode_manual`), capped at three entries. Empty list when
+ * the restaurant is not in `auto` mode or no blockades occurred.
  */
 final readonly class SendModeStats
 {
+    /**
+     * @param  list<array{reason: string, count: int}>  $topHardGateReasons
+     */
     public function __construct(
         public int $manual,
         public int $shadow,
         public int $auto,
         public int $shadowComparedSampleSize,
         public ?float $takeoverRate,
+        public array $topHardGateReasons = [],
     ) {}
 }

--- a/tests/Unit/Analytics/AnalyticsAggregatorEditRateTest.php
+++ b/tests/Unit/Analytics/AnalyticsAggregatorEditRateTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Analytics;
+
+use App\Enums\AnalyticsRange;
+use App\Enums\ReservationReplyStatus;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Analytics\AnalyticsAggregator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class AnalyticsAggregatorEditRateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function aggregator(): AnalyticsAggregator
+    {
+        return $this->app->make(AnalyticsAggregator::class);
+    }
+
+    private function makeReply(
+        Restaurant $restaurant,
+        string $body,
+        ?string $originalBody,
+        ReservationReplyStatus $status,
+        Carbon $createdAt,
+    ): ReservationReply {
+        $request = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['created_at' => $createdAt]);
+
+        $snapshot = $originalBody === null ? null : ['original_body' => $originalBody];
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => $status,
+            'body' => $body,
+            'ai_prompt_snapshot' => $snapshot,
+            'created_at' => $createdAt,
+        ]);
+    }
+
+    public function test_it_computes_edit_rate_when_body_differs_from_original(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        // 1 modified Sent reply.
+        $this->makeReply(
+            $restaurant,
+            body: 'edited',
+            originalBody: 'original',
+            status: ReservationReplyStatus::Sent,
+            createdAt: Carbon::now()->subDays(1),
+        );
+        // 1 unchanged Sent reply.
+        $this->makeReply(
+            $restaurant,
+            body: 'verbatim',
+            originalBody: 'verbatim',
+            status: ReservationReplyStatus::Sent,
+            createdAt: Carbon::now()->subDays(2),
+        );
+        // 2 unchanged Approved replies.
+        $this->makeReply(
+            $restaurant,
+            body: 'a',
+            originalBody: 'a',
+            status: ReservationReplyStatus::Approved,
+            createdAt: Carbon::now()->subDays(3),
+        );
+        $this->makeReply(
+            $restaurant,
+            body: 'b',
+            originalBody: 'b',
+            status: ReservationReplyStatus::Approved,
+            createdAt: Carbon::now()->subDays(4),
+        );
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        // 1 modified out of 4 → 0.25.
+        $this->assertNotNull($snapshot->editRate);
+        $this->assertEqualsWithDelta(0.25, $snapshot->editRate, 0.0001);
+    }
+
+    public function test_it_returns_null_edit_rate_when_no_comparable_replies(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        // Drafts are not eligible for edit-rate (only Sent / Approved count).
+        $this->makeReply(
+            $restaurant,
+            body: 'a',
+            originalBody: 'a',
+            status: ReservationReplyStatus::Draft,
+            createdAt: Carbon::now()->subDays(1),
+        );
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertNull($snapshot->editRate);
+    }
+
+    public function test_it_treats_replies_without_original_body_snapshot_as_not_modified(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        // Pre-PRD-008 reply without original_body in the snapshot — must
+        // count toward total but never as modified (PRD-008 risk note).
+        $this->makeReply(
+            $restaurant,
+            body: 'whatever',
+            originalBody: null,
+            status: ReservationReplyStatus::Sent,
+            createdAt: Carbon::now()->subDays(1),
+        );
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        // 0 modified out of 1 → 0.0.
+        $this->assertNotNull($snapshot->editRate);
+        $this->assertSame(0.0, $snapshot->editRate);
+    }
+
+    public function test_it_scopes_edit_rate_to_the_given_restaurant(): void
+    {
+        $own = Restaurant::factory()->create();
+        $other = Restaurant::factory()->create();
+
+        // Other restaurant has 5 modified replies — must not bleed in.
+        for ($i = 0; $i < 5; $i++) {
+            $this->makeReply(
+                $other,
+                body: 'edited',
+                originalBody: 'original',
+                status: ReservationReplyStatus::Sent,
+                createdAt: Carbon::now()->subDays(1),
+            );
+        }
+
+        // Own restaurant has 1 unchanged reply.
+        $this->makeReply(
+            $own,
+            body: 'a',
+            originalBody: 'a',
+            status: ReservationReplyStatus::Sent,
+            createdAt: Carbon::now()->subDays(1),
+        );
+
+        $snapshot = $this->aggregator()->aggregate($own, AnalyticsRange::Last7Days);
+
+        $this->assertSame(0.0, $snapshot->editRate);
+    }
+}

--- a/tests/Unit/Analytics/AnalyticsAggregatorSendModeStatsTest.php
+++ b/tests/Unit/Analytics/AnalyticsAggregatorSendModeStatsTest.php
@@ -1,0 +1,261 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Analytics;
+
+use App\Enums\AnalyticsRange;
+use App\Enums\ReservationReplyStatus;
+use App\Enums\SendMode;
+use App\Models\AutoSendAudit;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Analytics\AnalyticsAggregator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class AnalyticsAggregatorSendModeStatsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function aggregator(): AnalyticsAggregator
+    {
+        return $this->app->make(AnalyticsAggregator::class);
+    }
+
+    private function makeReply(
+        Restaurant $restaurant,
+        SendMode $modeAtCreation,
+        ReservationReplyStatus $status,
+        ?bool $shadowWasModified = null,
+        ?Carbon $shadowComparedAt = null,
+        ?Carbon $createdAt = null,
+    ): ReservationReply {
+        $createdAt ??= Carbon::now()->subDays(1);
+
+        $request = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['created_at' => $createdAt]);
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => $status,
+            'send_mode_at_creation' => $modeAtCreation,
+            'shadow_was_modified' => $shadowWasModified ?? false,
+            'shadow_compared_at' => $shadowComparedAt,
+            'created_at' => $createdAt,
+        ]);
+    }
+
+    private function makeAudit(
+        Restaurant $restaurant,
+        ReservationReply $reply,
+        string $decision,
+        string $reason,
+        ?Carbon $createdAt = null,
+    ): AutoSendAudit {
+        return AutoSendAudit::create([
+            'reservation_reply_id' => $reply->id,
+            'restaurant_id' => $restaurant->id,
+            'send_mode' => SendMode::Auto->value,
+            'decision' => $decision,
+            'reason' => $reason,
+            'created_at' => $createdAt ?? Carbon::now()->subDays(1),
+        ]);
+    }
+
+    public function test_it_returns_null_send_mode_stats_for_manual_mode_restaurants(): void
+    {
+        $restaurant = Restaurant::factory()->create(['send_mode' => SendMode::Manual]);
+
+        $this->makeReply($restaurant, SendMode::Manual, ReservationReplyStatus::Sent);
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertNull($snapshot->sendModeStats);
+    }
+
+    public function test_it_computes_shadow_takeover_rate(): void
+    {
+        $restaurant = Restaurant::factory()->create(['send_mode' => SendMode::Shadow]);
+
+        // 4 shadow replies, 3 of them compared. 2 not modified, 1 modified.
+        // takeoverRate = 2 / 3 ≈ 0.6667.
+        $this->makeReply(
+            $restaurant,
+            SendMode::Shadow,
+            ReservationReplyStatus::Shadow,
+            shadowWasModified: false,
+            shadowComparedAt: Carbon::now()->subHours(20),
+        );
+        $this->makeReply(
+            $restaurant,
+            SendMode::Shadow,
+            ReservationReplyStatus::Shadow,
+            shadowWasModified: false,
+            shadowComparedAt: Carbon::now()->subHours(18),
+        );
+        $this->makeReply(
+            $restaurant,
+            SendMode::Shadow,
+            ReservationReplyStatus::Shadow,
+            shadowWasModified: true,
+            shadowComparedAt: Carbon::now()->subHours(10),
+        );
+        // Fourth shadow reply not yet compared (operator still pending).
+        $this->makeReply(
+            $restaurant,
+            SendMode::Shadow,
+            ReservationReplyStatus::Shadow,
+            shadowWasModified: false,
+            shadowComparedAt: null,
+        );
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertNotNull($snapshot->sendModeStats);
+        $this->assertSame(4, $snapshot->sendModeStats->shadow);
+        $this->assertSame(3, $snapshot->sendModeStats->shadowComparedSampleSize);
+        $this->assertNotNull($snapshot->sendModeStats->takeoverRate);
+        $this->assertEqualsWithDelta(2 / 3, $snapshot->sendModeStats->takeoverRate, 0.0001);
+    }
+
+    public function test_it_returns_null_takeover_rate_when_no_shadow_replies_were_compared(): void
+    {
+        $restaurant = Restaurant::factory()->create(['send_mode' => SendMode::Shadow]);
+
+        $this->makeReply(
+            $restaurant,
+            SendMode::Shadow,
+            ReservationReplyStatus::Shadow,
+            shadowComparedAt: null,
+        );
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertNotNull($snapshot->sendModeStats);
+        $this->assertSame(0, $snapshot->sendModeStats->shadowComparedSampleSize);
+        $this->assertNull($snapshot->sendModeStats->takeoverRate);
+    }
+
+    public function test_it_lists_top_3_hard_gate_reasons_in_auto_mode(): void
+    {
+        $restaurant = Restaurant::factory()->create(['send_mode' => SendMode::Auto]);
+
+        // Reasons recorded as `manual` decisions in the audit log
+        // (auto-mode hard-gate fallback path):
+        //   short_notice           x4
+        //   party_size_over_limit  x3
+        //   first_time_guest       x2
+        //   low_confidence_email   x1
+        //   mode_manual            x5  → MUST be excluded
+        $reasonCounts = [
+            'short_notice' => 4,
+            'party_size_over_limit' => 3,
+            'first_time_guest' => 2,
+            'low_confidence_email' => 1,
+            'mode_manual' => 5,
+        ];
+
+        foreach ($reasonCounts as $reason => $count) {
+            for ($i = 0; $i < $count; $i++) {
+                $reply = $this->makeReply(
+                    $restaurant,
+                    SendMode::Auto,
+                    ReservationReplyStatus::Draft,
+                );
+                $this->makeAudit(
+                    $restaurant,
+                    $reply,
+                    AutoSendAudit::DECISION_MANUAL,
+                    $reason,
+                );
+            }
+        }
+
+        // Five real auto-sends in the same window.
+        for ($i = 0; $i < 5; $i++) {
+            $reply = $this->makeReply(
+                $restaurant,
+                SendMode::Auto,
+                ReservationReplyStatus::Sent,
+            );
+            $this->makeAudit(
+                $restaurant,
+                $reply,
+                AutoSendAudit::DECISION_AUTO_SEND,
+                'auto_send_passed',
+            );
+        }
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertNotNull($snapshot->sendModeStats);
+        $this->assertSame(5, $snapshot->sendModeStats->auto);
+
+        $reasons = $snapshot->sendModeStats->topHardGateReasons;
+        $this->assertCount(3, $reasons);
+        $this->assertSame(
+            ['short_notice', 'party_size_over_limit', 'first_time_guest'],
+            array_column($reasons, 'reason'),
+        );
+        $this->assertSame([4, 3, 2], array_column($reasons, 'count'));
+    }
+
+    public function test_it_scopes_send_mode_stats_to_the_given_restaurant(): void
+    {
+        $own = Restaurant::factory()->create(['send_mode' => SendMode::Auto]);
+        $other = Restaurant::factory()->create(['send_mode' => SendMode::Auto]);
+
+        // Other restaurant: 10 hard-gate audits — must NOT show up.
+        for ($i = 0; $i < 10; $i++) {
+            $reply = $this->makeReply(
+                $other,
+                SendMode::Auto,
+                ReservationReplyStatus::Draft,
+            );
+            $this->makeAudit(
+                $other,
+                $reply,
+                AutoSendAudit::DECISION_MANUAL,
+                'short_notice',
+            );
+        }
+
+        // Own restaurant: 1 audit reason, 0 auto sends.
+        $reply = $this->makeReply(
+            $own,
+            SendMode::Auto,
+            ReservationReplyStatus::Draft,
+        );
+        $this->makeAudit(
+            $own,
+            $reply,
+            AutoSendAudit::DECISION_MANUAL,
+            'first_time_guest',
+        );
+
+        $snapshot = $this->aggregator()->aggregate($own, AnalyticsRange::Last7Days);
+
+        $this->assertNotNull($snapshot->sendModeStats);
+        $this->assertSame(0, $snapshot->sendModeStats->auto);
+        $this->assertSame(
+            [['reason' => 'first_time_guest', 'count' => 1]],
+            $snapshot->sendModeStats->topHardGateReasons,
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- `editRate()` (private) — fraction of `Sent` / `Approved` replies whose `body` differs from `ai_prompt_snapshot.original_body`. Uses `json_extract` so SQLite + MySQL 8 both work; pre-PRD-008 replies without an `original_body` key count toward the denominator but never as edits (PRD-008 risk note). Returns `null` when no comparable reply exists in the window.
- `sendModeStats()` (private) — `null` for the V1.0 manual default, otherwise:
  - `manual` / `shadow` counts from `reservation_replies.send_mode_at_creation`
  - `auto` count from `auto_send_audits` (decision = `auto_send`)
  - `takeoverRate` = shadow replies kept verbatim / shadow replies compared (`null` when nothing was compared)
  - `topHardGateReasons` = top 3 `decision = manual` audit rows whose `reason != mode_manual` — i.e. the actual hard-gate blockades, not the baseline manual mode.
- DTO `SendModeStats` grows a `topHardGateReasons` field (defaults to `[]` for backwards compat); `AnalyticsSnapshotResource` forwards it.
- `ReservationReply` was missing `shadow_compared_at` / `shadow_was_modified` from `$fillable` + `casts` — added so the migration columns are actually writable.

## Why

Issue #228 — the V2.0-specific KPIs of PRD-008. Builds on #225 (DTO scaffolding), #226 (totals), #227 (response-time), #224 (`original_body` snapshot).

Closes #228

## Test plan

- [x] `php artisan test --filter='AnalyticsAggregatorEditRateTest|AnalyticsAggregatorSendModeStatsTest'` (9 passed, 23 assertions)
- [x] `php artisan test` (697 passed)
- [x] `./vendor/bin/pint --test`
- [x] `npm run lint` + `npm run format:check`

Test coverage:
- edit-rate when body differs from original (1 of 4 modified → 0.25)
- edit-rate `null` when no Sent / Approved reply exists
- pre-extension replies (no `original_body`) count toward denominator only
- multi-tenant scoping for edit-rate
- `sendModeStats` `null` for manual restaurants
- shadow takeover rate (2 kept of 3 compared → 0.667; uncompared shadow excluded)
- takeover rate `null` when nothing was compared
- top 3 hard-gate reasons (mode_manual deliberately excluded)
- multi-tenant scoping for `auto_send_audits` queries