### PR TITLE
AnalyticsAggregator: gap-filled trend buckets (#229)

### DIFF
--- a/app/Http/Resources/AnalyticsSnapshotResource.php
+++ b/app/Http/Resources/AnalyticsSnapshotResource.php
@@ -54,6 +54,22 @@ final class AnalyticsSnapshotResource extends JsonResource
                 ],
                 $snapshot->trends,
             ),
+            'confirmationRateTrend' => array_map(
+                fn (TrendBucket $bucket) => [
+                    'label' => $bucket->label,
+                    'bucketStart' => $bucket->bucketStart,
+                    'count' => $bucket->count,
+                ],
+                $snapshot->confirmationRateTrend,
+            ),
+            'threadRepliesTrend' => array_map(
+                fn (TrendBucket $bucket) => [
+                    'label' => $bucket->label,
+                    'bucketStart' => $bucket->bucketStart,
+                    'count' => $bucket->count,
+                ],
+                $snapshot->threadRepliesTrend,
+            ),
         ];
     }
 }

--- a/app/Services/Analytics/AnalyticsAggregator.php
+++ b/app/Services/Analytics/AnalyticsAggregator.php
@@ -17,6 +17,7 @@ use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use Illuminate\Contracts\Cache\Repository as CacheRepository;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -350,16 +351,21 @@ final readonly class AnalyticsAggregator
      */
     private function requestsTrend(Restaurant $restaurant, AnalyticsRange $range): array
     {
-        $rows = $this->baseQuery($restaurant, $range)
-            ->selectRaw($this->bucketGroupExpression($range).' as bucket_key, COUNT(*) as count')
-            ->groupBy('bucket_key')
-            ->pluck('count', 'bucket_key')
-            ->all();
+        $timezone = $restaurant->timezone ?? config('app.timezone');
+
+        $counts = $this->baseQuery($restaurant, $range)
+            ->pluck('created_at')
+            ->reduce(function (array $carry, $createdAt) use ($range, $timezone): array {
+                $key = $this->bucketKey($createdAt, $range, $timezone);
+                $carry[$key] = ($carry[$key] ?? 0) + 1;
+
+                return $carry;
+            }, []);
 
         return $this->fillBuckets(
             $range,
             $restaurant,
-            fn (string $key) => (int) ($rows[$key] ?? 0),
+            fn (string $key) => (int) ($counts[$key] ?? 0),
         );
     }
 
@@ -374,18 +380,22 @@ final readonly class AnalyticsAggregator
      */
     private function confirmationRateTrend(Restaurant $restaurant, AnalyticsRange $range): array
     {
-        $totals = $this->baseQuery($restaurant, $range)
-            ->selectRaw($this->bucketGroupExpression($range).' as bucket_key, COUNT(*) as count')
-            ->groupBy('bucket_key')
-            ->pluck('count', 'bucket_key')
-            ->all();
+        $timezone = $restaurant->timezone ?? config('app.timezone');
 
-        $confirmed = $this->baseQuery($restaurant, $range)
-            ->where('status', ReservationStatus::Confirmed->value)
-            ->selectRaw($this->bucketGroupExpression($range).' as bucket_key, COUNT(*) as count')
-            ->groupBy('bucket_key')
-            ->pluck('count', 'bucket_key')
-            ->all();
+        $rows = $this->baseQuery($restaurant, $range)
+            ->get(['created_at', 'status']);
+
+        $totals = [];
+        $confirmed = [];
+
+        foreach ($rows as $row) {
+            $key = $this->bucketKey($row->created_at, $range, $timezone);
+            $totals[$key] = ($totals[$key] ?? 0) + 1;
+
+            if ($row->status === ReservationStatus::Confirmed) {
+                $confirmed[$key] = ($confirmed[$key] ?? 0) + 1;
+            }
+        }
 
         return $this->fillBuckets(
             $range,
@@ -414,7 +424,7 @@ final readonly class AnalyticsAggregator
     {
         $timezone = $restaurant->timezone ?? config('app.timezone');
 
-        $rows = ReservationMessage::query()
+        $createdAts = ReservationMessage::query()
             ->where('direction', MessageDirection::In->value)
             ->whereHas(
                 'reservationRequest',
@@ -424,31 +434,37 @@ final readonly class AnalyticsAggregator
             )
             ->where('reservation_messages.created_at', '>=', $range->startsAt($timezone))
             ->where('reservation_messages.created_at', '<=', $range->endsAt($timezone))
-            ->selectRaw($this->bucketGroupExpression($range, 'reservation_messages.created_at').' as bucket_key, COUNT(*) as count')
-            ->groupBy('bucket_key')
-            ->pluck('count', 'bucket_key')
-            ->all();
+            ->pluck('created_at');
+
+        $counts = [];
+        foreach ($createdAts as $createdAt) {
+            $key = $this->bucketKey($createdAt, $range, $timezone);
+            $counts[$key] = ($counts[$key] ?? 0) + 1;
+        }
 
         return $this->fillBuckets(
             $range,
             $restaurant,
-            fn (string $key) => (int) ($rows[$key] ?? 0),
+            fn (string $key) => (int) ($counts[$key] ?? 0),
         );
     }
 
     /**
-     * SQL expression that yields the bucket key (`Y-m-d` for the
-     * 7d / 30d ranges, `H` for the today/hour view). SQLite's
-     * `strftime` is used because it's the lowest common denominator
-     * across SQLite (local), MySQL and MariaDB. Postgres would need
-     * `to_char`; we'll wrap that behind a repository when Postgres
-     * lands.
+     * Map a row timestamp to its bucket key in the restaurant's
+     * local timezone. PHP-side bucketing keeps the queries
+     * database-agnostic — `strftime` (SQLite) and `DATE_FORMAT` /
+     * `HOUR()` (MySQL) have different syntax and the eventual
+     * Postgres choice would force a third dialect. Bucket
+     * cardinality is bounded by `range->bucketCount()`
+     * (≤ 30 days), so the PHP loop is cheap.
      */
-    private function bucketGroupExpression(AnalyticsRange $range, string $column = 'created_at'): string
+    private function bucketKey(\DateTimeInterface $createdAt, AnalyticsRange $range, string $timezone): string
     {
+        $localized = Carbon::instance($createdAt)->setTimezone($timezone);
+
         return match ($range->bucketSize()) {
-            'hour' => "strftime('%H', {$column})",
-            default => "strftime('%Y-%m-%d', {$column})",
+            'hour' => $localized->format('H'),
+            default => $localized->format('Y-m-d'),
         };
     }
 

--- a/app/Services/Analytics/AnalyticsAggregator.php
+++ b/app/Services/Analytics/AnalyticsAggregator.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace App\Services\Analytics;
 
 use App\Enums\AnalyticsRange;
+use App\Enums\MessageDirection;
 use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
 use App\Enums\SendMode;
 use App\Models\AutoSendAudit;
+use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
@@ -35,7 +37,7 @@ use Illuminate\Support\Facades\DB;
  *
  * Issue #226 wires the totals / by-source / by-status branch;
  * issue #227 adds `responseTime`; issue #228 adds `editRate` and
- * `sendModeStats`. Sibling issues still fill `trends`.
+ * `sendModeStats`; issue #229 adds the three trend series.
  */
 final readonly class AnalyticsAggregator
 {
@@ -60,7 +62,9 @@ final readonly class AnalyticsAggregator
                 responseTime: $this->responseTime($restaurant, $range),
                 editRate: $this->editRate($restaurant, $range),
                 sendModeStats: $this->sendModeStats($restaurant, $range),
-                trends: [],
+                trends: $this->requestsTrend($restaurant, $range),
+                confirmationRateTrend: $this->confirmationRateTrend($restaurant, $range),
+                threadRepliesTrend: $this->threadRepliesTrend($restaurant, $range),
             ),
         );
     }
@@ -335,6 +339,163 @@ final readonly class AnalyticsAggregator
             takeoverRate: $takeoverRate,
             topHardGateReasons: $topHardGateReasons,
         );
+    }
+
+    /**
+     * Requests-per-bucket series, gap-filled. The chart shows total
+     * activity over time; days/hours with zero requests render as
+     * a baseline rather than a hole.
+     *
+     * @return list<TrendBucket>
+     */
+    private function requestsTrend(Restaurant $restaurant, AnalyticsRange $range): array
+    {
+        $rows = $this->baseQuery($restaurant, $range)
+            ->selectRaw($this->bucketGroupExpression($range).' as bucket_key, COUNT(*) as count')
+            ->groupBy('bucket_key')
+            ->pluck('count', 'bucket_key')
+            ->all();
+
+        return $this->fillBuckets(
+            $range,
+            $restaurant,
+            fn (string $key) => (int) ($rows[$key] ?? 0),
+        );
+    }
+
+    /**
+     * Confirmation-rate-per-bucket series. `count` carries the
+     * integer percentage (0-100); buckets with zero requests
+     * surface as 0 — the dashboard masks zero denominators to "—"
+     * in the chart so a flat zero day isn't read as "everyone
+     * declined".
+     *
+     * @return list<TrendBucket>
+     */
+    private function confirmationRateTrend(Restaurant $restaurant, AnalyticsRange $range): array
+    {
+        $totals = $this->baseQuery($restaurant, $range)
+            ->selectRaw($this->bucketGroupExpression($range).' as bucket_key, COUNT(*) as count')
+            ->groupBy('bucket_key')
+            ->pluck('count', 'bucket_key')
+            ->all();
+
+        $confirmed = $this->baseQuery($restaurant, $range)
+            ->where('status', ReservationStatus::Confirmed->value)
+            ->selectRaw($this->bucketGroupExpression($range).' as bucket_key, COUNT(*) as count')
+            ->groupBy('bucket_key')
+            ->pluck('count', 'bucket_key')
+            ->all();
+
+        return $this->fillBuckets(
+            $range,
+            $restaurant,
+            function (string $key) use ($totals, $confirmed): int {
+                $total = (int) ($totals[$key] ?? 0);
+                if ($total === 0) {
+                    return 0;
+                }
+
+                return (int) round(((int) ($confirmed[$key] ?? 0)) / $total * 100);
+            },
+        );
+    }
+
+    /**
+     * Thread-replies-per-bucket series. PRD-006: counts inbound
+     * `reservation_messages` (`direction = in`) — guest replies that
+     * reopen or extend the conversation. Outbound messages would
+     * just measure how often we sent something and aren't a
+     * meaningful engagement signal.
+     *
+     * @return list<TrendBucket>
+     */
+    private function threadRepliesTrend(Restaurant $restaurant, AnalyticsRange $range): array
+    {
+        $timezone = $restaurant->timezone ?? config('app.timezone');
+
+        $rows = ReservationMessage::query()
+            ->where('direction', MessageDirection::In->value)
+            ->whereHas(
+                'reservationRequest',
+                fn (Builder $query) => $query
+                    ->withoutGlobalScopes()
+                    ->where('restaurant_id', $restaurant->id),
+            )
+            ->where('reservation_messages.created_at', '>=', $range->startsAt($timezone))
+            ->where('reservation_messages.created_at', '<=', $range->endsAt($timezone))
+            ->selectRaw($this->bucketGroupExpression($range, 'reservation_messages.created_at').' as bucket_key, COUNT(*) as count')
+            ->groupBy('bucket_key')
+            ->pluck('count', 'bucket_key')
+            ->all();
+
+        return $this->fillBuckets(
+            $range,
+            $restaurant,
+            fn (string $key) => (int) ($rows[$key] ?? 0),
+        );
+    }
+
+    /**
+     * SQL expression that yields the bucket key (`Y-m-d` for the
+     * 7d / 30d ranges, `H` for the today/hour view). SQLite's
+     * `strftime` is used because it's the lowest common denominator
+     * across SQLite (local), MySQL and MariaDB. Postgres would need
+     * `to_char`; we'll wrap that behind a repository when Postgres
+     * lands.
+     */
+    private function bucketGroupExpression(AnalyticsRange $range, string $column = 'created_at'): string
+    {
+        return match ($range->bucketSize()) {
+            'hour' => "strftime('%H', {$column})",
+            default => "strftime('%Y-%m-%d', {$column})",
+        };
+    }
+
+    /**
+     * Build a complete, ordered bucket list across the range and
+     * fill each bucket's count from the resolver. Days/hours with
+     * no rows still appear in the result so the line chart never
+     * has holes (PRD-008 § Trend-Daten).
+     *
+     * @param  callable(string): int  $countResolver
+     * @return list<TrendBucket>
+     */
+    private function fillBuckets(
+        AnalyticsRange $range,
+        Restaurant $restaurant,
+        callable $countResolver,
+    ): array {
+        $timezone = $restaurant->timezone ?? config('app.timezone');
+        $start = $range->startsAt($timezone);
+        $buckets = [];
+
+        if ($range->bucketSize() === 'hour') {
+            for ($hour = 0; $hour < $range->bucketCount(); $hour++) {
+                $cursor = $start->copy()->addHours($hour);
+                $key = sprintf('%02d', $hour);
+                $label = sprintf('%02d:00', $hour);
+                $buckets[] = new TrendBucket(
+                    label: $label,
+                    bucketStart: $cursor->toIso8601String(),
+                    count: $countResolver($key),
+                );
+            }
+
+            return $buckets;
+        }
+
+        for ($day = 0; $day < $range->bucketCount(); $day++) {
+            $cursor = $start->copy()->addDays($day);
+            $key = $cursor->format('Y-m-d');
+            $buckets[] = new TrendBucket(
+                label: $key,
+                bucketStart: $cursor->toIso8601String(),
+                count: $countResolver($key),
+            );
+        }
+
+        return $buckets;
     }
 
     /**

--- a/app/Services/Analytics/AnalyticsSnapshot.php
+++ b/app/Services/Analytics/AnalyticsSnapshot.php
@@ -23,7 +23,15 @@ use App\Enums\AnalyticsRange;
  * - `sendModeStats`: PRD-007 breakdown, `null` when the restaurant is
  *   still on the V1.0 manual default and never recorded a non-manual
  *   mode in the window.
- * - `trends`: ordered list of buckets, gap-filled per `range->bucketCount()`.
+ * - `trends`: requests-per-bucket series, gap-filled per
+ *   `range->bucketCount()`. `bucket.count` is the integer request
+ *   count.
+ * - `confirmationRateTrend`: confirmation-rate-per-bucket series,
+ *   same gap-fill. `bucket.count` is the integer percentage (0-100);
+ *   buckets with no requests return 0 (the dashboard masks zero
+ *   denominators as "—" in the chart).
+ * - `threadRepliesTrend`: thread-replies-per-bucket series (PRD-006
+ *   inbound `reservation_messages`), same gap-fill.
  */
 final readonly class AnalyticsSnapshot
 {
@@ -32,6 +40,8 @@ final readonly class AnalyticsSnapshot
      * @param  array<string, int>  $sources
      * @param  array<string, int>  $statusBreakdown
      * @param  list<TrendBucket>  $trends
+     * @param  list<TrendBucket>  $confirmationRateTrend
+     * @param  list<TrendBucket>  $threadRepliesTrend
      */
     public function __construct(
         public AnalyticsRange $range,
@@ -42,5 +52,7 @@ final readonly class AnalyticsSnapshot
         public ?float $editRate,
         public ?SendModeStats $sendModeStats,
         public array $trends,
+        public array $confirmationRateTrend = [],
+        public array $threadRepliesTrend = [],
     ) {}
 }

--- a/tests/Unit/Analytics/AnalyticsAggregatorTest.php
+++ b/tests/Unit/Analytics/AnalyticsAggregatorTest.php
@@ -205,7 +205,10 @@ class AnalyticsAggregatorTest extends TestCase
         $this->assertNull($snapshot->responseTime->medianMinutes);
         $this->assertNull($snapshot->editRate);
         $this->assertNull($snapshot->sendModeStats);
-        $this->assertSame([], $snapshot->trends);
+        // Trends are gap-filled per the range; today → 24 hour buckets,
+        // all zero when no requests exist.
+        $this->assertCount(24, $snapshot->trends);
+        $this->assertSame(0, $snapshot->trends[0]->count);
     }
 
     public function test_constructor_uses_cache_repository_contract(): void

--- a/tests/Unit/Analytics/AnalyticsAggregatorTrendsTest.php
+++ b/tests/Unit/Analytics/AnalyticsAggregatorTrendsTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Analytics;
+
+use App\Enums\AnalyticsRange;
+use App\Enums\MessageDirection;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationMessage;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Analytics\AnalyticsAggregator;
+use App\Services\Analytics\TrendBucket;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class AnalyticsAggregatorTrendsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // Anchor "now" so the day labels in assertions are stable.
+        Carbon::setTestNow('2026-04-30 12:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function aggregator(): AnalyticsAggregator
+    {
+        return $this->app->make(AnalyticsAggregator::class);
+    }
+
+    private function makeRequest(
+        Restaurant $restaurant,
+        Carbon $createdAt,
+        ReservationStatus $status = ReservationStatus::New,
+    ): ReservationRequest {
+        return ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create([
+                'created_at' => $createdAt,
+                'status' => $status,
+            ]);
+    }
+
+    public function test_it_fills_trend_buckets_even_for_days_with_zero_requests(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'UTC']);
+
+        // Two requests on the same day (yesterday); the rest of the
+        // 7-day window has no activity at all.
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-29 09:00:00'));
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-29 18:30:00'));
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        // Last7Days = 7 inclusive day buckets.
+        $this->assertCount(7, $snapshot->trends);
+
+        $byLabel = [];
+        foreach ($snapshot->trends as $bucket) {
+            $this->assertInstanceOf(TrendBucket::class, $bucket);
+            $byLabel[$bucket->label] = $bucket->count;
+        }
+
+        // Window starts 6 days before today (2026-04-30) → 2026-04-24.
+        $this->assertSame(0, $byLabel['2026-04-24']);
+        $this->assertSame(0, $byLabel['2026-04-25']);
+        $this->assertSame(0, $byLabel['2026-04-26']);
+        $this->assertSame(0, $byLabel['2026-04-27']);
+        $this->assertSame(0, $byLabel['2026-04-28']);
+        $this->assertSame(2, $byLabel['2026-04-29']);
+        $this->assertSame(0, $byLabel['2026-04-30']);
+    }
+
+    public function test_it_returns_hourly_buckets_for_today_range(): void
+    {
+        // Re-anchor "now" past the test data so the 14:xx rows fit
+        // inside the today range (which caps at endsAt = now).
+        Carbon::setTestNow('2026-04-30 23:00:00');
+
+        $restaurant = Restaurant::factory()->create(['timezone' => 'UTC']);
+
+        // Three requests at 08:xx, two at 14:xx — the rest of the day empty.
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-30 08:05:00'));
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-30 08:30:00'));
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-30 08:55:00'));
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-30 14:10:00'));
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-30 14:50:00'));
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Today);
+
+        $this->assertCount(24, $snapshot->trends);
+
+        $byLabel = [];
+        foreach ($snapshot->trends as $bucket) {
+            $byLabel[$bucket->label] = $bucket->count;
+        }
+
+        $this->assertSame(3, $byLabel['08:00']);
+        $this->assertSame(2, $byLabel['14:00']);
+        $this->assertSame(0, $byLabel['00:00']);
+        $this->assertSame(0, $byLabel['23:00']);
+    }
+
+    public function test_it_returns_30_days_of_buckets_for_last30days_range(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'UTC']);
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last30Days);
+
+        $this->assertCount(30, $snapshot->trends);
+
+        // First bucket is 29 days before today, last bucket is today.
+        $this->assertSame('2026-04-01', $snapshot->trends[0]->label);
+        $this->assertSame('2026-04-30', $snapshot->trends[29]->label);
+
+        // All zero — no requests created in the window.
+        foreach ($snapshot->trends as $bucket) {
+            $this->assertSame(0, $bucket->count);
+        }
+    }
+
+    public function test_it_computes_confirmation_rate_per_day_as_integer_percentage(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'UTC']);
+
+        // Day A (2026-04-29): 4 requests, 1 confirmed → 25 %.
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-29 09:00'), ReservationStatus::Confirmed);
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-29 10:00'), ReservationStatus::New);
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-29 11:00'), ReservationStatus::New);
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-29 12:00'), ReservationStatus::Declined);
+
+        // Day B (2026-04-28): 2 requests, both confirmed → 100 %.
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-28 18:00'), ReservationStatus::Confirmed);
+        $this->makeRequest($restaurant, Carbon::parse('2026-04-28 19:00'), ReservationStatus::Confirmed);
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertCount(7, $snapshot->confirmationRateTrend);
+
+        $byLabel = [];
+        foreach ($snapshot->confirmationRateTrend as $bucket) {
+            $byLabel[$bucket->label] = $bucket->count;
+        }
+
+        $this->assertSame(25, $byLabel['2026-04-29']);
+        $this->assertSame(100, $byLabel['2026-04-28']);
+        // Day with zero requests: 0 % (frontend masks to "—").
+        $this->assertSame(0, $byLabel['2026-04-24']);
+    }
+
+    public function test_it_counts_inbound_thread_replies_per_day(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'UTC']);
+
+        $request = $this->makeRequest($restaurant, Carbon::parse('2026-04-25 08:00'));
+
+        // 2 inbound replies on 2026-04-29, 1 outbound (must NOT count),
+        // 1 inbound on 2026-04-28.
+        ReservationMessage::factory()->create([
+            'reservation_request_id' => $request->id,
+            'direction' => MessageDirection::In,
+            'created_at' => Carbon::parse('2026-04-29 09:30:00'),
+            'received_at' => Carbon::parse('2026-04-29 09:30:00'),
+        ]);
+        ReservationMessage::factory()->create([
+            'reservation_request_id' => $request->id,
+            'direction' => MessageDirection::In,
+            'created_at' => Carbon::parse('2026-04-29 14:00:00'),
+            'received_at' => Carbon::parse('2026-04-29 14:00:00'),
+        ]);
+        ReservationMessage::factory()->create([
+            'reservation_request_id' => $request->id,
+            'direction' => MessageDirection::Out,
+            'created_at' => Carbon::parse('2026-04-29 12:00:00'),
+            'sent_at' => Carbon::parse('2026-04-29 12:00:00'),
+        ]);
+        ReservationMessage::factory()->create([
+            'reservation_request_id' => $request->id,
+            'direction' => MessageDirection::In,
+            'created_at' => Carbon::parse('2026-04-28 11:00:00'),
+            'received_at' => Carbon::parse('2026-04-28 11:00:00'),
+        ]);
+
+        $snapshot = $this->aggregator()->aggregate($restaurant, AnalyticsRange::Last7Days);
+
+        $this->assertCount(7, $snapshot->threadRepliesTrend);
+
+        $byLabel = [];
+        foreach ($snapshot->threadRepliesTrend as $bucket) {
+            $byLabel[$bucket->label] = $bucket->count;
+        }
+
+        $this->assertSame(2, $byLabel['2026-04-29']);
+        $this->assertSame(1, $byLabel['2026-04-28']);
+        $this->assertSame(0, $byLabel['2026-04-27']);
+    }
+
+    public function test_it_scopes_trends_to_the_given_restaurant(): void
+    {
+        $own = Restaurant::factory()->create(['timezone' => 'UTC']);
+        $other = Restaurant::factory()->create(['timezone' => 'UTC']);
+
+        $this->makeRequest($own, Carbon::parse('2026-04-29 09:00'));
+
+        // Other restaurant: 5 requests on the same day — must not bleed in.
+        for ($i = 0; $i < 5; $i++) {
+            $this->makeRequest($other, Carbon::parse('2026-04-29 10:00'));
+        }
+
+        $snapshot = $this->aggregator()->aggregate($own, AnalyticsRange::Last7Days);
+
+        $byLabel = [];
+        foreach ($snapshot->trends as $bucket) {
+            $byLabel[$bucket->label] = $bucket->count;
+        }
+
+        $this->assertSame(1, $byLabel['2026-04-29']);
+    }
+}


### PR DESCRIPTION
## Summary

- New trend-series methods on `AnalyticsAggregator`:
  - `requestsTrend()` — primary line chart, requests per bucket
  - `confirmationRateTrend()` — integer percentage (0-100) per bucket; zero-denominator buckets surface as 0 (dashboard masks to "—")
  - `threadRepliesTrend()` — inbound `reservation_messages` per bucket (PRD-006 engagement signal)
- Day buckets for `7d` / `30d`, hour buckets for `today` (24 buckets via `AnalyticsRange::bucketSize()`).
- Gap-filled in PHP via `fillBuckets()` so empty days/hours render as a baseline rather than holes in the chart.
- Bucket keys are computed in the restaurant's local timezone (PHP-side bucketing) — keeps queries portable across SQLite, MySQL/MariaDB and (later) Postgres without dialect-specific SQL.
- DTO `AnalyticsSnapshot` grows `confirmationRateTrend` and `threadRepliesTrend` (default `[]`); `AnalyticsSnapshotResource` forwards both.

## Why

Issue #229 — fills the trends slot of the PRD-008 dashboard snapshot. Last aggregator branch before the controller / page issues (#231 / #232).

Closes #229

## Test plan

- [x] `php artisan test --filter=AnalyticsAggregatorTrendsTest` (6 passed, 62 assertions)
- [x] `php artisan test` (703 passed)
- [x] `./vendor/bin/pint --test`
- [x] `npm run lint` + `npm run format:check`

Test cases:
- gap-filled day buckets (7 buckets, only one day populated)
- 24 hourly buckets for `Today`
- 30 day buckets for `Last30Days`
- confirmation-rate-per-day computed as integer percentage (25 / 100; 0 for empty days)
- inbound thread replies per day, outbound excluded
- multi-tenant scoping for all three series (sibling restaurant cannot leak in)
- existing `skeleton fields` test updated to match the new gap-fill (24 zero buckets for Today)