### PR TITLE
Wire analytics route + controller + sidebar (#231)

### DIFF
--- a/app/Http/Controllers/AnalyticsController.php
+++ b/app/Http/Controllers/AnalyticsController.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\AnalyticsIndexRequest;
+use App\Http\Resources\AnalyticsSnapshotResource;
+use App\Services\Analytics\AnalyticsAggregator;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Renders the PRD-008 analytics dashboard. The controller owns
+ * the tenant resolution (`auth()->user()->restaurant`) and the
+ * range validation (via {@see AnalyticsIndexRequest}); the actual
+ * aggregation lives in {@see AnalyticsAggregator} so this layer
+ * stays a thin Inertia adapter.
+ */
+final class AnalyticsController extends Controller
+{
+    public function __construct(
+        private readonly AnalyticsAggregator $aggregator,
+    ) {}
+
+    public function index(AnalyticsIndexRequest $request): Response
+    {
+        $restaurant = $request->user()?->restaurant;
+
+        if ($restaurant === null) {
+            // A user without a restaurant cannot meaningfully view
+            // analytics — surface a 404 rather than a confusing
+            // empty dashboard. Onboarding/seat-management is out of
+            // V1.0 scope.
+            throw new NotFoundHttpException;
+        }
+
+        $range = $request->range();
+        $snapshot = $this->aggregator->aggregate($restaurant, $range);
+
+        return Inertia::render('Analytics', [
+            // Resolve to a plain array so the Inertia prop is a flat
+            // map and not wrapped in JsonResource's `data` envelope —
+            // the Vue page consumes the snapshot directly.
+            'snapshot' => (new AnalyticsSnapshotResource($snapshot))->resolve($request),
+        ]);
+    }
+}

--- a/app/Http/Requests/AnalyticsIndexRequest.php
+++ b/app/Http/Requests/AnalyticsIndexRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Enums\AnalyticsRange;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates the `range` query parameter for the analytics page
+ * (PRD-008). The form-request maps the string token (`today` /
+ * `7d` / `30d`) onto the {@see AnalyticsRange} enum so the
+ * aggregator never has to defend against unknown ranges.
+ */
+class AnalyticsIndexRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'range' => ['nullable', Rule::enum(AnalyticsRange::class)],
+        ];
+    }
+
+    /**
+     * Resolved range with the PRD-008 default (`30d`) for empty
+     * query strings.
+     */
+    public function range(): AnalyticsRange
+    {
+        $value = $this->validated()['range'] ?? null;
+
+        return $value === null
+            ? AnalyticsRange::Last30Days
+            : AnalyticsRange::from($value);
+    }
+}

--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -4,7 +4,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
-import { CalendarClock, Settings } from 'lucide-vue-next';
+import { BarChart3, CalendarClock, Settings } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
 const mainNavItems: NavItem[] = [
@@ -12,6 +12,11 @@ const mainNavItems: NavItem[] = [
         title: 'Reservierungen',
         href: '/dashboard',
         icon: CalendarClock,
+    },
+    {
+        title: 'Analytics',
+        href: '/analytics',
+        icon: BarChart3,
     },
     {
         title: 'Einstellungen',

--- a/resources/js/pages/Analytics.vue
+++ b/resources/js/pages/Analytics.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import { type BreadcrumbItem } from '@/types';
+import { Head, router } from '@inertiajs/vue3';
+
+interface TrendBucket {
+    label: string;
+    bucketStart: string;
+    count: number;
+}
+
+interface AnalyticsSnapshot {
+    range: 'today' | '7d' | '30d';
+    bucketSize: 'hour' | 'day';
+    totals: Record<string, number>;
+    sources: Record<string, number>;
+    statusBreakdown: Record<string, number>;
+    responseTime: {
+        medianMinutes: number | null;
+        p90Minutes: number | null;
+        sampleSize: number;
+    };
+    editRate: number | null;
+    sendModeStats: {
+        manual: number;
+        shadow: number;
+        auto: number;
+        shadowComparedSampleSize: number;
+        takeoverRate: number | null;
+        topHardGateReasons: Array<{ reason: string; count: number }>;
+    } | null;
+    trends: TrendBucket[];
+    confirmationRateTrend: TrendBucket[];
+    threadRepliesTrend: TrendBucket[];
+}
+
+defineProps<{
+    snapshot: AnalyticsSnapshot;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'Analytics', href: '/analytics' }];
+
+// Range tabs trigger an Inertia partial reload so cache + tenant
+// scoping stay on the server. The full chart UI lands in #232; this
+// stub keeps the wiring testable.
+const ranges: Array<{ value: 'today' | '7d' | '30d'; label: string }> = [
+    { value: 'today', label: 'Heute' },
+    { value: '7d', label: 'Letzte 7 Tage' },
+    { value: '30d', label: 'Letzte 30 Tage' },
+];
+
+function selectRange(range: 'today' | '7d' | '30d') {
+    router.reload({
+        data: { range },
+        only: ['snapshot'],
+        preserveScroll: true,
+    });
+}
+</script>
+
+<template>
+    <Head title="Analytics" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="flex flex-col gap-6 p-4">
+            <div class="flex flex-wrap gap-2">
+                <button
+                    v-for="r in ranges"
+                    :key="r.value"
+                    type="button"
+                    class="rounded-md border px-3 py-1.5 text-sm transition"
+                    :class="snapshot.range === r.value ? 'border-primary bg-primary/10 text-primary' : 'border-border hover:bg-muted'"
+                    @click="selectRange(r.value)"
+                >
+                    {{ r.label }}
+                </button>
+            </div>
+
+            <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                <div class="rounded-lg border p-4">
+                    <p class="text-sm text-muted-foreground">Anfragen gesamt</p>
+                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.totals.total ?? 0 }}</p>
+                </div>
+                <div class="rounded-lg border p-4">
+                    <p class="text-sm text-muted-foreground">Web-Formular</p>
+                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.sources.web_form ?? 0 }}</p>
+                </div>
+                <div class="rounded-lg border p-4">
+                    <p class="text-sm text-muted-foreground">E-Mail</p>
+                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.sources.email ?? 0 }}</p>
+                </div>
+                <div class="rounded-lg border p-4">
+                    <p class="text-sm text-muted-foreground">Bestätigt</p>
+                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.statusBreakdown.confirmed ?? 0 }}</p>
+                </div>
+            </section>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -3,6 +3,7 @@ declare module 'ziggy-js' {
   interface RouteList {
     "home": [],
     "dashboard": [],
+    "analytics.index": [],
     "reservations.show": [
         {
             "name": "reservation",

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\ReservationMessagesController;
@@ -16,6 +17,10 @@ Route::get('/', function () {
 Route::get('dashboard', [DashboardController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('dashboard');
+
+Route::get('analytics', [AnalyticsController::class, 'index'])
+    ->middleware(['auth', 'verified'])
+    ->name('analytics.index');
 
 Route::get('reservations/{reservation}', [ReservationRequestController::class, 'show'])
     ->whereNumber('reservation')

--- a/tests/Feature/Analytics/AnalyticsPageTest.php
+++ b/tests/Feature/Analytics/AnalyticsPageTest.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Enums\ReservationSource;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class AnalyticsPageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_guests_are_redirected_to_login(): void
+    {
+        $this->get('/analytics')->assertRedirect('/login');
+    }
+
+    public function test_it_renders_the_analytics_page_for_owner(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->count(3)
+            ->create([
+                'created_at' => Carbon::now()->subDays(2),
+                'source' => ReservationSource::WebForm,
+            ]);
+
+        $this->actingAs($user)
+            ->get('/analytics')
+            ->assertOk()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Analytics')
+                    ->has('snapshot', fn (AssertableInertia $snapshot) => $snapshot
+                        ->where('range', '30d')
+                        ->where('totals.total', 3)
+                        ->where('sources.web_form', 3)
+                        ->etc()
+                    )
+            );
+    }
+
+    public function test_it_switches_range_via_query_string(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        // One request today, two requests 10 days ago.
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create(['created_at' => Carbon::now()->subHours(2)]);
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->count(2)
+            ->create(['created_at' => Carbon::now()->subDays(10)]);
+
+        $this->actingAs($user)
+            ->get('/analytics?range=today')
+            ->assertOk()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->component('Analytics')
+                    ->where('snapshot.range', 'today')
+                    ->where('snapshot.totals.total', 1)
+                    ->etc()
+            );
+    }
+
+    public function test_it_rejects_invalid_range_values(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($user)
+            ->get('/analytics?range=all-time')
+            ->assertSessionHasErrors('range');
+    }
+
+    public function test_it_forbids_access_for_users_without_restaurant(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $this->actingAs($user)
+            ->get('/analytics')
+            ->assertNotFound();
+    }
+
+    public function test_it_scopes_data_to_the_users_restaurant(): void
+    {
+        $own = Restaurant::factory()->create();
+        $other = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($own)->create();
+
+        ReservationRequest::factory()
+            ->forRestaurant($own)
+            ->create(['created_at' => Carbon::now()->subDays(1)]);
+        ReservationRequest::factory()
+            ->forRestaurant($other)
+            ->count(5)
+            ->create(['created_at' => Carbon::now()->subDays(1)]);
+
+        $this->actingAs($user)
+            ->get('/analytics')
+            ->assertOk()
+            ->assertInertia(
+                fn (AssertableInertia $page) => $page
+                    ->where('snapshot.totals.total', 1)
+                    ->etc()
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Route \`GET /analytics\` (auth + verified, named \`analytics.index\`).
- \`AnalyticsController\` loads \`\$request->user()->restaurant\` and 404s when the user has no restaurant (onboarding is out of V1.0 scope).
- \`AnalyticsIndexRequest\` validates \`range\` against \`AnalyticsRange\` (default \`30d\`).
- Snapshot is resolved to a flat array via \`(new AnalyticsSnapshotResource(\$snapshot))->resolve(\$request)\` so the Inertia prop is not wrapped in JsonResource's \`data\` envelope.
- Sidebar grows an \"Analytics\" entry with the \`BarChart3\` icon.
- Stub \`Analytics.vue\` renders four headline KPI cards and hooks the range tabs to a partial reload — full chart UI lands in #232.
- Ziggy types regenerated.

## Why

Issue #231 — first user-facing wiring for the PRD-008 dashboard. Builds on the aggregator (#226–#230).

Closes #231

## Test plan

- [x] \`php artisan test --filter=AnalyticsPageTest\` (6 passed, 49 assertions)
- [x] \`php artisan test\` (713 passed)
- [x] \`./vendor/bin/pint --test\`
- [x] \`npm run lint\` + \`npm run format:check\`
- [x] \`php artisan ziggy:generate --types-only resources/js/ziggy.d.ts\`

Test cases:
- guests are redirected to login
- owner sees the 30-day snapshot by default
- range query parameter switches the window (today → 1 of 3 requests)
- invalid range token fails validation
- user without a restaurant → 404
- snapshot scoped to the user's restaurant (sibling restaurant data does not leak in)