### PR TITLE
Full Analytics.vue page: range tabs, KPI cards, charts (#232)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
                 "@vitejs/plugin-vue": "^5.2.1",
                 "@vueuse/core": "^12.0.0",
                 "autoprefixer": "^10.4.20",
+                "chart.js": "^4.5.1",
                 "class-variance-authority": "^0.7.1",
                 "clsx": "^2.1.1",
                 "concurrently": "^9.0.1",
@@ -26,6 +27,7 @@
                 "typescript": "^5.2.2",
                 "vite": "^6.0.3",
                 "vue": "^3.5.13",
+                "vue-chartjs": "^5.3.3",
                 "vue-tsc": "^2.2.0",
                 "ziggy-js": "^2.4.2"
             },
@@ -931,6 +933,12 @@
                 "@jridgewell/resolve-uri": "^3.1.0",
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
+        },
+        "node_modules/@kurkle/color": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+            "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+            "license": "MIT"
         },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
@@ -2383,6 +2391,18 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/chart.js": {
+            "version": "4.5.1",
+            "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+            "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+            "license": "MIT",
+            "dependencies": {
+                "@kurkle/color": "^0.3.0"
+            },
+            "engines": {
+                "pnpm": ">=8"
             }
         },
         "node_modules/chokidar": {
@@ -5849,6 +5869,16 @@
                 "typescript": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vue-chartjs": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/vue-chartjs/-/vue-chartjs-5.3.3.tgz",
+            "integrity": "sha512-jqxtL8KZ6YJ5NTv6XzrzLS7osyegOi28UGNZW0h9OkDL7Sh1396ht4Dorh04aKrl2LiSalQ84WtqiG0RIJb0tA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "chart.js": "^4.1.1",
+                "vue": "^3.0.0-0 || ^2.7.0"
             }
         },
         "node_modules/vue-component-type-helpers": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@vitejs/plugin-vue": "^5.2.1",
         "@vueuse/core": "^12.0.0",
         "autoprefixer": "^10.4.20",
+        "chart.js": "^4.5.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "concurrently": "^9.0.1",
@@ -49,6 +50,7 @@
         "typescript": "^5.2.2",
         "vite": "^6.0.3",
         "vue": "^3.5.13",
+        "vue-chartjs": "^5.3.3",
         "vue-tsc": "^2.2.0",
         "ziggy-js": "^2.4.2"
     },

--- a/resources/js/pages/Analytics.spec.ts
+++ b/resources/js/pages/Analytics.spec.ts
@@ -1,0 +1,191 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Analytics, { type AnalyticsSnapshot } from './Analytics.vue';
+
+const reloadMock = vi.fn();
+
+vi.mock('@inertiajs/vue3', () => ({
+    Head: { name: 'Head', render: () => null },
+    router: {
+        get reload() {
+            return reloadMock;
+        },
+    },
+}));
+
+// vue-chartjs spins up a real chart instance against the canvas
+// element which happy-dom doesn't fully implement. A stub keeps
+// these tests fast and chart-library-agnostic — the chart's input
+// data is asserted via the prop the stub records.
+vi.mock('vue-chartjs', () => ({
+    Line: {
+        name: 'Line',
+        props: ['data', 'options'],
+        template: '<div data-testid="chart-stub" :data-labels="JSON.stringify(data.labels)" :data-counts="JSON.stringify(data.datasets[0].data)" />',
+    },
+}));
+
+vi.mock('chart.js', () => ({
+    Chart: { register: vi.fn() },
+    CategoryScale: {},
+    LinearScale: {},
+    PointElement: {},
+    LineElement: {},
+    Title: {},
+    Tooltip: {},
+    Legend: {},
+    Filler: {},
+}));
+
+vi.mock('@/layouts/AppLayout.vue', () => ({
+    default: {
+        name: 'AppLayout',
+        template: '<div data-testid="layout"><slot /></div>',
+    },
+}));
+
+function makeSnapshot(overrides: Partial<AnalyticsSnapshot> = {}): AnalyticsSnapshot {
+    return {
+        range: '30d',
+        bucketSize: 'day',
+        totals: { total: 12 },
+        sources: { web_form: 8, email: 4 },
+        statusBreakdown: {
+            new: 3,
+            in_review: 2,
+            replied: 1,
+            confirmed: 4,
+            declined: 1,
+            cancelled: 1,
+        },
+        responseTime: { medianMinutes: 30, p90Minutes: 120, sampleSize: 9 },
+        editRate: 0.25,
+        sendModeStats: null,
+        trends: [
+            { label: '2026-04-29', bucketStart: '2026-04-29T00:00:00+00:00', count: 5 },
+            { label: '2026-04-30', bucketStart: '2026-04-30T00:00:00+00:00', count: 7 },
+        ],
+        confirmationRateTrend: [
+            { label: '2026-04-29', bucketStart: '2026-04-29T00:00:00+00:00', count: 40 },
+            { label: '2026-04-30', bucketStart: '2026-04-30T00:00:00+00:00', count: 60 },
+        ],
+        threadRepliesTrend: [
+            { label: '2026-04-29', bucketStart: '2026-04-29T00:00:00+00:00', count: 1 },
+            { label: '2026-04-30', bucketStart: '2026-04-30T00:00:00+00:00', count: 2 },
+        ],
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    reloadMock.mockReset();
+});
+
+describe('Analytics.vue', () => {
+    it('range-toggle switches active tab and triggers a partial reload', async () => {
+        const wrapper = mount(Analytics, {
+            props: { snapshot: makeSnapshot({ range: '30d' }) },
+        });
+
+        const tabs = wrapper.findAll('[role="tab"]');
+        expect(tabs).toHaveLength(3);
+
+        const todayTab = tabs[0];
+        expect(todayTab.attributes('aria-selected')).toBe('false');
+
+        await todayTab.trigger('click');
+
+        expect(reloadMock).toHaveBeenCalledTimes(1);
+        expect(reloadMock).toHaveBeenCalledWith({
+            data: { range: 'today' },
+            only: ['snapshot'],
+            preserveScroll: true,
+        });
+    });
+
+    it('does not reload when the active range tab is clicked again', async () => {
+        const wrapper = mount(Analytics, {
+            props: { snapshot: makeSnapshot({ range: '30d' }) },
+        });
+
+        // The third tab (30d) is active per the snapshot above.
+        const activeTab = wrapper.findAll('[role="tab"]')[2];
+        expect(activeTab.attributes('aria-selected')).toBe('true');
+
+        await activeTab.trigger('click');
+
+        expect(reloadMock).not.toHaveBeenCalled();
+    });
+
+    it('chart renders with the provided trend data', () => {
+        const wrapper = mount(Analytics, {
+            props: { snapshot: makeSnapshot() },
+        });
+
+        const charts = wrapper.findAll('[data-testid="chart-stub"]');
+        expect(charts).toHaveLength(3);
+
+        const requestsChart = charts[0];
+        expect(JSON.parse(requestsChart.attributes('data-counts') ?? '[]')).toEqual([5, 7]);
+
+        const confirmationChart = charts[1];
+        expect(JSON.parse(confirmationChart.attributes('data-counts') ?? '[]')).toEqual([40, 60]);
+
+        const threadChart = charts[2];
+        expect(JSON.parse(threadChart.attributes('data-counts') ?? '[]')).toEqual([1, 2]);
+    });
+
+    it('shows the empty state when totals are zero', () => {
+        const wrapper = mount(Analytics, {
+            props: {
+                snapshot: makeSnapshot({
+                    totals: { total: 0 },
+                    sources: { web_form: 0, email: 0 },
+                    statusBreakdown: {
+                        new: 0,
+                        in_review: 0,
+                        replied: 0,
+                        confirmed: 0,
+                        declined: 0,
+                        cancelled: 0,
+                    },
+                }),
+            },
+        });
+
+        expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(true);
+        expect(wrapper.findAll('[data-testid="chart-stub"]')).toHaveLength(0);
+    });
+
+    it('hides send-mode stats in manual mode', () => {
+        const wrapper = mount(Analytics, {
+            props: { snapshot: makeSnapshot({ sendModeStats: null }) },
+        });
+
+        expect(wrapper.find('[data-testid="send-mode-section"]').exists()).toBe(false);
+    });
+
+    it('shows send-mode stats when shadow / auto mode is active', () => {
+        const wrapper = mount(Analytics, {
+            props: {
+                snapshot: makeSnapshot({
+                    sendModeStats: {
+                        manual: 0,
+                        shadow: 4,
+                        auto: 0,
+                        shadowComparedSampleSize: 3,
+                        takeoverRate: 0.667,
+                        topHardGateReasons: [
+                            { reason: 'short_notice', count: 2 },
+                            { reason: 'first_time_guest', count: 1 },
+                        ],
+                    },
+                }),
+            },
+        });
+
+        expect(wrapper.find('[data-testid="send-mode-section"]').exists()).toBe(true);
+        expect(wrapper.text()).toContain('short_notice');
+        expect(wrapper.text()).toContain('first_time_guest');
+    });
+});

--- a/resources/js/pages/Analytics.test.ts
+++ b/resources/js/pages/Analytics.test.ts
@@ -1,4 +1,4 @@
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Analytics, { type AnalyticsSnapshot } from './Analytics.vue';
 
@@ -117,10 +117,15 @@ describe('Analytics.vue', () => {
         expect(reloadMock).not.toHaveBeenCalled();
     });
 
-    it('chart renders with the provided trend data', () => {
+    it('chart renders with the provided trend data', async () => {
         const wrapper = mount(Analytics, {
             props: { snapshot: makeSnapshot() },
         });
+
+        // Line is wired up via defineAsyncComponent (PRD-008
+        // bundle budget): flush the microtask queue so the async
+        // chunk's stubbed module resolves before assertions.
+        await flushPromises();
 
         const charts = wrapper.findAll('[data-testid="chart-stub"]');
         expect(charts).toHaveLength(3);

--- a/resources/js/pages/Analytics.vue
+++ b/resources/js/pages/Analytics.vue
@@ -3,11 +3,30 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head, router } from '@inertiajs/vue3';
-import { CategoryScale, Chart as ChartJS, Filler, Legend, LinearScale, LineElement, PointElement, Title, Tooltip } from 'chart.js';
-import { computed } from 'vue';
-import { Line } from 'vue-chartjs';
+import { computed, defineAsyncComponent } from 'vue';
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler);
+// PRD-008 Bundle-Budget: chart.js + vue-chartjs are ~70 KB gzipped,
+// above the 60 KB threshold the PRD sets for the initial bundle.
+// `defineAsyncComponent` + dynamic import keep the chart code out of
+// the SPA's initial chunk; only users navigating to /analytics
+// download it. The Chart.js global registry is set up inside the
+// async chunk so it never executes for non-analytics pages.
+const Line = defineAsyncComponent(async () => {
+    const [{ Line: LineComponent }, chartjs] = await Promise.all([import('vue-chartjs'), import('chart.js')]);
+
+    chartjs.Chart.register(
+        chartjs.CategoryScale,
+        chartjs.LinearScale,
+        chartjs.PointElement,
+        chartjs.LineElement,
+        chartjs.Title,
+        chartjs.Tooltip,
+        chartjs.Legend,
+        chartjs.Filler,
+    );
+
+    return LineComponent;
+});
 
 interface TrendBucket {
     label: string;

--- a/resources/js/pages/Analytics.vue
+++ b/resources/js/pages/Analytics.vue
@@ -1,7 +1,13 @@
 <script setup lang="ts">
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { type BreadcrumbItem } from '@/types';
 import { Head, router } from '@inertiajs/vue3';
+import { CategoryScale, Chart as ChartJS, Filler, Legend, LinearScale, LineElement, PointElement, Title, Tooltip } from 'chart.js';
+import { computed } from 'vue';
+import { Line } from 'vue-chartjs';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler);
 
 interface TrendBucket {
     label: string;
@@ -9,91 +15,268 @@ interface TrendBucket {
     count: number;
 }
 
-interface AnalyticsSnapshot {
+interface ResponseTime {
+    medianMinutes: number | null;
+    p90Minutes: number | null;
+    sampleSize: number;
+}
+
+interface SendModeStats {
+    manual: number;
+    shadow: number;
+    auto: number;
+    shadowComparedSampleSize: number;
+    takeoverRate: number | null;
+    topHardGateReasons: Array<{ reason: string; count: number }>;
+}
+
+export interface AnalyticsSnapshot {
     range: 'today' | '7d' | '30d';
     bucketSize: 'hour' | 'day';
-    totals: Record<string, number>;
-    sources: Record<string, number>;
-    statusBreakdown: Record<string, number>;
-    responseTime: {
-        medianMinutes: number | null;
-        p90Minutes: number | null;
-        sampleSize: number;
-    };
+    totals: { total: number };
+    sources: { web_form: number; email: number };
+    statusBreakdown: Record<'new' | 'in_review' | 'replied' | 'confirmed' | 'declined' | 'cancelled', number>;
+    responseTime: ResponseTime;
     editRate: number | null;
-    sendModeStats: {
-        manual: number;
-        shadow: number;
-        auto: number;
-        shadowComparedSampleSize: number;
-        takeoverRate: number | null;
-        topHardGateReasons: Array<{ reason: string; count: number }>;
-    } | null;
+    sendModeStats: SendModeStats | null;
     trends: TrendBucket[];
     confirmationRateTrend: TrendBucket[];
     threadRepliesTrend: TrendBucket[];
 }
 
-defineProps<{
+const props = defineProps<{
     snapshot: AnalyticsSnapshot;
 }>();
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Analytics', href: '/analytics' }];
 
-// Range tabs trigger an Inertia partial reload so cache + tenant
-// scoping stay on the server. The full chart UI lands in #232; this
-// stub keeps the wiring testable.
 const ranges: Array<{ value: 'today' | '7d' | '30d'; label: string }> = [
     { value: 'today', label: 'Heute' },
-    { value: '7d', label: 'Letzte 7 Tage' },
-    { value: '30d', label: 'Letzte 30 Tage' },
+    { value: '7d', label: '7 Tage' },
+    { value: '30d', label: '30 Tage' },
 ];
 
 function selectRange(range: 'today' | '7d' | '30d') {
+    if (range === props.snapshot.range) {
+        return;
+    }
     router.reload({
         data: { range },
         only: ['snapshot'],
         preserveScroll: true,
     });
 }
+
+const isEmpty = computed(() => props.snapshot.totals.total === 0);
+
+const confirmationRate = computed(() => {
+    const total = props.snapshot.totals.total;
+    if (total === 0) {
+        return null;
+    }
+    const confirmed = props.snapshot.statusBreakdown.confirmed ?? 0;
+    return Math.round((confirmed / total) * 100);
+});
+
+const rejectionRate = computed(() => {
+    const total = props.snapshot.totals.total;
+    if (total === 0) {
+        return null;
+    }
+    const declined = props.snapshot.statusBreakdown.declined ?? 0;
+    return Math.round((declined / total) * 100);
+});
+
+const editRatePercent = computed(() => (props.snapshot.editRate === null ? null : Math.round(props.snapshot.editRate * 100)));
+
+const takeoverRatePercent = computed(() => {
+    const r = props.snapshot.sendModeStats?.takeoverRate;
+    return r === null || r === undefined ? null : Math.round(r * 100);
+});
+
+function formatPercent(value: number | null): string {
+    return value === null ? '—' : `${value} %`;
+}
+
+function formatMinutes(value: number | null): string {
+    return value === null ? '—' : `${value} min`;
+}
+
+const chartOptions = computed(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+        legend: { display: false },
+        tooltip: { intersect: false, mode: 'index' as const },
+    },
+    scales: {
+        y: { beginAtZero: true, ticks: { precision: 0 } },
+        x: { grid: { display: false } },
+    },
+}));
+
+function buildLineData(buckets: TrendBucket[], color: string) {
+    return {
+        labels: buckets.map((b) => b.label),
+        datasets: [
+            {
+                data: buckets.map((b) => b.count),
+                borderColor: color,
+                backgroundColor: `${color}33`,
+                fill: true,
+                tension: 0.25,
+                pointRadius: 2,
+            },
+        ],
+    };
+}
+
+const requestsChart = computed(() => buildLineData(props.snapshot.trends, '#2563eb'));
+const confirmationChart = computed(() => buildLineData(props.snapshot.confirmationRateTrend, '#16a34a'));
+const threadRepliesChart = computed(() => buildLineData(props.snapshot.threadRepliesTrend, '#9333ea'));
 </script>
 
 <template>
     <Head title="Analytics" />
 
     <AppLayout :breadcrumbs="breadcrumbs">
-        <div class="flex flex-col gap-6 p-4">
-            <div class="flex flex-wrap gap-2">
-                <button
-                    v-for="r in ranges"
-                    :key="r.value"
-                    type="button"
-                    class="rounded-md border px-3 py-1.5 text-sm transition"
-                    :class="snapshot.range === r.value ? 'border-primary bg-primary/10 text-primary' : 'border-border hover:bg-muted'"
-                    @click="selectRange(r.value)"
-                >
-                    {{ r.label }}
-                </button>
+        <div class="flex flex-col gap-6 p-4 md:p-6">
+            <header class="flex flex-wrap items-center justify-between gap-3">
+                <h1 class="text-2xl font-semibold tracking-tight">Analytics</h1>
+                <div role="tablist" aria-label="Zeitraum" class="flex flex-wrap gap-2">
+                    <button
+                        v-for="r in ranges"
+                        :key="r.value"
+                        type="button"
+                        role="tab"
+                        :aria-selected="snapshot.range === r.value"
+                        :data-active="snapshot.range === r.value"
+                        class="rounded-md border px-3 py-1.5 text-sm transition"
+                        :class="snapshot.range === r.value ? 'border-primary bg-primary/10 text-primary' : 'border-border hover:bg-muted'"
+                        @click="selectRange(r.value)"
+                    >
+                        {{ r.label }}
+                    </button>
+                </div>
+            </header>
+
+            <div v-if="isEmpty" class="rounded-lg border border-dashed p-10 text-center" data-testid="empty-state">
+                <p class="text-lg font-medium">Noch keine Anfragen im gewählten Zeitraum.</p>
+                <p class="mt-1 text-sm text-muted-foreground">Sobald Reservierungsanfragen eingehen, erscheinen hier die KPIs und Trend-Charts.</p>
             </div>
 
-            <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                <div class="rounded-lg border p-4">
-                    <p class="text-sm text-muted-foreground">Anfragen gesamt</p>
-                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.totals.total ?? 0 }}</p>
-                </div>
-                <div class="rounded-lg border p-4">
-                    <p class="text-sm text-muted-foreground">Web-Formular</p>
-                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.sources.web_form ?? 0 }}</p>
-                </div>
-                <div class="rounded-lg border p-4">
-                    <p class="text-sm text-muted-foreground">E-Mail</p>
-                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.sources.email ?? 0 }}</p>
-                </div>
-                <div class="rounded-lg border p-4">
-                    <p class="text-sm text-muted-foreground">Bestätigt</p>
-                    <p class="mt-1 text-2xl font-semibold">{{ snapshot.statusBreakdown.confirmed ?? 0 }}</p>
-                </div>
-            </section>
+            <template v-else>
+                <section class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+                    <Card>
+                        <CardHeader>
+                            <CardDescription>Anfragen gesamt</CardDescription>
+                            <CardTitle class="text-3xl">{{ snapshot.totals.total }}</CardTitle>
+                        </CardHeader>
+                        <CardContent class="text-sm text-muted-foreground">
+                            Web-Formular: {{ snapshot.sources.web_form }} · E-Mail: {{ snapshot.sources.email }}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardDescription>Bestätigungsquote</CardDescription>
+                            <CardTitle class="text-3xl">{{ formatPercent(confirmationRate) }}</CardTitle>
+                        </CardHeader>
+                        <CardContent class="text-sm text-muted-foreground"> Ablehnungsquote: {{ formatPercent(rejectionRate) }} </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardDescription>Zeit bis Antwort</CardDescription>
+                            <CardTitle class="text-3xl">{{ formatMinutes(snapshot.responseTime.medianMinutes) }}</CardTitle>
+                        </CardHeader>
+                        <CardContent class="text-sm text-muted-foreground">
+                            p90: {{ formatMinutes(snapshot.responseTime.p90Minutes) }} · n =
+                            {{ snapshot.responseTime.sampleSize }}
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardDescription>Edit-Quote</CardDescription>
+                            <CardTitle class="text-3xl">{{ formatPercent(editRatePercent) }}</CardTitle>
+                        </CardHeader>
+                        <CardContent class="text-sm text-muted-foreground"> Anteil der KI-Drafts, die nachbearbeitet wurden. </CardContent>
+                    </Card>
+                </section>
+
+                <section v-if="snapshot.sendModeStats" class="grid grid-cols-1 gap-4 lg:grid-cols-2" data-testid="send-mode-section">
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Send-Mode-Stats</CardTitle>
+                            <CardDescription>PRD-007 Auto-Send-Vertrauen</CardDescription>
+                        </CardHeader>
+                        <CardContent class="space-y-2 text-sm">
+                            <div class="flex justify-between">
+                                <span>Manual</span>
+                                <span>{{ snapshot.sendModeStats.manual }}</span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Shadow</span>
+                                <span>{{ snapshot.sendModeStats.shadow }}</span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Auto</span>
+                                <span>{{ snapshot.sendModeStats.auto }}</span>
+                            </div>
+                            <div class="flex justify-between">
+                                <span>Shadow-Übernahme-Rate</span>
+                                <span>{{ formatPercent(takeoverRatePercent) }}</span>
+                            </div>
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Top Hard-Gate-Reasons</CardTitle>
+                            <CardDescription>Häufigste Gründe, warum auto auf manual fällt</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                            <ul v-if="snapshot.sendModeStats.topHardGateReasons.length > 0" class="space-y-1 text-sm">
+                                <li v-for="entry in snapshot.sendModeStats.topHardGateReasons" :key="entry.reason" class="flex justify-between">
+                                    <span>{{ entry.reason }}</span>
+                                    <span>{{ entry.count }}</span>
+                                </li>
+                            </ul>
+                            <p v-else class="text-sm text-muted-foreground">Keine Hard-Gate-Blockaden im aktuellen Zeitraum.</p>
+                        </CardContent>
+                    </Card>
+                </section>
+
+                <section class="grid grid-cols-1 gap-4 lg:grid-cols-3">
+                    <Card class="col-span-1 lg:col-span-1">
+                        <CardHeader>
+                            <CardTitle>Anfragen pro {{ snapshot.bucketSize === 'hour' ? 'Stunde' : 'Tag' }}</CardTitle>
+                        </CardHeader>
+                        <CardContent class="h-64">
+                            <Line :data="requestsChart" :options="chartOptions" />
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Bestätigungsquote (%)</CardTitle>
+                        </CardHeader>
+                        <CardContent class="h-64">
+                            <Line :data="confirmationChart" :options="chartOptions" />
+                        </CardContent>
+                    </Card>
+
+                    <Card>
+                        <CardHeader>
+                            <CardTitle>Thread-Replies (Gast)</CardTitle>
+                        </CardHeader>
+                        <CardContent class="h-64">
+                            <Line :data="threadRepliesChart" :options="chartOptions" />
+                        </CardContent>
+                    </Card>
+                </section>
+            </template>
         </div>
     </AppLayout>
 </template>


### PR DESCRIPTION
## Summary

Replaces the #231 stub with the full PRD-008 dashboard surface:

- **Range tabs** (Heute / 7 Tage / 30 Tage) trigger Inertia partial reload — no separate fetch, no own state.
- **KPI grid** via Reka-UI \`Card\` components:
  - Anfragen gesamt + Web-Formular / E-Mail breakdown
  - Bestätigungsquote / Ablehnungsquote (computed from \`statusBreakdown\` + \`totals.total\`)
  - Median + p90 Zeit bis Antwort + sample size
  - Edit-Quote
  - Send-mode block (only when \`sendModeStats !== null\`): manual/shadow/auto counts, shadow-Übernahme-Rate, Top-3 hard-gate-Reasons
- **Three line charts** via \`vue-chartjs\`: requests-per-bucket, confirmation-rate-per-bucket (%), thread-replies-per-bucket. Charts read directly from Inertia props — no fetches.
- **Empty state** for \`totals.total === 0\` — friendly text instead of empty charts.
- **Mobile**: KPIs collapse 4 → 2 → 1 columns; chart row stacks below \`lg:\`.
- Adds \`vue-chartjs\` + \`chart.js\` to \`package.json\`.

Vitest suite stubs \`vue-chartjs\` / \`chart.js\` / \`AppLayout\` / \`@inertiajs/vue3\` to keep tests fast and chart-library-agnostic — chart props are asserted via the stub's recorded data.

## Why

Issue #232 — completes the user-facing PRD-008 surface; depends on #231 (route + controller) and #226–#230 (aggregator + cache).

Closes #232

## Test plan

- [x] \`npx vitest run resources/js/pages/Analytics.spec.ts\` (6 passed)
- [x] \`npm run test\` (56 passed)
- [x] \`php artisan test\` (713 passed)
- [x] \`./vendor/bin/pint --test\`
- [x] \`npm run lint\` + \`npm run format:check\`

Vitest cases:
- range-toggle switches active tab and triggers a partial reload
- clicking the active tab again does NOT trigger a reload (idempotent)
- chart renders with the provided trend data (counts / labels match props)
- empty state shows when totals are zero
- send-mode stats hidden in manual mode
- send-mode stats visible (with hard-gate list) in shadow / auto mode