### PR TITLE
Dashboard drawer: shadow + scheduled-auto-send banners (#221)

### DIFF
--- a/app/Http/Controllers/ReservationReplyController.php
+++ b/app/Http/Controllers/ReservationReplyController.php
@@ -27,20 +27,65 @@ class ReservationReplyController extends Controller
             return back()->with('error', 'Diese Antwort wurde bereits freigegeben.');
         }
 
+        // Promotion path from `shadow` → `approved` (PRD-007 issue
+        // #221): capturing whether the operator changed the AI text
+        // before sending feeds the takeover-rate stat exposed by
+        // PRD-008. Strict trimmed comparison so a whitespace-only
+        // diff is not counted as a real edit.
+        $wasShadow = $reply->status === ReservationReplyStatus::Shadow;
         $editedBody = $request->string('body')->trim()->toString();
-        if ($editedBody !== '' && $editedBody !== $reply->body) {
+        $bodyChanged = $editedBody !== '' && $editedBody !== trim($reply->body);
+
+        if ($bodyChanged) {
             $reply->body = $editedBody;
         }
 
-        $reply->forceFill([
+        $payload = [
             'status' => ReservationReplyStatus::Approved,
             'approved_by' => Auth::id(),
             'approved_at' => now(),
-        ])->save();
+        ];
+
+        if ($wasShadow) {
+            $payload['shadow_was_modified'] = $bodyChanged;
+            // The operator demonstrably reviewed the draft when they
+            // hit Approve; mark it compared if the side-effect
+            // endpoint hasn't already done so.
+            if ($reply->shadow_compared_at === null) {
+                $payload['shadow_compared_at'] = now();
+            }
+        }
+
+        $reply->forceFill($payload)->save();
 
         SendReservationReplyJob::dispatch($reply->id);
 
         return back()->with('success', 'Antwort freigegeben — sie wird gleich versendet.');
+    }
+
+    /**
+     * Mark a shadow reply as "the operator has reviewed this" so the
+     * PRD-008 takeover-rate denominator (`shadow_compared_at IS NOT
+     * NULL`) counts it. Idempotent: re-opening the drawer must not
+     * overwrite the timestamp; the front-end relies on
+     * `shadow_compared_at` being set the moment the operator first
+     * looked at the draft. Only applies to replies whose current
+     * status is still `shadow` — once promoted to `approved`, the
+     * approve flow itself sets the timestamp.
+     */
+    public function markShadowCompared(ReservationReply $reply): RedirectResponse
+    {
+        if ($reply->status !== ReservationReplyStatus::Shadow) {
+            return back();
+        }
+
+        if ($reply->shadow_compared_at !== null) {
+            return back();
+        }
+
+        $reply->forceFill(['shadow_compared_at' => now()])->save();
+
+        return back();
     }
 
     /**

--- a/app/Http/Resources/ReservationRequestDetailResource.php
+++ b/app/Http/Resources/ReservationRequestDetailResource.php
@@ -67,6 +67,16 @@ final class ReservationRequestDetailResource extends JsonResource
             'approved_at' => $reply->approved_at?->toISOString(),
             'sent_at' => $reply->sent_at?->toISOString(),
             'error_message' => $reply->error_message,
+            // PRD-007 detail-drawer hooks (issue #221):
+            //   - `auto_send_scheduled_for` powers the cancel-window
+            //     countdown for `scheduled_auto_send` replies.
+            //   - `shadow_compared_at` lets the drawer skip the
+            //     "mark as compared" round-trip on subsequent opens.
+            //   - `send_mode_at_creation` so the operator sees which
+            //     mode was active when the draft landed.
+            'auto_send_scheduled_for' => $reply->auto_send_scheduled_for?->toISOString(),
+            'shadow_compared_at' => $reply->shadow_compared_at?->toISOString(),
+            'send_mode_at_creation' => $reply->send_mode_at_creation?->value,
         ];
     }
 }

--- a/app/Policies/ReservationReplyPolicy.php
+++ b/app/Policies/ReservationReplyPolicy.php
@@ -30,4 +30,16 @@ final class ReservationReplyPolicy
     {
         return $this->view($user, $reply);
     }
+
+    /**
+     * Marking a shadow reply as compared is a side-effect on view —
+     * same tenancy gate, no role distinction. The dashboard fires
+     * this on first drawer open for a shadow reply; cross-restaurant
+     * users still must not be able to flip the timestamp on someone
+     * else's data.
+     */
+    public function markShadowCompared(User $user, ReservationReply $reply): bool
+    {
+        return $this->view($user, $reply);
+    }
 }

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -6,6 +6,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useCountdown } from '@/composables/useCountdown';
 import { usePagePolling } from '@/composables/usePagePolling';
 import { useRowSelection } from '@/composables/useRowSelection';
 import AppLayout from '@/layouts/AppLayout.vue';
@@ -260,18 +261,24 @@ function selectDrawerTab(tab: DrawerTab): void {
     }
 }
 
-const REPLY_STATUS_LABEL: Record<'draft' | 'approved' | 'sent' | 'failed', string> = {
+const REPLY_STATUS_LABEL: Partial<Record<NonNullable<ReservationRequestDetail['latest_reply']>['status'], string>> = {
     draft: 'KI-Vorschlag verfügbar',
     approved: 'Wird versendet',
     sent: 'Versendet',
     failed: 'Versand fehlgeschlagen',
+    shadow: 'Schatten-Modus — nicht versendet',
+    scheduled_auto_send: 'Auto-Versand vorgemerkt',
+    cancelled_auto: 'Auto-Versand abgebrochen',
 };
 
-const REPLY_STATUS_BADGE: Record<'draft' | 'approved' | 'sent' | 'failed', string> = {
+const REPLY_STATUS_BADGE: Partial<Record<NonNullable<ReservationRequestDetail['latest_reply']>['status'], string>> = {
     draft: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200',
     approved: 'bg-blue-100 text-blue-900 dark:bg-blue-900/40 dark:text-blue-200',
     sent: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200',
     failed: 'bg-red-100 text-red-900 dark:bg-red-900/40 dark:text-red-200',
+    shadow: 'bg-yellow-100 text-yellow-900 dark:bg-yellow-900/40 dark:text-yellow-200',
+    scheduled_auto_send: 'bg-orange-100 text-orange-900 dark:bg-orange-900/40 dark:text-orange-200',
+    cancelled_auto: 'bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-200',
 };
 
 const replyBody = ref('');
@@ -294,8 +301,20 @@ const currentReplyId = computed(() => props.selectedRequest?.latest_reply?.id ??
 
 const isReplyEditable = computed(() => {
     const reply = props.selectedRequest?.latest_reply;
-    return reply !== null && reply !== undefined && reply.status === 'draft';
+    if (reply === null || reply === undefined) {
+        return false;
+    }
+    // Shadow drafts are also editable: the operator promotes them
+    // to manual send via the same approve flow (PRD-007 #221).
+    return reply.status === 'draft' || reply.status === 'shadow';
 });
+
+const isShadowReply = computed(() => props.selectedRequest?.latest_reply?.status === 'shadow');
+const isScheduledAutoSend = computed(() => props.selectedRequest?.latest_reply?.status === 'scheduled_auto_send');
+
+const autoSendDeadline = computed(() => props.selectedRequest?.latest_reply?.auto_send_scheduled_for ?? null);
+const autoSendCountdown = useCountdown(autoSendDeadline);
+const cancellingAutoSend = ref(false);
 
 const isEdited = computed(() => {
     const reply = props.selectedRequest?.latest_reply;
@@ -334,7 +353,7 @@ watch(
 
 function submitApproval(): void {
     const reply = props.selectedRequest?.latest_reply;
-    if (!reply || reply.status !== 'draft') {
+    if (!reply || (reply.status !== 'draft' && reply.status !== 'shadow')) {
         return;
     }
 
@@ -360,6 +379,50 @@ function submitApproval(): void {
         },
     });
 }
+
+function cancelAutoSend(): void {
+    const reply = props.selectedRequest?.latest_reply;
+    if (!reply || reply.status !== 'scheduled_auto_send') {
+        return;
+    }
+
+    cancellingAutoSend.value = true;
+    router.post(
+        route('reservation-replies.cancel-auto-send', { reply: reply.id }),
+        {},
+        {
+            preserveScroll: true,
+            onFinish: () => {
+                cancellingAutoSend.value = false;
+            },
+        },
+    );
+}
+
+// Mark a shadow reply as compared the moment the operator first
+// looks at it (PRD-008 takeover-rate denominator). Idempotent on
+// the server: the endpoint is a no-op once `shadow_compared_at`
+// is already set, so re-opens after polling don't write again.
+const markedAsShadowCompared = ref<Set<number>>(new Set());
+
+watch(
+    () => props.selectedRequest?.latest_reply,
+    (reply) => {
+        if (!reply || reply.status !== 'shadow' || reply.shadow_compared_at !== null) {
+            return;
+        }
+        if (markedAsShadowCompared.value.has(reply.id)) {
+            return;
+        }
+        markedAsShadowCompared.value.add(reply.id);
+        router.post(
+            route('reservation-replies.mark-shadow-compared', { reply: reply.id }),
+            {},
+            { preserveScroll: true, preserveState: true, only: ['selectedRequest'] },
+        );
+    },
+    { immediate: true },
+);
 
 const selection = useRowSelection();
 const visibleRowIds = computed(() => props.requests.data.map((row) => row.id));
@@ -784,6 +847,42 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                             </span>
                         </div>
 
+                        <div
+                            v-if="isShadowReply"
+                            class="rounded-md border border-yellow-300 bg-yellow-50 p-3 text-xs text-yellow-900 dark:border-yellow-800 dark:bg-yellow-950/40 dark:text-yellow-200"
+                            data-testid="ai-reply-shadow-banner"
+                        >
+                            <p class="font-medium">Schatten-Modus — diese Antwort wurde <strong>nicht</strong> versendet.</p>
+                            <p v-if="props.selectedRequest.latest_reply.auto_send_scheduled_for" class="mt-1">
+                                Hätte automatisch versendet werden sollen am
+                                {{ renderTime(props.selectedRequest.latest_reply.auto_send_scheduled_for) }}.
+                            </p>
+                            <p v-else class="mt-1">Du kannst den KI-Text bearbeiten und manuell freigeben — Auswertung läuft im Hintergrund.</p>
+                        </div>
+
+                        <div
+                            v-if="isScheduledAutoSend"
+                            class="rounded-md border border-orange-300 bg-orange-50 p-3 text-xs text-orange-900 dark:border-orange-800 dark:bg-orange-950/40 dark:text-orange-200"
+                            data-testid="ai-reply-scheduled-banner"
+                        >
+                            <p class="font-medium">
+                                <span v-if="autoSendCountdown.secondsLeft.value > 0">
+                                    Wird automatisch versendet in {{ autoSendCountdown.secondsLeft.value }} s.
+                                </span>
+                                <span v-else>Auto-Versand wird gerade ausgelöst …</span>
+                            </p>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                class="mt-2"
+                                :disabled="cancellingAutoSend || autoSendCountdown.isExpired.value"
+                                data-testid="ai-reply-cancel-auto-send"
+                                @click="cancelAutoSend"
+                            >
+                                Versand abbrechen
+                            </Button>
+                        </div>
+
                         <textarea
                             v-model="replyBody"
                             :disabled="!isReplyEditable"
@@ -838,7 +937,12 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                         </p>
 
                         <Button v-if="isReplyEditable" :disabled="approving" class="w-full" data-testid="ai-reply-approve" @click="submitApproval">
-                            {{ isEdited ? 'Bearbeitete Version senden' : 'Freigeben & Versenden' }}
+                            <template v-if="isShadowReply">
+                                {{ isEdited ? 'Bearbeitete Version manuell senden' : 'Doch manuell freigeben & versenden' }}
+                            </template>
+                            <template v-else>
+                                {{ isEdited ? 'Bearbeitete Version senden' : 'Freigeben & Versenden' }}
+                            </template>
                         </Button>
                     </section>
                 </template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -104,7 +104,9 @@ export interface DashboardStats {
     in_review: number;
 }
 
-export type ReservationReplyStatus = 'draft' | 'approved' | 'sent' | 'failed';
+export type ReservationReplyStatus = 'draft' | 'approved' | 'sent' | 'failed' | 'shadow' | 'scheduled_auto_send' | 'cancelled_auto';
+
+export type SendMode = 'manual' | 'shadow' | 'auto';
 
 export interface ReservationReplySummary {
     id: number;
@@ -113,6 +115,10 @@ export interface ReservationReplySummary {
     approved_at: string | null;
     sent_at: string | null;
     error_message: string | null;
+    /** PRD-007 detail-drawer fields (issue #221). */
+    auto_send_scheduled_for: string | null;
+    shadow_compared_at: string | null;
+    send_mode_at_creation: SendMode | null;
 }
 
 export interface ReservationRequestDetail extends ReservationRequestRow {

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -31,6 +31,13 @@ declare module 'ziggy-js' {
             "binding": "id"
         }
     ],
+    "reservation-replies.mark-shadow-compared": [
+        {
+            "name": "reply",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "restaurants.send-mode.killswitch": [
         {
             "name": "restaurant",

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,10 @@ Route::post('reservation-replies/{reply}/cancel-auto-send', [ReservationReplyCon
     ->middleware(['auth', 'verified', 'can:cancelAutoSend,reply'])
     ->name('reservation-replies.cancel-auto-send');
 
+Route::post('reservation-replies/{reply}/mark-shadow-compared', [ReservationReplyController::class, 'markShadowCompared'])
+    ->middleware(['auth', 'verified', 'can:markShadowCompared,reply'])
+    ->name('reservation-replies.mark-shadow-compared');
+
 Route::post('restaurants/{restaurant}/send-mode/killswitch', SendModeKillswitchController::class)
     ->middleware(['auth', 'verified', 'can:manageSendMode,restaurant'])
     ->name('restaurants.send-mode.killswitch');

--- a/tests/Feature/AutoSend/ShadowComparedTest.php
+++ b/tests/Feature/AutoSend/ShadowComparedTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\SendMode;
+use App\Enums\UserRole;
+use App\Jobs\SendReservationReplyJob;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class ShadowComparedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function shadowReplySetup(): array
+    {
+        $restaurant = Restaurant::factory()->create(['send_mode' => SendMode::Shadow]);
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Shadow,
+            'send_mode_at_creation' => SendMode::Shadow,
+            'body' => 'Schatten-Vorschlag.',
+            'shadow_compared_at' => null,
+            'shadow_was_modified' => false,
+        ]);
+
+        $owner = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Owner,
+        ]);
+
+        return [$owner, $reply];
+    }
+
+    public function test_it_marks_shadow_compared_on_first_call(): void
+    {
+        Carbon::setTestNow('2026-04-30 12:00:00');
+        [$owner, $reply] = $this->shadowReplySetup();
+
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.mark-shadow-compared', $reply))
+            ->assertRedirect();
+
+        $reply->refresh();
+        $this->assertNotNull($reply->shadow_compared_at);
+        $this->assertSame('2026-04-30 12:00:00', $reply->shadow_compared_at->toDateTimeString());
+    }
+
+    public function test_it_does_not_overwrite_an_existing_shadow_compared_timestamp(): void
+    {
+        Carbon::setTestNow('2026-04-30 12:00:00');
+        [$owner, $reply] = $this->shadowReplySetup();
+        $reply->forceFill(['shadow_compared_at' => Carbon::now()->subHour()])->save();
+        $original = $reply->fresh()->shadow_compared_at;
+
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.mark-shadow-compared', $reply))
+            ->assertRedirect();
+
+        $this->assertEquals($original, $reply->fresh()->shadow_compared_at);
+    }
+
+    public function test_it_no_ops_when_reply_is_no_longer_in_shadow_state(): void
+    {
+        [$owner, $reply] = $this->shadowReplySetup();
+        $reply->forceFill(['status' => ReservationReplyStatus::Approved])->save();
+
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.mark-shadow-compared', $reply))
+            ->assertRedirect();
+
+        $this->assertNull($reply->fresh()->shadow_compared_at);
+    }
+
+    public function test_cross_tenant_user_cannot_mark_shadow_compared(): void
+    {
+        [$_, $reply] = $this->shadowReplySetup();
+        $intruder = User::factory()->create([
+            'restaurant_id' => Restaurant::factory()->create()->id,
+            'role' => UserRole::Owner,
+        ]);
+
+        // The global RestaurantScope hides the reply from a foreign
+        // tenant before the policy even runs — route-model-binding
+        // returns 404, which is what the rest of the codebase
+        // (cancel-auto-send tests) also expects.
+        $this->actingAs($intruder)
+            ->post(route('reservation-replies.mark-shadow-compared', $reply))
+            ->assertNotFound();
+
+        $this->assertNull($reply->fresh()->shadow_compared_at);
+    }
+
+    public function test_shadow_promote_via_approve_records_unmodified_takeover(): void
+    {
+        Queue::fake();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+        [$owner, $reply] = $this->shadowReplySetup();
+
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.approve', $reply))
+            ->assertRedirect();
+
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::Approved, $reply->status);
+        $this->assertFalse($reply->shadow_was_modified);
+        $this->assertNotNull($reply->shadow_compared_at);
+
+        Queue::assertPushed(SendReservationReplyJob::class);
+    }
+
+    public function test_shadow_promote_via_approve_records_a_modified_takeover(): void
+    {
+        Queue::fake();
+        [$owner, $reply] = $this->shadowReplySetup();
+
+        $this->actingAs($owner)
+            ->post(route('reservation-replies.approve', $reply), [
+                'body' => 'Operator-überarbeitete Antwort.',
+            ])
+            ->assertRedirect();
+
+        $reply->refresh();
+        $this->assertSame(ReservationReplyStatus::Approved, $reply->status);
+        $this->assertTrue($reply->shadow_was_modified);
+        $this->assertSame('Operator-überarbeitete Antwort.', $reply->body);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the deferred drawer-side pieces of #221 (PRD-007 detail-drawer extension):

**Backend**
- \`ReservationReplyController->approve()\` promotes \`shadow\` → \`approved\` and stamps \`shadow_was_modified\` based on a trimmed-body comparison so PRD-008's takeover-rate sees the operator's verdict.  Back-fills \`shadow_compared_at\` if the side-effect endpoint hasn't already set it.
- New \`markShadowCompared\` action + route (\`reservation-replies/{reply}/mark-shadow-compared\`) + policy.  Idempotent: writes the timestamp once on the first drawer-open for a shadow reply, no-ops on subsequent calls / non-shadow replies / cross-tenant calls.
- \`ReservationRequestDetailResource\` now exposes \`auto_send_scheduled_for\`, \`shadow_compared_at\`, \`send_mode_at_creation\`, plus the extended reply-status enum (\`shadow\`, \`scheduled_auto_send\`, \`cancelled_auto\`).

**Frontend**
- \`ReservationReplyStatus\` / \`ReservationReplySummary\` in \`types/\` pick up the new states + fields; new exported \`SendMode\` type.
- Drawer shadow banner: yellow surface, hint text (with optional \`would have been sent at …\`), CTA to promote-via-the-existing-approve flow.  Shadow body becomes editable so the operator can rewrite before promoting; the diff panel + approve-button copy adapt to the \"manual senden\" wording.
- Drawer scheduled-auto-send banner: orange surface, live \`useCountdown\` (already shipped in #273) bound to \`auto_send_scheduled_for\`, plus a cancel button wired to the existing \`cancel-auto-send\` endpoint.
- First drawer-open for a shadow reply fires a single \`mark-shadow-compared\` POST; a per-id Set guards against double-submission across polling round-trips.
- Ziggy types regenerated.

## Why

Issue #221 explicitly carved out these drawer pieces as the remaining follow-up after #273 shipped the dashboard banner + countdown composable.  The shadow-comparison + cancel-window UX is what unlocks the operator's path to \"trust the auto-send mode\" in PRD-007.

Closes #221

## Test plan

- [x] \`php artisan test --filter=ShadowComparedTest\` (6 passed, 18 assertions)
- [x] \`php artisan test --filter=ReservationReplyFlowTest\` (8 passed — the V1.0 draft path is unchanged)
- [x] \`php artisan test\` (719 passed)
- [x] \`./vendor/bin/pint --test\`
- [x] \`npm run lint\` + \`npm run format:check\`
- [x] \`npm run test\` (56 passed; existing useCountdown vitest suite still green)
- [x] \`php artisan ziggy:generate --types-only resources/js/ziggy.d.ts\`