### PR TITLE
Add export_audits table + ExportAudit model (#234)

### DIFF
--- a/app/Enums/ExportFormat.php
+++ b/app/Enums/ExportFormat.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Output format for the PRD-009 reservation export pipeline.
+ *
+ * `Csv` is the default — small, machine-friendly, opens cleanly in
+ * Excel with the UTF-8 BOM the generator writes. `Pdf` is the
+ * presentation copy (printed daily-list, stapled to a clipboard
+ * shift hand-off). Sibling issue #235 layers the validated form
+ * request on top; sibling issue #237/#238 add the actual generators.
+ */
+enum ExportFormat: string
+{
+    case Csv = 'csv';
+    case Pdf = 'pdf';
+}

--- a/app/Models/ExportAudit.php
+++ b/app/Models/ExportAudit.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\ExportFormat;
+use Illuminate\Database\Eloquent\Casts\AsArrayObject;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Audit row for every reservation export the operator opens
+ * (PRD-009 § Audit & Cleanup). Append-only — no `updated_at` —
+ * because each export is a single point-in-time event.
+ *
+ * `storage_path` carries the disk path of the generated artefact
+ * for the async path; the sync path (≤ 100 records, streamed
+ * straight to the operator) leaves it null. The `PurgeExpiredExportsJob`
+ * (sibling issue #241) deletes the file after `expires_at` and
+ * nulls `storage_path` while keeping the audit row intact.
+ *
+ * `downloaded_at` is stamped the first time the operator follows
+ * the signed download URL. The audit therefore answers both
+ * "did this export ever happen?" and "did the operator actually
+ * fetch it?".
+ *
+ * `filter_snapshot` is the exact dashboard filter set that was
+ * frozen at export time, so reproducing the file (or honouring a
+ * GDPR access request after the artefact is gone) doesn't depend
+ * on the operator remembering which filters they had open.
+ */
+class ExportAudit extends Model
+{
+    public $timestamps = false;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'restaurant_id',
+        'user_id',
+        'format',
+        'filter_snapshot',
+        'record_count',
+        'storage_path',
+        'downloaded_at',
+        'expires_at',
+        'created_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'format' => ExportFormat::class,
+            'filter_snapshot' => AsArrayObject::class,
+            'record_count' => 'integer',
+            'downloaded_at' => 'datetime',
+            'expires_at' => 'datetime',
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Single entry point the export pipeline uses to start a new
+     * audit row. The user's restaurant supplies the tenant (one
+     * user → one restaurant in V1.0); call sites don't have to
+     * repeat that resolution. The async-path ExportReservationsJob
+     * (sibling issue #239) updates `storage_path` and `expires_at`
+     * once the artefact lands on disk.
+     *
+     * @param  array<string, mixed>  $filters
+     */
+    public static function open(User $user, ExportFormat $format, array $filters, int $count): self
+    {
+        return self::create([
+            'restaurant_id' => $user->restaurant_id,
+            'user_id' => $user->id,
+            'format' => $format->value,
+            'filter_snapshot' => $filters,
+            'record_count' => $count,
+            'storage_path' => null,
+            'downloaded_at' => null,
+            'expires_at' => null,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Models/ExportAudit.php
+++ b/app/Models/ExportAudit.php
@@ -8,6 +8,7 @@ use App\Enums\ExportFormat;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use RuntimeException;
 
 /**
  * Audit row for every reservation export the operator opens
@@ -92,6 +93,13 @@ class ExportAudit extends Model
      */
     public static function open(User $user, ExportFormat $format, array $filters, int $count): self
     {
+        if ($user->restaurant_id === null) {
+            throw new RuntimeException(
+                'ExportAudit::open requires a user with a resolved restaurant_id; '
+                .'export pipelines must not silently fall through to a null tenant.'
+            );
+        }
+
         return self::create([
             'restaurant_id' => $user->restaurant_id,
             'user_id' => $user->id,

--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -82,6 +82,19 @@ class Restaurant extends Model
     }
 
     /**
+     * Audit trail of CSV/PDF exports run for this restaurant
+     * (PRD-009). Append-only and tenant-scoped; cleanup of the
+     * generated files is handled by `PurgeExpiredExportsJob`,
+     * the audit rows themselves are retained.
+     *
+     * @return HasMany<ExportAudit, $this>
+     */
+    public function exportAudits(): HasMany
+    {
+        return $this->hasMany(ExportAudit::class);
+    }
+
+    /**
      * Free seats at a given point in time, or null if the restaurant is
      * closed then.
      *

--- a/database/migrations/2026_04_30_000005_create_export_audits_table.php
+++ b/database/migrations/2026_04_30_000005_create_export_audits_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('export_audits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->foreignId('user_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('format');
+            $table->json('filter_snapshot');
+            $table->unsignedInteger('record_count');
+            // `storage_path` is null for sync exports (≤100 records,
+            // streamed straight to the operator) and for async ones
+            // after the cleanup job has expired the file. The audit
+            // row itself is retained for reproducibility / GDPR.
+            $table->string('storage_path')->nullable();
+            $table->dateTime('downloaded_at')->nullable();
+            // 24-hour shelf life for async-path artefacts; null for
+            // the sync path that never persists a file.
+            $table->dateTime('expires_at')->nullable();
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['restaurant_id', 'created_at']);
+            $table->index('expires_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('export_audits');
+    }
+};

--- a/database/migrations/2026_04_30_000005_create_export_audits_table.php
+++ b/database/migrations/2026_04_30_000005_create_export_audits_table.php
@@ -13,9 +13,14 @@ return new class extends Migration
             $table->foreignId('restaurant_id')
                 ->constrained()
                 ->cascadeOnDelete();
+            // The audit row outlives the user — GDPR reproducibility
+            // and "who exported this" reporting must survive a staff
+            // member leaving. Same convention as
+            // `auto_send_audits.triggered_by_user_id` (PRD-007).
             $table->foreignId('user_id')
+                ->nullable()
                 ->constrained()
-                ->cascadeOnDelete();
+                ->nullOnDelete();
             $table->string('format');
             $table->json('filter_snapshot');
             $table->unsignedInteger('record_count');

--- a/tests/Feature/Models/ExportAuditTest.php
+++ b/tests/Feature/Models/ExportAuditTest.php
@@ -105,6 +105,32 @@ class ExportAuditTest extends TestCase
         $this->assertSame($filters, $audit->filter_snapshot->getArrayCopy());
     }
 
+    public function test_open_throws_when_the_user_has_no_restaurant(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $this->expectException(\RuntimeException::class);
+
+        ExportAudit::open($user, ExportFormat::Csv, [], 1);
+    }
+
+    public function test_audit_is_retained_when_the_acting_user_is_deleted(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, ['x' => 1], 5);
+
+        $user->delete();
+        $audit->refresh();
+
+        // GDPR reproducibility: the audit row outlives the user.
+        // user_id is nulled out via the FK's `nullOnDelete`, the
+        // restaurant + payload stay intact.
+        $this->assertNull($audit->user_id);
+        $this->assertSame($restaurant->id, $audit->restaurant_id);
+        $this->assertSame(['x' => 1], $audit->filter_snapshot->getArrayCopy());
+    }
+
     public function test_storage_path_and_expires_at_can_be_set_after_async_run_completes(): void
     {
         $user = User::factory()->forRestaurant(Restaurant::factory()->create())->create();

--- a/tests/Feature/Models/ExportAuditTest.php
+++ b/tests/Feature/Models/ExportAuditTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Models;
+
+use App\Enums\ExportFormat;
+use App\Models\ExportAudit;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class ExportAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    public function test_open_writes_an_audit_row_with_the_user_context(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $audit = ExportAudit::open(
+            $user,
+            ExportFormat::Csv,
+            ['status' => ['confirmed', 'replied']],
+            42,
+        );
+
+        $this->assertSame($restaurant->id, $audit->restaurant_id);
+        $this->assertSame($user->id, $audit->user_id);
+        $this->assertSame(ExportFormat::Csv, $audit->format);
+        $this->assertSame(42, $audit->record_count);
+        $this->assertNull($audit->storage_path);
+        $this->assertNull($audit->downloaded_at);
+        $this->assertNull($audit->expires_at);
+        $this->assertSame(
+            ['status' => ['confirmed', 'replied']],
+            $audit->filter_snapshot->getArrayCopy(),
+        );
+        $this->assertSame('2026-04-30 12:00:00', $audit->created_at->toDateTimeString());
+    }
+
+    public function test_open_supports_pdf_format(): void
+    {
+        $user = User::factory()->forRestaurant(Restaurant::factory()->create())->create();
+
+        $audit = ExportAudit::open($user, ExportFormat::Pdf, [], 0);
+
+        $this->assertSame(ExportFormat::Pdf, $audit->format);
+        $this->assertSame(0, $audit->record_count);
+        $this->assertSame([], $audit->filter_snapshot->getArrayCopy());
+    }
+
+    public function test_restaurant_relation_returns_owning_tenant(): void
+    {
+        $restaurant = Restaurant::factory()->create(['name' => 'Trattoria Trabant']);
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 1);
+
+        $this->assertSame($restaurant->id, $audit->restaurant->id);
+        $this->assertSame('Trattoria Trabant', $audit->restaurant->name);
+    }
+
+    public function test_restaurant_has_many_export_audits(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $user = User::factory()->forRestaurant($restaurant)->create();
+
+        ExportAudit::open($user, ExportFormat::Csv, [], 10);
+        ExportAudit::open($user, ExportFormat::Pdf, [], 20);
+
+        $this->assertCount(2, $restaurant->exportAudits);
+    }
+
+    public function test_filter_snapshot_round_trips_complex_arrays(): void
+    {
+        $user = User::factory()->forRestaurant(Restaurant::factory()->create())->create();
+
+        $filters = [
+            'status' => ['new', 'in_review'],
+            'source' => ['email'],
+            'from' => '2026-04-01',
+            'to' => '2026-04-30',
+            'q' => 'Geburtstag',
+        ];
+
+        $audit = ExportAudit::open($user, ExportFormat::Csv, $filters, 7);
+        $audit->refresh();
+
+        $this->assertSame($filters, $audit->filter_snapshot->getArrayCopy());
+    }
+
+    public function test_storage_path_and_expires_at_can_be_set_after_async_run_completes(): void
+    {
+        $user = User::factory()->forRestaurant(Restaurant::factory()->create())->create();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 200);
+
+        $audit->forceFill([
+            'storage_path' => 'exports/2026-04/200.csv',
+            'expires_at' => Carbon::now()->addDay(),
+        ])->save();
+        $audit->refresh();
+
+        $this->assertSame('exports/2026-04/200.csv', $audit->storage_path);
+        $this->assertSame(
+            '2026-05-01 12:00:00',
+            $audit->expires_at?->toDateTimeString(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- New \`export_audits\` migration (PRD-009 § Audit & Cleanup) with the columns the audit/cleanup pipeline needs: \`restaurant_id\`, \`user_id\`, \`format\`, \`filter_snapshot\` (json), \`record_count\`, nullable \`storage_path\` / \`downloaded_at\` / \`expires_at\`, \`created_at\` (timestamp default CURRENT_TIMESTAMP). Indexes on \`(restaurant_id, created_at)\` and \`expires_at\`.
- \`App\\Models\\ExportAudit\` is append-only (\`\$timestamps = false\`), casts \`format\` to the new \`App\\Enums\\ExportFormat\` enum, \`filter_snapshot\` to \`AsArrayObject\`, plus the usual datetime/integer casts. \`open(User, ExportFormat, array, int): self\` is the single helper the export pipeline goes through; it resolves \`restaurant_id\` from the user (one user → one restaurant in V1.0).
- New \`App\\Enums\\ExportFormat\` enum with \`Csv\` / \`Pdf\` cases (minimum needed for #234 to compile; sibling issue #235 builds the validated request on top).
- \`Restaurant\` gains a \`HasMany exportAudits\` relation.

## Why

First step of the PRD-009 chain — without an audit row no later sibling (sync/async generators, signed download URL, GDPR purge) has a place to record state.

Closes #234

## Test plan

- [x] \`php artisan test --filter=ExportAuditTest\` (6 passed, 18 assertions)
- [x] \`php artisan test\` (725 passed)
- [x] \`./vendor/bin/pint --test\`
- [x] \`php artisan migrate --pretend\` confirms the schema