### PR TITLE
ExportDispatcher: sync/async path + audit row (#236)

### DIFF
--- a/app/Jobs/ExportReservationsJob.php
+++ b/app/Jobs/ExportReservationsJob.php
@@ -35,6 +35,15 @@ class ExportReservationsJob implements ShouldQueue
     use SerializesModels;
 
     /**
+     * `restaurantId` is carried explicitly so the worker can
+     * re-apply tenant isolation: the queue runs without an
+     * authenticated user, which makes `RestaurantScope`
+     * short-circuit and the otherwise-implicit `where
+     * restaurant_id = ?` predicate disappear. The #239 handler
+     * must therefore call `withoutGlobalScope(RestaurantScope::class)`
+     * + `where('restaurant_id', $this->restaurantId)` (same
+     * pattern the analytics aggregator uses).
+     *
      * @param  array<string, mixed>  $filters
      */
     public function __construct(
@@ -42,6 +51,7 @@ class ExportReservationsJob implements ShouldQueue
         public readonly ExportFormat $format,
         public readonly array $filters,
         public readonly int $userId,
+        public readonly int $restaurantId,
     ) {}
 
     public function handle(): void

--- a/app/Jobs/ExportReservationsJob.php
+++ b/app/Jobs/ExportReservationsJob.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Enums\ExportFormat;
+use App\Models\ExportAudit;
+use App\Services\Exports\ExportDispatcher;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Async export pipeline (PRD-009 § Controller + ExportDispatcher).
+ *
+ * Queued by {@see ExportDispatcher} when
+ * the filtered record count exceeds the sync threshold (100).
+ * The job runs the heavy CSV / PDF generation, persists the
+ * artefact to the storage disk, stamps `storage_path` +
+ * `expires_at` on the supplied audit row, and notifies the
+ * operator with a signed download URL via `ExportReadyMail`.
+ *
+ * Issue #236 wires the dispatch path; the actual `handle()`
+ * implementation lands in sibling issue #239 along with the
+ * mail + signed-URL controller.
+ */
+class ExportReservationsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    public function __construct(
+        public readonly int $exportAuditId,
+        public readonly ExportFormat $format,
+        public readonly array $filters,
+        public readonly int $userId,
+    ) {}
+
+    public function handle(): void
+    {
+        // Implementation lands in #239 (job + mail + signed URL).
+        // The dispatch path of #236 only needs the constructor +
+        // interface; making `handle()` a no-op here keeps the job
+        // dispatchable end-to-end without producing an artefact
+        // until the next sibling issue fills it in.
+        ExportAudit::query()
+            ->whereKey($this->exportAuditId)
+            ->exists();
+    }
+}

--- a/app/Services/Exports/Contracts/ExportGenerator.php
+++ b/app/Services/Exports/Contracts/ExportGenerator.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Exports\Contracts;
+
+use App\Enums\ExportFormat;
+use App\Models\Restaurant;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Concrete generators (CSV via league/csv in #237, PDF via
+ * dompdf in #238) implement this contract. The dispatcher
+ * delegates to it for the sync (≤ 100 records) path; the async
+ * path (#239) writes to disk via the same shape but wrapped in
+ * a job. Keeping the interface tight means the dispatcher and
+ * the job don't have to know which format they're producing.
+ */
+interface ExportGenerator
+{
+    /**
+     * Stream the export back to the operator's browser. The
+     * filtered query already runs through `RestaurantScope`, so
+     * the generator never has to enforce tenant isolation.
+     *
+     * @param  array<string, mixed>  $filters  Validated filter snapshot.
+     */
+    public function generateSync(
+        ExportFormat $format,
+        Restaurant $restaurant,
+        array $filters,
+    ): StreamedResponse;
+}

--- a/app/Services/Exports/ExportDispatcher.php
+++ b/app/Services/Exports/ExportDispatcher.php
@@ -27,10 +27,17 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  *     {@see ExportReservationsJob} which (per #239) renders the
  *     artefact on disk and emails a signed download URL.
  *
- * Tenant isolation is implicit: the filtered query runs through
- * the global `RestaurantScope`, so the count and the downstream
- * generator both see only the user's own restaurant. The audit
- * row's `restaurant_id` is resolved from the user.
+ * Tenant isolation:
+ *   - **Sync path**: implicit. The count + generator run with the
+ *     authenticated user, so the global `RestaurantScope` applies
+ *     the `where restaurant_id = ?` predicate.
+ *   - **Async path**: must be explicit. The queue worker has no
+ *     authenticated user, so `RestaurantScope` short-circuits;
+ *     the job carries `restaurantId` and re-applies the predicate
+ *     via `withoutGlobalScope(RestaurantScope::class)` (same pattern
+ *     the analytics aggregator uses). #239's handler relies on it.
+ *
+ * The audit row's `restaurant_id` is resolved from the user.
  */
 final readonly class ExportDispatcher
 {
@@ -68,6 +75,7 @@ final readonly class ExportDispatcher
             $format,
             $filters,
             $user->id,
+            (int) $user->restaurant_id,
         );
 
         return back()->with(

--- a/app/Services/Exports/ExportDispatcher.php
+++ b/app/Services/Exports/ExportDispatcher.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Exports;
+
+use App\Enums\ExportFormat;
+use App\Http\Requests\Exports\ExportRequest;
+use App\Jobs\ExportReservationsJob;
+use App\Models\ExportAudit;
+use App\Models\ReservationRequest;
+use App\Models\User;
+use App\Services\Exports\Contracts\ExportGenerator;
+use Illuminate\Http\RedirectResponse;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Decision layer for the PRD-009 export pipeline.
+ *
+ * Counts the filtered set once, opens an `ExportAudit` row, and
+ * routes the work to either:
+ *
+ *   - the **sync** generator (≤ 100 records) — streams the
+ *     artefact back to the operator's browser, no disk write,
+ *     no email roundtrip; or
+ *   - the **async** job (> 100 records) — queues
+ *     {@see ExportReservationsJob} which (per #239) renders the
+ *     artefact on disk and emails a signed download URL.
+ *
+ * Tenant isolation is implicit: the filtered query runs through
+ * the global `RestaurantScope`, so the count and the downstream
+ * generator both see only the user's own restaurant. The audit
+ * row's `restaurant_id` is resolved from the user.
+ */
+final readonly class ExportDispatcher
+{
+    /**
+     * Threshold below which the export is streamed synchronously.
+     * Above this, the operator gets a flash message and an email.
+     */
+    public const int SYNC_THRESHOLD = 100;
+
+    public function __construct(
+        private ExportGenerator $generator,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $filters  Validated filter snapshot from {@see ExportRequest}.
+     */
+    public function dispatch(
+        ExportFormat $format,
+        array $filters,
+        User $user,
+    ): StreamedResponse|RedirectResponse {
+        $count = ReservationRequest::query()->filter($filters)->count();
+        $audit = ExportAudit::open($user, $format, $filters, $count);
+
+        if ($count <= self::SYNC_THRESHOLD) {
+            return $this->generator->generateSync(
+                $format,
+                $user->restaurant,
+                $filters,
+            );
+        }
+
+        ExportReservationsJob::dispatch(
+            $audit->id,
+            $format,
+            $filters,
+            $user->id,
+        );
+
+        return back()->with(
+            'flash.export',
+            sprintf(
+                'Export läuft im Hintergrund — du bekommst gleich eine E-Mail mit dem %s-Download (%d Einträge).',
+                $format->label(),
+                $count,
+            ),
+        );
+    }
+}

--- a/tests/Unit/Exports/ExportDispatcherTest.php
+++ b/tests/Unit/Exports/ExportDispatcherTest.php
@@ -95,6 +95,7 @@ class ExportDispatcherTest extends TestCase
             ExportReservationsJob::class,
             fn (ExportReservationsJob $job): bool => $job->format === ExportFormat::Pdf
                 && $job->userId === $user->id
+                && $job->restaurantId === $user->restaurant_id
                 && $job->filters === [],
         );
 

--- a/tests/Unit/Exports/ExportDispatcherTest.php
+++ b/tests/Unit/Exports/ExportDispatcherTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Exports;
+
+use App\Enums\ExportFormat;
+use App\Jobs\ExportReservationsJob;
+use App\Models\ExportAudit;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Services\Exports\Contracts\ExportGenerator;
+use App\Services\Exports\ExportDispatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Mockery;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\TestCase;
+
+class ExportDispatcherTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Mockery::close();
+        parent::tearDown();
+    }
+
+    private function userWithRestaurant(): User
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        return User::factory()->forRestaurant($restaurant)->create();
+    }
+
+    private function seedRequests(User $user, int $count): void
+    {
+        ReservationRequest::factory()
+            ->forRestaurant($user->restaurant)
+            ->count($count)
+            ->create();
+    }
+
+    public function test_it_picks_sync_path_under_threshold(): void
+    {
+        $user = $this->userWithRestaurant();
+        $this->actingAs($user);
+
+        $this->seedRequests($user, 50);
+
+        $generator = Mockery::mock(ExportGenerator::class);
+        $generator->shouldReceive('generateSync')
+            ->once()
+            ->with(
+                ExportFormat::Csv,
+                Mockery::on(fn ($r) => $r instanceof Restaurant && $r->id === $user->restaurant_id),
+                ['status' => ['confirmed']],
+            )
+            ->andReturn(new StreamedResponse);
+
+        Queue::fake();
+
+        $dispatcher = new ExportDispatcher($generator);
+        $response = $dispatcher->dispatch(
+            ExportFormat::Csv,
+            ['status' => ['confirmed']],
+            $user,
+        );
+
+        $this->assertInstanceOf(StreamedResponse::class, $response);
+        Queue::assertNothingPushed();
+    }
+
+    public function test_it_picks_async_path_over_threshold(): void
+    {
+        Queue::fake();
+        $user = $this->userWithRestaurant();
+        $this->actingAs($user);
+
+        $this->seedRequests($user, ExportDispatcher::SYNC_THRESHOLD + 1);
+
+        $generator = Mockery::mock(ExportGenerator::class);
+        $generator->shouldNotReceive('generateSync');
+
+        $dispatcher = new ExportDispatcher($generator);
+        $response = $dispatcher->dispatch(
+            ExportFormat::Pdf,
+            [],
+            $user,
+        );
+
+        Queue::assertPushed(
+            ExportReservationsJob::class,
+            fn (ExportReservationsJob $job): bool => $job->format === ExportFormat::Pdf
+                && $job->userId === $user->id
+                && $job->filters === [],
+        );
+
+        $this->assertNotInstanceOf(StreamedResponse::class, $response);
+    }
+
+    public function test_it_writes_audit_row_in_sync_path(): void
+    {
+        $user = $this->userWithRestaurant();
+        $this->actingAs($user);
+        $this->seedRequests($user, 5);
+
+        $generator = Mockery::mock(ExportGenerator::class);
+        $generator->shouldReceive('generateSync')->andReturn(new StreamedResponse);
+
+        // Use the `web_form` source to match the factory default,
+        // so the filter actually returns the 5 seeded rows and the
+        // audit's `record_count` reflects that.
+        $dispatcher = new ExportDispatcher($generator);
+        $dispatcher->dispatch(ExportFormat::Csv, ['source' => ['web_form']], $user);
+
+        $this->assertDatabaseHas('export_audits', [
+            'restaurant_id' => $user->restaurant_id,
+            'user_id' => $user->id,
+            'format' => 'csv',
+            'record_count' => 5,
+        ]);
+    }
+
+    public function test_it_writes_audit_row_in_async_path(): void
+    {
+        Queue::fake();
+        $user = $this->userWithRestaurant();
+        $this->actingAs($user);
+        $this->seedRequests($user, 250);
+
+        $generator = Mockery::mock(ExportGenerator::class);
+
+        $dispatcher = new ExportDispatcher($generator);
+        $dispatcher->dispatch(ExportFormat::Pdf, ['status' => ['new']], $user);
+
+        $this->assertDatabaseHas('export_audits', [
+            'restaurant_id' => $user->restaurant_id,
+            'user_id' => $user->id,
+            'format' => 'pdf',
+            'record_count' => 250,
+        ]);
+
+        $audit = ExportAudit::query()->where('user_id', $user->id)->sole();
+        Queue::assertPushed(
+            ExportReservationsJob::class,
+            fn (ExportReservationsJob $job): bool => $job->exportAuditId === $audit->id,
+        );
+    }
+
+    public function test_threshold_boundary_exactly_100_uses_sync_path(): void
+    {
+        Queue::fake();
+        $user = $this->userWithRestaurant();
+        $this->actingAs($user);
+        $this->seedRequests($user, ExportDispatcher::SYNC_THRESHOLD);
+
+        $generator = Mockery::mock(ExportGenerator::class);
+        $generator->shouldReceive('generateSync')->once()->andReturn(new StreamedResponse);
+
+        $dispatcher = new ExportDispatcher($generator);
+        $dispatcher->dispatch(ExportFormat::Csv, [], $user);
+
+        Queue::assertNothingPushed();
+    }
+}


### PR DESCRIPTION
## Summary

- New \`App\\Services\\Exports\\Contracts\\ExportGenerator\` interface — the sync streaming surface concrete generators (CSV in #237, PDF in #238) implement.
- \`App\\Jobs\\ExportReservationsJob\` (queueable) carries the audit id, format, filters, and user id so the async path can resume the work in a worker. \`handle()\` is intentionally a no-op until #239 lands the real disk-write + \`ExportReadyMail\` + signed-URL controller — #236 only needs the job class to exist for \`::dispatch()\` to work.
- \`ExportDispatcher::dispatch(format, filters, user)\`:
  - counts \`ReservationRequest::query()->filter(\$filters)->count()\` once (multi-tenant via the existing global \`RestaurantScope\`)
  - opens an \`ExportAudit\` row before doing any work
  - \`<= SYNC_THRESHOLD\` (100) records → \`ExportGenerator::generateSync\`, returns a \`StreamedResponse\`
  - \`> SYNC_THRESHOLD\` records → \`ExportReservationsJob::dispatch\`, returns \`back()->with('flash.export', …)\` so the operator gets a UI breadcrumb that the email is on its way.

## Why

Issue #236 — the decision layer between the validated request (#235) and the eventual generators (#237, #238). Closes #236.

## Test plan

- [x] \`php artisan test --filter=ExportDispatcherTest\` (5 passed, 8 assertions)
- [x] \`php artisan test\` (746 passed)
- [x] \`./vendor/bin/pint --test\`

Test coverage: sync path picked under threshold, async path picked over threshold, audit row written on both paths, boundary case where \`count = SYNC_THRESHOLD\` deliberately uses sync.