### PR TITLE
CsvExportGenerator with Excel-DE compatibility (#237)

### DIFF
--- a/app/Services/Exports/CsvExportGenerator.php
+++ b/app/Services/Exports/CsvExportGenerator.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Exports;
+
+use App\Enums\ExportFormat;
+use App\Enums\ReservationReplyStatus;
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Exports\Contracts\ExportGenerator;
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
+use League\Csv\Writer;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * CSV export generator for the PRD-009 pipeline.
+ *
+ * Excel-DE compatible: UTF-8 with BOM (so Excel doesn't mojibake
+ * the German umlauts) plus the `;` separator (so Excel-DE parses
+ * the columns correctly without an import wizard). German enum
+ * labels per the PRD column schema.
+ *
+ * Sync path streams the file straight back to the operator's
+ * browser; the async path (sibling issue #239) writes to disk
+ * via `writeToDisk(...)` and notifies the operator with a
+ * signed URL.
+ */
+final class CsvExportGenerator implements ExportGenerator
+{
+    private const string EXCEL_BOM = "\xEF\xBB\xBF";
+
+    private const string DELIMITER = ';';
+
+    /**
+     * @var list<string>
+     */
+    private const array HEADER_ROW = [
+        'ID',
+        'Eingegangen',
+        'Status',
+        'Quelle',
+        'Wunschdatum',
+        'Personen',
+        'Name',
+        'E-Mail',
+        'Telefon',
+        'Manuelle Prüfung',
+        'Letzte Antwort',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const array STATUS_LABELS = [
+        'new' => 'Neu',
+        'in_review' => 'In Bearbeitung',
+        'replied' => 'Beantwortet',
+        'confirmed' => 'Bestätigt',
+        'declined' => 'Abgelehnt',
+        'cancelled' => 'Storniert',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const array SOURCE_LABELS = [
+        'web_form' => 'Webformular',
+        'email' => 'E-Mail',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    private const array REPLY_STATUS_LABELS = [
+        'draft' => 'Entwurf',
+        'approved' => 'Freigegeben',
+        'sent' => 'Versendet',
+        'failed' => 'Versand fehlgeschlagen',
+        'shadow' => 'Schatten-Modus',
+        'scheduled_auto_send' => 'Auto-Versand geplant',
+        'cancelled_auto' => 'Auto-Versand abgebrochen',
+    ];
+
+    public function generateSync(
+        ExportFormat $format,
+        Restaurant $restaurant,
+        array $filters,
+    ): StreamedResponse {
+        if ($format !== ExportFormat::Csv) {
+            throw new InvalidArgumentException(sprintf(
+                'CsvExportGenerator can only emit CSV; got %s.',
+                $format->value,
+            ));
+        }
+
+        $payload = $this->renderCsv($restaurant, $filters);
+        $filename = $this->filename($restaurant);
+
+        return new StreamedResponse(
+            function () use ($payload): void {
+                echo $payload;
+            },
+            200,
+            [
+                'Content-Type' => $format->mimeType(),
+                'Content-Disposition' => 'attachment; filename="'.$filename.'"',
+            ],
+        );
+    }
+
+    /**
+     * Async-path entry point used by `ExportReservationsJob`
+     * (#239): renders the CSV string so the job can persist it
+     * to its chosen disk path. Returning the raw payload keeps
+     * the disk concern in the job — easier to unit-test the
+     * generator without spinning up a Storage fake.
+     *
+     * @param  array<string, mixed>  $filters
+     */
+    public function renderToString(Restaurant $restaurant, array $filters): string
+    {
+        return $this->renderCsv($restaurant, $filters);
+    }
+
+    /**
+     * @param  array<string, mixed>  $filters
+     */
+    private function renderCsv(Restaurant $restaurant, array $filters): string
+    {
+        $writer = Writer::createFromString();
+        $writer->setDelimiter(self::DELIMITER);
+        $writer->insertOne(self::HEADER_ROW);
+
+        $timezone = $restaurant->timezone ?? config('app.timezone');
+
+        ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->where('restaurant_id', $restaurant->id)
+            ->filter($filters)
+            ->with(['latestReply'])
+            ->orderByDesc('created_at')
+            ->chunk(500, function ($chunk) use ($writer, $timezone): void {
+                foreach ($chunk as $request) {
+                    $writer->insertOne($this->row($request, $timezone));
+                }
+            });
+
+        return self::EXCEL_BOM.$writer->toString();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function row(ReservationRequest $request, string $timezone): array
+    {
+        $status = $request->status instanceof ReservationStatus
+            ? $request->status->value
+            : (string) $request->status;
+        $source = $request->source instanceof ReservationSource
+            ? $request->source->value
+            : (string) $request->source;
+
+        $latestReplyLabel = '';
+        if ($request->relationLoaded('latestReply') && $request->latestReply !== null) {
+            $replyStatus = $request->latestReply->status;
+            $key = $replyStatus instanceof ReservationReplyStatus
+                ? $replyStatus->value
+                : (string) $replyStatus;
+            $latestReplyLabel = self::REPLY_STATUS_LABELS[$key] ?? $key;
+        }
+
+        return [
+            (string) $request->id,
+            $this->formatDate($request->created_at, $timezone),
+            self::STATUS_LABELS[$status] ?? $status,
+            self::SOURCE_LABELS[$source] ?? $source,
+            $this->formatDate($request->desired_at, $timezone),
+            (string) ($request->party_size ?? 0),
+            (string) ($request->guest_name ?? ''),
+            (string) ($request->guest_email ?? ''),
+            (string) ($request->guest_phone ?? ''),
+            $request->needs_manual_review ? 'Ja' : 'Nein',
+            $latestReplyLabel,
+        ];
+    }
+
+    private function formatDate(?Carbon $value, string $timezone): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        return $value->copy()->setTimezone($timezone)->format('Y-m-d H:i');
+    }
+
+    private function filename(Restaurant $restaurant): string
+    {
+        $slug = $restaurant->slug !== null && $restaurant->slug !== ''
+            ? $restaurant->slug
+            : 'export';
+
+        return sprintf(
+            'reservations-%s-%s.csv',
+            $slug,
+            Carbon::now($restaurant->timezone ?? config('app.timezone'))->format('Y-m-d_H-i'),
+        );
+    }
+}

--- a/app/Services/Exports/CsvExportGenerator.php
+++ b/app/Services/Exports/CsvExportGenerator.php
@@ -131,7 +131,12 @@ final class CsvExportGenerator implements ExportGenerator
      */
     private function renderCsv(Restaurant $restaurant, array $filters): string
     {
-        $writer = Writer::createFromString();
+        // `createFromString()` is deprecated since league/csv 9.27.
+        // The replacement `Writer::fromString()` is available in 9.28
+        // (the version we installed) and avoids the
+        // E_DEPRECATED notice that PHP 8.4+ would otherwise emit on
+        // every export.
+        $writer = Writer::fromString();
         $writer->setDelimiter(self::DELIMITER);
         $writer->insertOne(self::HEADER_ROW);
 
@@ -180,12 +185,41 @@ final class CsvExportGenerator implements ExportGenerator
             self::SOURCE_LABELS[$source] ?? $source,
             $this->formatDate($request->desired_at, $timezone),
             (string) ($request->party_size ?? 0),
-            (string) ($request->guest_name ?? ''),
-            (string) ($request->guest_email ?? ''),
-            (string) ($request->guest_phone ?? ''),
+            $this->sanitizeCell((string) ($request->guest_name ?? '')),
+            $this->sanitizeCell((string) ($request->guest_email ?? '')),
+            $this->sanitizeCell((string) ($request->guest_phone ?? '')),
             $request->needs_manual_review ? 'Ja' : 'Nein',
             $latestReplyLabel,
         ];
+    }
+
+    /**
+     * CSV-injection guard: Excel / LibreOffice / Numbers treat any
+     * cell that starts with `=`, `+`, `-` or `@` as a formula and
+     * will execute it on open. A guest who registers with a name
+     * like `=HYPERLINK("https://evil.example","Click")` would turn
+     * the operator's export into an attack surface. Prefixing the
+     * cell with a tab character is the OWASP-recommended fix:
+     * spreadsheets parse it as text instead of a formula, but the
+     * displayed content stays readable.
+     *
+     * Only applied to the three operator-untrusted columns
+     * (guest_name / guest_email / guest_phone). The other cells
+     * are derived from enums or DB-controlled values that the
+     * operator can't influence.
+     */
+    private function sanitizeCell(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        return str_starts_with($value, '=')
+            || str_starts_with($value, '+')
+            || str_starts_with($value, '-')
+            || str_starts_with($value, '@')
+            ? "\t".$value
+            : $value;
     }
 
     private function formatDate(?Carbon $value, string $timezone): string

--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
         "inertiajs/inertia-laravel": "^2.0",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
+        "league/csv": "^9.28",
         "openai-php/laravel": "^0.19.1",
         "tightenco/ziggy": "^2.4",
         "webklex/laravel-imap": "^6.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f9b3ee0b4aff9d2a4f38c95e43c8193",
+    "content-hash": "de5e052608a9af66a1b939be0ae50779",
     "packages": [
         {
             "name": "brick/math",
@@ -1722,6 +1722,97 @@
                 }
             ],
             "time": "2022-12-11T20:36:23+00:00"
+        },
+        {
+            "name": "league/csv",
+            "version": "9.28.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/csv.git",
+                "reference": "6582ace29ae09ba5b07049d40ea13eb19c8b5073"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/csv/zipball/6582ace29ae09ba5b07049d40ea13eb19c8b5073",
+                "reference": "6582ace29ae09ba5b07049d40ea13eb19c8b5073",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "php": "^8.1.2"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "ext-xdebug": "*",
+                "friendsofphp/php-cs-fixer": "^3.92.3",
+                "phpbench/phpbench": "^1.4.3",
+                "phpstan/phpstan": "^1.12.32",
+                "phpstan/phpstan-deprecation-rules": "^1.2.1",
+                "phpstan/phpstan-phpunit": "^1.4.2",
+                "phpstan/phpstan-strict-rules": "^1.6.2",
+                "phpunit/phpunit": "^10.5.16 || ^11.5.22 || ^12.5.4",
+                "symfony/var-dumper": "^6.4.8 || ^7.4.0 || ^8.0"
+            },
+            "suggest": {
+                "ext-dom": "Required to use the XMLConverter and the HTMLConverter classes",
+                "ext-iconv": "Needed to ease transcoding CSV using iconv stream filters",
+                "ext-mbstring": "Needed to ease transcoding CSV using mb stream filters",
+                "ext-mysqli": "Requiered to use the package with the MySQLi extension",
+                "ext-pdo": "Required to use the package with the PDO extension",
+                "ext-pgsql": "Requiered to use the package with the PgSQL extension",
+                "ext-sqlite3": "Required to use the package with the SQLite3 extension"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "League\\Csv\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "email": "nyamsprod@gmail.com",
+                    "homepage": "https://github.com/nyamsprod/",
+                    "role": "Developer"
+                }
+            ],
+            "description": "CSV data manipulation made easy in PHP",
+            "homepage": "https://csv.thephpleague.com",
+            "keywords": [
+                "convert",
+                "csv",
+                "export",
+                "filter",
+                "import",
+                "read",
+                "transform",
+                "write"
+            ],
+            "support": {
+                "docs": "https://csv.thephpleague.com",
+                "issues": "https://github.com/thephpleague/csv/issues",
+                "rss": "https://github.com/thephpleague/csv/releases.atom",
+                "source": "https://github.com/thephpleague/csv"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-27T15:18:42+00:00"
         },
         {
             "name": "league/flysystem",

--- a/tests/Feature/Exports/CsvExportTest.php
+++ b/tests/Feature/Exports/CsvExportTest.php
@@ -222,6 +222,29 @@ class CsvExportTest extends TestCase
         $this->generator()->generateSync(ExportFormat::Pdf, $restaurant, []);
     }
 
+    public function test_it_sanitizes_csv_injection_attempts_in_guest_columns(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create([
+                'guest_name' => '=HYPERLINK("http://evil.example","Click")',
+                'guest_email' => '+evil@example.com',
+                'guest_phone' => '-49301234567',
+            ]);
+
+        $payload = $this->captureCsv(
+            $this->generator()->generateSync(ExportFormat::Csv, $restaurant, []),
+        );
+
+        // Each operator-untrusted cell that starts with =/+/-/@
+        // gets a tab prefix so spreadsheets parse it as text, not a
+        // live formula. The original value is preserved after the tab.
+        $this->assertStringContainsString("\t=HYPERLINK", $payload);
+        $this->assertStringContainsString("\t+evil@example.com", $payload);
+        $this->assertStringContainsString("\t-49301234567", $payload);
+    }
+
     public function test_render_to_string_supplies_async_path_payload(): void
     {
         $restaurant = Restaurant::factory()->create();

--- a/tests/Feature/Exports/CsvExportTest.php
+++ b/tests/Feature/Exports/CsvExportTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Exports;
+
+use App\Enums\ExportFormat;
+use App\Enums\ReservationReplyStatus;
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Exports\CsvExportGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Tests\TestCase;
+
+class CsvExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function generator(): CsvExportGenerator
+    {
+        return $this->app->make(CsvExportGenerator::class);
+    }
+
+    private function captureCsv(StreamedResponse $response): string
+    {
+        ob_start();
+        $response->sendContent();
+
+        return (string) ob_get_clean();
+    }
+
+    public function test_it_streams_a_csv_download_for_small_result_sets(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'slug' => 'le-bistro',
+            'timezone' => 'Europe/Berlin',
+        ]);
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->count(3)
+            ->create();
+
+        $response = $this->generator()->generateSync(ExportFormat::Csv, $restaurant, []);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('text/csv; charset=UTF-8', $response->headers->get('Content-Type'));
+        $this->assertStringContainsString(
+            'attachment; filename="reservations-le-bistro-',
+            (string) $response->headers->get('Content-Disposition'),
+        );
+        $this->assertStringEndsWith('.csv"', (string) $response->headers->get('Content-Disposition'));
+
+        $payload = $this->captureCsv($response);
+        $lines = explode("\n", trim($payload));
+        // 1 header + 3 data rows.
+        $this->assertCount(4, $lines);
+    }
+
+    public function test_payload_starts_with_excel_bom_and_uses_semicolon_separator(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        $response = $this->generator()->generateSync(ExportFormat::Csv, $restaurant, []);
+        $payload = $this->captureCsv($response);
+
+        $this->assertSame("\xEF\xBB\xBF", substr($payload, 0, 3));
+
+        $headerLine = explode("\n", substr($payload, 3))[0];
+        // league/csv quotes header cells that contain spaces — both
+        // forms (raw `Manuelle Prüfung` or quoted `"Manuelle Prüfung"`)
+        // are valid Excel-DE input. We only care that the columns are
+        // present in order with `;` separators.
+        $expectedColumns = [
+            'ID',
+            'Eingegangen',
+            'Status',
+            'Quelle',
+            'Wunschdatum',
+            'Personen',
+            'Name',
+            'E-Mail',
+            'Telefon',
+            'Manuelle Prüfung',
+            'Letzte Antwort',
+        ];
+        foreach ($expectedColumns as $column) {
+            $this->assertStringContainsString($column, $headerLine);
+        }
+        $this->assertGreaterThanOrEqual(10, substr_count($headerLine, ';'));
+    }
+
+    public function test_it_applies_dashboard_filters(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create([
+                'guest_name' => 'Anna Müller',
+                'source' => ReservationSource::Email,
+                'status' => ReservationStatus::Confirmed,
+            ]);
+        ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create([
+                'guest_name' => 'Bert Schmidt',
+                'source' => ReservationSource::WebForm,
+                'status' => ReservationStatus::New,
+            ]);
+
+        $response = $this->generator()->generateSync(
+            ExportFormat::Csv,
+            $restaurant,
+            ['source' => ['email']],
+        );
+        $payload = $this->captureCsv($response);
+
+        $this->assertStringContainsString('Anna Müller', $payload);
+        $this->assertStringNotContainsString('Bert Schmidt', $payload);
+    }
+
+    public function test_it_renders_guest_email_party_size_phone_and_manual_review_flag(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'UTC']);
+        $request = ReservationRequest::factory()
+            ->forRestaurant($restaurant)
+            ->create([
+                'guest_name' => 'Carla Engels',
+                'guest_email' => 'carla@example.com',
+                'guest_phone' => '+49 30 1234567',
+                'party_size' => 6,
+                'needs_manual_review' => true,
+                'status' => ReservationStatus::Confirmed,
+                'source' => ReservationSource::Email,
+                'created_at' => Carbon::parse('2026-04-29 10:30:00'),
+                'desired_at' => Carbon::parse('2026-05-02 19:00:00'),
+            ]);
+        ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Sent,
+        ]);
+
+        $payload = $this->captureCsv(
+            $this->generator()->generateSync(ExportFormat::Csv, $restaurant, []),
+        );
+
+        // Skip BOM + header line.
+        $dataLine = explode("\n", trim(substr($payload, 3)))[1];
+
+        $this->assertStringContainsString('Carla Engels', $dataLine);
+        $this->assertStringContainsString('carla@example.com', $dataLine);
+        $this->assertStringContainsString('+49 30 1234567', $dataLine);
+        $this->assertStringContainsString(';6;', $dataLine);
+        $this->assertStringContainsString(';Bestätigt;', $dataLine);
+        $this->assertStringContainsString(';E-Mail;', $dataLine);
+        $this->assertStringContainsString('2026-04-29 10:30', $dataLine);
+        $this->assertStringContainsString('2026-05-02 19:00', $dataLine);
+        $this->assertStringContainsString(';Ja;', $dataLine);
+        $this->assertStringContainsString('Versendet', $dataLine);
+    }
+
+    public function test_it_does_not_include_rows_from_other_restaurants(): void
+    {
+        $own = Restaurant::factory()->create();
+        $other = Restaurant::factory()->create();
+
+        ReservationRequest::factory()->forRestaurant($own)->create([
+            'guest_name' => 'Own Tenant Guest',
+        ]);
+        ReservationRequest::factory()->forRestaurant($other)->count(3)->create([
+            'guest_name' => 'Other Tenant Guest',
+        ]);
+
+        $payload = $this->captureCsv(
+            $this->generator()->generateSync(ExportFormat::Csv, $own, []),
+        );
+
+        $this->assertStringContainsString('Own Tenant Guest', $payload);
+        $this->assertStringNotContainsString('Other Tenant Guest', $payload);
+    }
+
+    public function test_it_renders_dates_in_the_restaurant_timezone(): void
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'created_at' => Carbon::parse('2026-04-29 22:30:00', 'UTC'),
+        ]);
+
+        $payload = $this->captureCsv(
+            $this->generator()->generateSync(ExportFormat::Csv, $restaurant, []),
+        );
+
+        // 22:30 UTC = 00:30 Berlin (CEST, +02:00) — the date should
+        // surface in the operator's local timezone.
+        $this->assertStringContainsString('2026-04-30 00:30', $payload);
+    }
+
+    public function test_it_rejects_pdf_format(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->generator()->generateSync(ExportFormat::Pdf, $restaurant, []);
+    }
+
+    public function test_render_to_string_supplies_async_path_payload(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        ReservationRequest::factory()->forRestaurant($restaurant)->count(2)->create();
+
+        $payload = $this->generator()->renderToString($restaurant, []);
+
+        $this->assertSame("\xEF\xBB\xBF", substr($payload, 0, 3));
+        $this->assertStringContainsString('ID;Eingegangen', $payload);
+    }
+}


### PR DESCRIPTION
## Summary

- \`composer require league/csv\` (^9.28).
- \`App\\Services\\Exports\\CsvExportGenerator\` implements the \`ExportGenerator\` contract from #236.
  - \`generateSync()\` streams a UTF-8-BOM-prefixed CSV with \`;\` separator (the Excel-DE handshake) and the 11-column schema from PRD-009. Status / source / reply-status rendered as German labels; dates in the restaurant's local timezone.
  - Tenant scoping is explicit (\`withoutGlobalScopes()\` + \`where('restaurant_id', \$restaurant->id)\`) so the same code path works in both the sync request lifecycle and the future async queue worker (#239).
  - Rows walked in 500-record chunks; a 10k-record export doesn't materialise the whole result set in memory.
  - \`renderToString(restaurant, filters)\` is the async-path entry point #239 will use to persist to disk — keeps the disk concern out of the generator.
  - Throws \`InvalidArgumentException\` if called with the PDF format (the dispatcher routes by format, the safety net stays for future composite generators).

## Why

Issue #237 — concrete CSV emitter for the PRD-009 export pipeline. Closes #237.

## Test plan

- [x] \`php artisan test --filter=CsvExportTest\` (8 passed, 37 assertions)
- [x] \`php artisan test\` (754 passed)
- [x] \`./vendor/bin/pint --test\`

Test coverage: streaming, BOM + \`;\` header, dashboard filter flow-through, full row content (guest email / party size / phone / manual-review flag / reply status), cross-tenant isolation, restaurant-local timezone applied to dates, PDF rejection, async-path \`renderToString\` payload.