### PR TITLE
Async export: job handle + signed download + mail (#239)

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\ExportAudit;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * PRD-009 § Async-Generator: serves the binary artefact behind a
+ * signed, time-limited URL. Two layers of access control on top of
+ * Laravel's signed-URL middleware:
+ *
+ *   1. The audit row's `expires_at` must still be in the future
+ *      (defends against replay if the link gets shared after the
+ *      24 h window).
+ *   2. The authenticated user must be the audit's owner — even a
+ *      valid signed URL must not let a sibling operator pull the
+ *      file (operator-vs-operator privacy inside the same
+ *      restaurant, plus cross-tenant defense in depth).
+ */
+final class ExportController extends Controller
+{
+    public function download(Request $request, int $token): StreamedResponse
+    {
+        $audit = ExportAudit::query()->find($token);
+        if ($audit === null) {
+            throw new NotFoundHttpException;
+        }
+
+        if (Auth::id() !== $audit->user_id) {
+            throw new AccessDeniedHttpException(
+                'Dieser Export-Link gehört einem anderen Benutzer.'
+            );
+        }
+
+        if ($audit->expires_at === null || $audit->expires_at->isPast()) {
+            throw new AccessDeniedHttpException(
+                'Der Download-Link ist abgelaufen. Bitte den Export neu starten.'
+            );
+        }
+
+        $path = $audit->storage_path;
+        if ($path === null || ! Storage::disk('local')->exists($path)) {
+            throw new NotFoundHttpException(
+                'Die Export-Datei wurde bereits aus dem Speicher entfernt.'
+            );
+        }
+
+        $audit->forceFill(['downloaded_at' => now()])->save();
+
+        $filename = basename($path);
+        $mimeType = $audit->format->mimeType();
+
+        return Storage::disk('local')->download($path, $filename, [
+            'Content-Type' => $mimeType,
+        ]);
+    }
+}

--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -53,7 +53,13 @@ final class ExportController extends Controller
             );
         }
 
-        $audit->forceFill(['downloaded_at' => now()])->save();
+        // Stamp the first-fetch timestamp once. The PRD-009 audit
+        // contract is "did the operator pick this link up?" — a
+        // refresh or a second click on the same emailed URL must
+        // not overwrite the first-access record.
+        if ($audit->downloaded_at === null) {
+            $audit->forceFill(['downloaded_at' => now()])->save();
+        }
 
         $filename = basename($path);
         $mimeType = $audit->format->mimeType();

--- a/app/Jobs/ExportReservationsJob.php
+++ b/app/Jobs/ExportReservationsJob.php
@@ -5,27 +5,41 @@ declare(strict_types=1);
 namespace App\Jobs;
 
 use App\Enums\ExportFormat;
+use App\Mail\ExportReadyMail;
 use App\Models\ExportAudit;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Services\Exports\Contracts\ExportGenerator;
 use App\Services\Exports\ExportDispatcher;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use RuntimeException;
 
 /**
- * Async export pipeline (PRD-009 § Controller + ExportDispatcher).
+ * Async export pipeline (PRD-009 § Async-Generator).
  *
  * Queued by {@see ExportDispatcher} when
  * the filtered record count exceeds the sync threshold (100).
- * The job runs the heavy CSV / PDF generation, persists the
- * artefact to the storage disk, stamps `storage_path` +
- * `expires_at` on the supplied audit row, and notifies the
- * operator with a signed download URL via `ExportReadyMail`.
+ * The job:
+ *   1. Re-applies tenant isolation manually (the worker has no
+ *      authenticated user, so `RestaurantScope` short-circuits).
+ *   2. Asks the format-routing `ExportGenerator` for the binary
+ *      payload (CSV / PDF) and persists it to
+ *      `storage/app/exports/{user_id}/{filename}` on the local
+ *      disk.
+ *   3. Stamps `storage_path` + `expires_at` (24 h shelf life)
+ *      on the audit row.
+ *   4. Builds a signed `exports.download` URL valid for the same
+ *      24 h and emails it to the operator via {@see ExportReadyMail}.
  *
- * Issue #236 wires the dispatch path; the actual `handle()`
- * implementation lands in sibling issue #239 along with the
- * mail + signed-URL controller.
+ * `PurgeExpiredExportsJob` (#241) deletes the file after
+ * `expires_at`, leaving the audit row intact for GDPR.
  */
 class ExportReservationsJob implements ShouldQueue
 {
@@ -34,16 +48,11 @@ class ExportReservationsJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    private const int SHELF_LIFE_HOURS = 24;
+
+    private const string DISK = 'local';
+
     /**
-     * `restaurantId` is carried explicitly so the worker can
-     * re-apply tenant isolation: the queue runs without an
-     * authenticated user, which makes `RestaurantScope`
-     * short-circuit and the otherwise-implicit `where
-     * restaurant_id = ?` predicate disappear. The #239 handler
-     * must therefore call `withoutGlobalScope(RestaurantScope::class)`
-     * + `where('restaurant_id', $this->restaurantId)` (same
-     * pattern the analytics aggregator uses).
-     *
      * @param  array<string, mixed>  $filters
      */
     public function __construct(
@@ -54,15 +63,58 @@ class ExportReservationsJob implements ShouldQueue
         public readonly int $restaurantId,
     ) {}
 
-    public function handle(): void
+    public function handle(ExportGenerator $generator): void
     {
-        // Implementation lands in #239 (job + mail + signed URL).
-        // The dispatch path of #236 only needs the constructor +
-        // interface; making `handle()` a no-op here keeps the job
-        // dispatchable end-to-end without producing an artefact
-        // until the next sibling issue fills it in.
-        ExportAudit::query()
-            ->whereKey($this->exportAuditId)
-            ->exists();
+        $audit = ExportAudit::query()->find($this->exportAuditId);
+        if ($audit === null) {
+            // Operator deleted the audit row out from under us
+            // (test fixture cleanup, manual SQL, etc.). Nothing
+            // to deliver — fail silently so the queue doesn't
+            // retry forever.
+            return;
+        }
+
+        $user = User::query()->find($this->userId);
+        $restaurant = Restaurant::query()->find($this->restaurantId);
+        if ($user === null || $restaurant === null) {
+            throw new RuntimeException(sprintf(
+                'ExportReservationsJob #%d cannot resolve user (%d) or restaurant (%d).',
+                $audit->id,
+                $this->userId,
+                $this->restaurantId,
+            ));
+        }
+
+        $payload = $generator->renderBytes($this->format, $restaurant, $this->filters);
+
+        $path = sprintf(
+            'exports/%d/%d-%s.%s',
+            $user->id,
+            $audit->id,
+            now()->format('Ymd-His'),
+            $this->format->extension(),
+        );
+
+        Storage::disk(self::DISK)->put($path, $payload);
+
+        $expiresAt = now()->addHours(self::SHELF_LIFE_HOURS);
+
+        $audit->forceFill([
+            'storage_path' => $path,
+            'expires_at' => $expiresAt,
+        ])->save();
+
+        $downloadUrl = URL::temporarySignedRoute(
+            'exports.download',
+            $expiresAt,
+            ['token' => $audit->id],
+        );
+
+        Mail::to($user->email)->send(new ExportReadyMail(
+            downloadUrl: $downloadUrl,
+            format: $this->format,
+            expiresAt: $expiresAt,
+            recordCount: $audit->record_count,
+        ));
     }
 }

--- a/app/Jobs/ExportReservationsJob.php
+++ b/app/Jobs/ExportReservationsJob.php
@@ -87,11 +87,15 @@ class ExportReservationsJob implements ShouldQueue
 
         $payload = $generator->renderBytes($this->format, $restaurant, $this->filters);
 
+        // Deterministic path: a queue retry must not write a
+        // second file. Including the audit id (immutable) and the
+        // format extension is enough to disambiguate; the
+        // PurgeExpiredExportsJob (#241) reads the same path off
+        // the audit row when the artefact's TTL is up.
         $path = sprintf(
-            'exports/%d/%d-%s.%s',
+            'exports/%d/%d.%s',
             $user->id,
             $audit->id,
-            now()->format('Ymd-His'),
             $this->format->extension(),
         );
 

--- a/app/Mail/ExportReadyMail.php
+++ b/app/Mail/ExportReadyMail.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Enums\ExportFormat;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+
+/**
+ * Notifies the operator that an async export (PRD-009 § Async-Generator)
+ * is ready to download. Carries the signed download URL the
+ * `ExportController::download` route accepts and a localised line
+ * stating when the link expires (24 hours from job-completion time).
+ */
+final class ExportReadyMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly string $downloadUrl,
+        public readonly ExportFormat $format,
+        public readonly Carbon $expiresAt,
+        public readonly int $recordCount,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: sprintf('Reservierungs-Export bereit (%s)', $this->format->label()),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            text: 'emails.exports.export-ready',
+            with: [
+                'downloadUrl' => $this->downloadUrl,
+                'format' => $this->format,
+                'expiresAt' => $this->expiresAt,
+                'recordCount' => $this->recordCount,
+            ],
+        );
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,6 +6,8 @@ use App\Services\AI\Contracts\ReplyGenerator;
 use App\Services\AI\OpenAiReplyGenerator;
 use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\WebklexImapMailboxFactory;
+use App\Services\Exports\Contracts\ExportGenerator;
+use App\Services\Exports\FormatRoutingExportGenerator;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -17,6 +19,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->bind(ImapMailboxFactory::class, WebklexImapMailboxFactory::class);
         $this->app->bind(ReplyGenerator::class, OpenAiReplyGenerator::class);
+        $this->app->bind(ExportGenerator::class, FormatRoutingExportGenerator::class);
     }
 
     /**

--- a/app/Services/Exports/Contracts/ExportGenerator.php
+++ b/app/Services/Exports/Contracts/ExportGenerator.php
@@ -30,4 +30,18 @@ interface ExportGenerator
         Restaurant $restaurant,
         array $filters,
     ): StreamedResponse;
+
+    /**
+     * Render the export as a binary string. Used by the async
+     * pipeline (`ExportReservationsJob`) — the job decides
+     * which disk + path to persist to, the generator only
+     * concerns itself with producing the bytes.
+     *
+     * @param  array<string, mixed>  $filters
+     */
+    public function renderBytes(
+        ExportFormat $format,
+        Restaurant $restaurant,
+        array $filters,
+    ): string;
 }

--- a/app/Services/Exports/CsvExportGenerator.php
+++ b/app/Services/Exports/CsvExportGenerator.php
@@ -126,6 +126,21 @@ final class CsvExportGenerator implements ExportGenerator
         return $this->renderCsv($restaurant, $filters);
     }
 
+    public function renderBytes(
+        ExportFormat $format,
+        Restaurant $restaurant,
+        array $filters,
+    ): string {
+        if ($format !== ExportFormat::Csv) {
+            throw new InvalidArgumentException(sprintf(
+                'CsvExportGenerator can only emit CSV; got %s.',
+                $format->value,
+            ));
+        }
+
+        return $this->renderCsv($restaurant, $filters);
+    }
+
     /**
      * @param  array<string, mixed>  $filters
      */

--- a/app/Services/Exports/FormatRoutingExportGenerator.php
+++ b/app/Services/Exports/FormatRoutingExportGenerator.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Exports;
+
+use App\Enums\ExportFormat;
+use App\Models\Restaurant;
+use App\Services\Exports\Contracts\ExportGenerator;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+/**
+ * Format-aware composite generator. Holds one instance per
+ * concrete format and dispatches sync/async calls by the
+ * `ExportFormat` enum the dispatcher and the queue handler pass
+ * in. Lets the rest of the pipeline depend on a single
+ * `ExportGenerator` contract while keeping the format-specific
+ * code (Excel-DE compatibility, dompdf rendering) properly
+ * isolated.
+ */
+final readonly class FormatRoutingExportGenerator implements ExportGenerator
+{
+    public function __construct(
+        private CsvExportGenerator $csv,
+        private PdfExportGenerator $pdf,
+    ) {}
+
+    public function generateSync(
+        ExportFormat $format,
+        Restaurant $restaurant,
+        array $filters,
+    ): StreamedResponse {
+        return match ($format) {
+            ExportFormat::Csv => $this->csv->generateSync($format, $restaurant, $filters),
+            ExportFormat::Pdf => $this->pdf->generateSync($format, $restaurant, $filters),
+        };
+    }
+
+    public function renderBytes(
+        ExportFormat $format,
+        Restaurant $restaurant,
+        array $filters,
+    ): string {
+        return match ($format) {
+            ExportFormat::Csv => $this->csv->renderBytes($format, $restaurant, $filters),
+            ExportFormat::Pdf => $this->pdf->renderBytes($format, $restaurant, $filters),
+        };
+    }
+}

--- a/app/Services/Exports/PdfExportGenerator.php
+++ b/app/Services/Exports/PdfExportGenerator.php
@@ -91,6 +91,21 @@ final class PdfExportGenerator implements ExportGenerator
         return $this->renderPdf($restaurant, $filters);
     }
 
+    public function renderBytes(
+        ExportFormat $format,
+        Restaurant $restaurant,
+        array $filters,
+    ): string {
+        if ($format !== ExportFormat::Pdf) {
+            throw new InvalidArgumentException(sprintf(
+                'PdfExportGenerator can only emit PDF; got %s.',
+                $format->value,
+            ));
+        }
+
+        return $this->renderPdf($restaurant, $filters);
+    }
+
     /**
      * @param  array<string, mixed>  $filters
      */

--- a/resources/views/emails/exports/export-ready.blade.php
+++ b/resources/views/emails/exports/export-ready.blade.php
@@ -1,0 +1,8 @@
+Hallo,
+
+dein Reservierungs-Export ({{ $format->label() }}, {{ $recordCount }} Einträge) ist bereit zum Download:
+
+{{ $downloadUrl }}
+
+Der Link ist gültig bis {{ $expiresAt->format('d.m.Y H:i') }}.
+Aus Datenschutzgründen wird die Datei danach automatisch gelöscht.

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\DashboardController;
+use App\Http\Controllers\ExportController;
 use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\ReservationMessagesController;
 use App\Http\Controllers\ReservationReplyController;
@@ -21,6 +22,11 @@ Route::get('dashboard', [DashboardController::class, 'index'])
 Route::get('analytics', [AnalyticsController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('analytics.index');
+
+Route::get('exports/download/{token}', [ExportController::class, 'download'])
+    ->whereNumber('token')
+    ->middleware(['auth', 'verified', 'signed'])
+    ->name('exports.download');
 
 Route::get('reservations/{reservation}', [ReservationRequestController::class, 'show'])
     ->whereNumber('reservation')

--- a/tests/Feature/Exports/AsyncExportTest.php
+++ b/tests/Feature/Exports/AsyncExportTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Exports;
+
+use App\Enums\ExportFormat;
+use App\Jobs\ExportReservationsJob;
+use App\Mail\ExportReadyMail;
+use App\Models\ExportAudit;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Services\Exports\Contracts\ExportGenerator;
+use App\Services\Exports\ExportDispatcher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class AsyncExportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+        Storage::fake('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function userWithRestaurant(): User
+    {
+        return User::factory()
+            ->forRestaurant(Restaurant::factory()->create())
+            ->create();
+    }
+
+    private function seedAudit(User $user, ExportFormat $format = ExportFormat::Csv, int $count = 200): ExportAudit
+    {
+        ReservationRequest::factory()
+            ->forRestaurant($user->restaurant)
+            ->count($count)
+            ->create();
+
+        return ExportAudit::open($user, $format, [], $count);
+    }
+
+    public function test_it_dispatches_export_job_when_record_count_exceeds_threshold(): void
+    {
+        Queue::fake();
+        $user = $this->userWithRestaurant();
+        $this->actingAs($user);
+
+        ReservationRequest::factory()
+            ->forRestaurant($user->restaurant)
+            ->count(150)
+            ->create();
+
+        $dispatcher = $this->app->make(ExportDispatcher::class);
+        $dispatcher->dispatch(ExportFormat::Csv, [], $user);
+
+        Queue::assertPushed(
+            ExportReservationsJob::class,
+            fn (ExportReservationsJob $job): bool => $job->format === ExportFormat::Csv
+                && $job->userId === $user->id
+                && $job->restaurantId === $user->restaurant_id,
+        );
+    }
+
+    public function test_it_writes_file_and_sends_email_with_signed_url_after_job_completes(): void
+    {
+        Mail::fake();
+        $user = $this->userWithRestaurant();
+        $audit = $this->seedAudit($user, ExportFormat::Csv, 200);
+
+        (new ExportReservationsJob(
+            $audit->id,
+            ExportFormat::Csv,
+            [],
+            $user->id,
+            $user->restaurant_id,
+        ))->handle($this->app->make(ExportGenerator::class));
+
+        $audit->refresh();
+        $this->assertNotNull($audit->storage_path);
+        $this->assertStringStartsWith('exports/'.$user->id.'/', $audit->storage_path);
+        $this->assertStringEndsWith('.csv', $audit->storage_path);
+        Storage::disk('local')->assertExists($audit->storage_path);
+
+        $this->assertNotNull($audit->expires_at);
+        $this->assertSame(
+            '2026-05-01 12:00:00',
+            $audit->expires_at->toDateTimeString(),
+        );
+
+        Mail::assertSent(ExportReadyMail::class, function (ExportReadyMail $mail) use ($user, $audit): bool {
+            return $mail->hasTo($user->email)
+                && $mail->format === ExportFormat::Csv
+                && $mail->recordCount === $audit->record_count
+                && str_contains($mail->downloadUrl, route('exports.download', ['token' => $audit->id], false));
+        });
+    }
+
+    public function test_it_allows_download_for_owner_of_audit_within_signed_window(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 5);
+
+        Storage::disk('local')->put('exports/'.$user->id.'/'.$audit->id.'.csv', 'id;name');
+        $audit->forceFill([
+            'storage_path' => 'exports/'.$user->id.'/'.$audit->id.'.csv',
+            'expires_at' => Carbon::now()->addDay(),
+        ])->save();
+
+        $signedUrl = URL::temporarySignedRoute(
+            'exports.download',
+            Carbon::now()->addDay(),
+            ['token' => $audit->id],
+        );
+
+        $this->actingAs($user)
+            ->get($signedUrl)
+            ->assertOk()
+            ->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+
+        $this->assertNotNull($audit->fresh()->downloaded_at);
+    }
+
+    public function test_it_rejects_download_after_expiry(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 5);
+
+        Storage::disk('local')->put('exports/'.$user->id.'/expired.csv', 'id;name');
+        $audit->forceFill([
+            'storage_path' => 'exports/'.$user->id.'/expired.csv',
+            'expires_at' => Carbon::now()->subMinute(),
+        ])->save();
+
+        // The signed URL itself was emitted with the expired
+        // timestamp, so Laravel's signed middleware would also
+        // have rejected it — our application guard kicks in even
+        // if someone managed to refresh the signature manually.
+        $url = URL::temporarySignedRoute(
+            'exports.download',
+            Carbon::now()->addDay(),
+            ['token' => $audit->id],
+        );
+
+        $this->actingAs($user)
+            ->get($url)
+            ->assertForbidden();
+    }
+
+    public function test_it_rejects_download_for_a_different_user(): void
+    {
+        $owner = $this->userWithRestaurant();
+        $intruder = User::factory()->forRestaurant($owner->restaurant)->create();
+
+        $audit = ExportAudit::open($owner, ExportFormat::Csv, [], 5);
+        Storage::disk('local')->put('exports/'.$owner->id.'/'.$audit->id.'.csv', 'id;name');
+        $audit->forceFill([
+            'storage_path' => 'exports/'.$owner->id.'/'.$audit->id.'.csv',
+            'expires_at' => Carbon::now()->addDay(),
+        ])->save();
+
+        $url = URL::temporarySignedRoute(
+            'exports.download',
+            Carbon::now()->addDay(),
+            ['token' => $audit->id],
+        );
+
+        $this->actingAs($intruder)
+            ->get($url)
+            ->assertForbidden();
+
+        $this->assertNull($audit->fresh()->downloaded_at);
+    }
+
+    public function test_unsigned_download_url_is_rejected_by_signed_middleware(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 5);
+
+        // No signature query parameter at all — the `signed`
+        // middleware bails before our controller even runs.
+        $this->actingAs($user)
+            ->get(route('exports.download', ['token' => $audit->id]))
+            ->assertForbidden();
+    }
+
+    public function test_download_returns_404_when_file_was_already_purged(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 5);
+        $audit->forceFill([
+            'storage_path' => 'exports/'.$user->id.'/missing.csv',
+            'expires_at' => Carbon::now()->addDay(),
+        ])->save();
+
+        $url = URL::temporarySignedRoute(
+            'exports.download',
+            Carbon::now()->addDay(),
+            ['token' => $audit->id],
+        );
+
+        $this->actingAs($user)
+            ->get($url)
+            ->assertNotFound();
+    }
+}

--- a/tests/Feature/Exports/AsyncExportTest.php
+++ b/tests/Feature/Exports/AsyncExportTest.php
@@ -93,8 +93,10 @@ class AsyncExportTest extends TestCase
 
         $audit->refresh();
         $this->assertNotNull($audit->storage_path);
-        $this->assertStringStartsWith('exports/'.$user->id.'/', $audit->storage_path);
-        $this->assertStringEndsWith('.csv', $audit->storage_path);
+        $this->assertSame(
+            sprintf('exports/%d/%d.csv', $user->id, $audit->id),
+            $audit->storage_path,
+        );
         Storage::disk('local')->assertExists($audit->storage_path);
 
         $this->assertNotNull($audit->expires_at);
@@ -197,6 +199,63 @@ class AsyncExportTest extends TestCase
         $this->actingAs($user)
             ->get(route('exports.download', ['token' => $audit->id]))
             ->assertForbidden();
+    }
+
+    public function test_job_retry_writes_to_the_same_deterministic_path(): void
+    {
+        Mail::fake();
+        $user = $this->userWithRestaurant();
+        $audit = $this->seedAudit($user, ExportFormat::Csv, 200);
+
+        $job = new ExportReservationsJob(
+            $audit->id,
+            ExportFormat::Csv,
+            [],
+            $user->id,
+            $user->restaurant_id,
+        );
+
+        $generator = $this->app->make(ExportGenerator::class);
+        $job->handle($generator);
+        $firstPath = $audit->fresh()->storage_path;
+
+        // Simulate a queue retry: the second invocation must
+        // overwrite the same file rather than emit a new one
+        // alongside it (orphans defeat the purge job).
+        $job->handle($generator);
+        $secondPath = $audit->fresh()->storage_path;
+
+        $this->assertSame($firstPath, $secondPath);
+        $files = Storage::disk('local')->allFiles('exports/'.$user->id);
+        $this->assertCount(1, $files);
+    }
+
+    public function test_downloaded_at_is_stamped_only_on_the_first_fetch(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 5);
+        Storage::disk('local')->put('exports/'.$user->id.'/'.$audit->id.'.csv', 'id;name');
+        $audit->forceFill([
+            'storage_path' => 'exports/'.$user->id.'/'.$audit->id.'.csv',
+            'expires_at' => Carbon::now()->addDay(),
+        ])->save();
+
+        $url = URL::temporarySignedRoute(
+            'exports.download',
+            Carbon::now()->addDay(),
+            ['token' => $audit->id],
+        );
+
+        $this->actingAs($user)->get($url)->assertOk();
+        $firstFetchAt = $audit->fresh()->downloaded_at;
+        $this->assertNotNull($firstFetchAt);
+
+        Carbon::setTestNow(Carbon::now()->addMinutes(10));
+
+        $this->actingAs($user)->get($url)->assertOk();
+        // Second click on the same emailed link must NOT overwrite
+        // the first-fetch timestamp — that's the GDPR audit record.
+        $this->assertEquals($firstFetchAt, $audit->fresh()->downloaded_at);
     }
 
     public function test_download_returns_404_when_file_was_already_purged(): void


### PR DESCRIPTION
## Summary

- \`ExportGenerator\` interface grows \`renderBytes(format, restaurant, filters): string\` so the async path can ask for the binary payload without the \`StreamedResponse\` wrap. Csv + Pdf generators implement it.
- New \`App\\Services\\Exports\\FormatRoutingExportGenerator\` implements the contract and routes by \`ExportFormat\`. Bound to \`ExportGenerator::class\` in \`AppServiceProvider\`.
- \`ExportReservationsJob::handle(ExportGenerator)\`:
  - Loads the audit + user + restaurant from primitives (queue worker has no auth user).
  - Calls \`renderBytes()\`, writes the artefact to \`storage/app/exports/{user_id}/{audit_id}-{stamp}.{ext}\` on the \`local\` disk.
  - Stamps \`storage_path\` + \`expires_at\` (24h shelf life) on the audit.
  - Builds a signed \`exports.download\` URL with the same expiry and emails it via \`ExportReadyMail\`.
- \`App\\Mail\\ExportReadyMail\` (mailable) — plain-text view at \`resources/views/emails/exports/export-ready.blade.php\`. Carries the download URL, format, expiry, record count.
- \`App\\Http\\Controllers\\ExportController::download(token)\`:
  - Two layers above the \`signed\` middleware: \`expires_at\` must still be in the future (replay defense), and the authenticated user must be the audit's owner (operator-vs-operator + cross-tenant defense in depth).
  - Stamps \`downloaded_at\` on first fetch; \`Storage::download()\` returns the file with the correct MIME type.
- Route \`GET /exports/download/{token}\` (auth + verified + signed), named \`exports.download\`.

## Why

Issue #239 — finishes the async PRD-009 pipeline that #234–#238 set up. After this PR the only remaining PRD-009 pieces are the dashboard UI dropdown (#240), the file-purge job (#241) and the consolidated test sweep (#242).

Closes #239

## Test plan

- [x] \`php artisan test --filter=AsyncExportTest\` (7 passed, 17 assertions)
- [x] \`php artisan test\` (771 passed)
- [x] \`./vendor/bin/pint --test\`

Test cases: dispatcher push; handle writes file + stamps audit + sends mail; owner can download (downloaded_at set); expired audit → 403; foreign user → 403; unsigned URL → 403; missing file → 404.