### PR TITLE
PurgeExpiredExportsJob: six-hourly file cleanup (#241)

### DIFF
--- a/app/Jobs/PurgeExpiredExportsJob.php
+++ b/app/Jobs/PurgeExpiredExportsJob.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\ExportAudit;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * Six-hourly cleanup of stale export artefacts (PRD-009 §
+ * Audit & Cleanup).
+ *
+ * For every audit row whose `expires_at` is in the past **and**
+ * still has a `storage_path`, the file is deleted from disk and
+ * the column nulled out — but the audit row stays. GDPR access
+ * requests need the audit record (who exported what, when) even
+ * after the binary artefact is gone.
+ *
+ * Idempotent: rows whose `storage_path` is already `null` are
+ * filtered out at the query layer, so a second run within the
+ * same six-hour window does no extra work.
+ */
+class PurgeExpiredExportsJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    private const string DISK = 'local';
+
+    private const int CHUNK_SIZE = 100;
+
+    public function handle(): void
+    {
+        ExportAudit::query()
+            ->whereNotNull('storage_path')
+            ->where('expires_at', '<', now())
+            ->orderBy('id')
+            ->chunkById(self::CHUNK_SIZE, function ($chunk): void {
+                foreach ($chunk as $audit) {
+                    if ($audit->storage_path !== null) {
+                        Storage::disk(self::DISK)->delete($audit->storage_path);
+                    }
+
+                    $audit->forceFill(['storage_path' => null])->save();
+                }
+            });
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Jobs\FetchReservationEmailsJob;
 use App\Jobs\PruneFailedEmailImportsJob;
+use App\Jobs\PurgeExpiredExportsJob;
 use App\Models\Restaurant;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
@@ -25,4 +26,9 @@ Schedule::call(function (): void {
 Schedule::job(new PruneFailedEmailImportsJob)
     ->name(PruneFailedEmailImportsJob::class)
     ->dailyAt('03:00')
+    ->withoutOverlapping();
+
+Schedule::job(new PurgeExpiredExportsJob)
+    ->name(PurgeExpiredExportsJob::class)
+    ->everySixHours()
     ->withoutOverlapping();

--- a/tests/Feature/Exports/PurgeExpiredExportsJobTest.php
+++ b/tests/Feature/Exports/PurgeExpiredExportsJobTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Exports;
+
+use App\Enums\ExportFormat;
+use App\Jobs\PurgeExpiredExportsJob;
+use App\Models\ExportAudit;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class PurgeExpiredExportsJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Carbon::setTestNow('2026-04-30 12:00:00');
+        Storage::fake('local');
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function userWithRestaurant(): User
+    {
+        return User::factory()
+            ->forRestaurant(Restaurant::factory()->create())
+            ->create();
+    }
+
+    private function expiredAuditWithFile(User $user, string $relativePath = 'exports/old/file.csv'): ExportAudit
+    {
+        Storage::disk('local')->put($relativePath, 'id;name');
+
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 5);
+        $audit->forceFill([
+            'storage_path' => $relativePath,
+            'expires_at' => Carbon::now()->subHour(),
+        ])->save();
+
+        return $audit;
+    }
+
+    public function test_it_deletes_files_older_than_expiry(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = $this->expiredAuditWithFile($user, 'exports/'.$user->id.'/expired.csv');
+
+        Storage::disk('local')->assertExists($audit->storage_path);
+
+        (new PurgeExpiredExportsJob)->handle();
+
+        Storage::disk('local')->assertMissing('exports/'.$user->id.'/expired.csv');
+    }
+
+    public function test_it_keeps_audit_record_after_file_delete(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = $this->expiredAuditWithFile($user);
+
+        (new PurgeExpiredExportsJob)->handle();
+
+        $this->assertNotNull(ExportAudit::query()->find($audit->id));
+    }
+
+    public function test_it_sets_storage_path_to_null_after_delete(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = $this->expiredAuditWithFile($user);
+
+        (new PurgeExpiredExportsJob)->handle();
+
+        $audit->refresh();
+        $this->assertNull($audit->storage_path);
+    }
+
+    public function test_it_skips_audits_that_have_not_yet_expired(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = ExportAudit::open($user, ExportFormat::Csv, [], 5);
+        Storage::disk('local')->put('exports/'.$user->id.'/fresh.csv', 'id;name');
+        $audit->forceFill([
+            'storage_path' => 'exports/'.$user->id.'/fresh.csv',
+            'expires_at' => Carbon::now()->addDay(),
+        ])->save();
+
+        (new PurgeExpiredExportsJob)->handle();
+
+        Storage::disk('local')->assertExists('exports/'.$user->id.'/fresh.csv');
+        $this->assertSame(
+            'exports/'.$user->id.'/fresh.csv',
+            $audit->fresh()->storage_path,
+        );
+    }
+
+    public function test_it_is_idempotent_on_a_second_run(): void
+    {
+        $user = $this->userWithRestaurant();
+        $audit = $this->expiredAuditWithFile($user);
+
+        (new PurgeExpiredExportsJob)->handle();
+        $firstRunPath = $audit->fresh()->storage_path;
+
+        // Second run touches no rows because every expired audit
+        // already has storage_path = null.
+        (new PurgeExpiredExportsJob)->handle();
+        $secondRunPath = $audit->fresh()->storage_path;
+
+        $this->assertNull($firstRunPath);
+        $this->assertNull($secondRunPath);
+    }
+
+    public function test_it_processes_audits_across_multiple_restaurants_and_users(): void
+    {
+        $userA = $this->userWithRestaurant();
+        $userB = $this->userWithRestaurant();
+
+        $expiredA = $this->expiredAuditWithFile($userA, 'exports/a.csv');
+        $expiredB = $this->expiredAuditWithFile($userB, 'exports/b.csv');
+
+        (new PurgeExpiredExportsJob)->handle();
+
+        Storage::disk('local')->assertMissing('exports/a.csv');
+        Storage::disk('local')->assertMissing('exports/b.csv');
+        $this->assertNull($expiredA->fresh()->storage_path);
+        $this->assertNull($expiredB->fresh()->storage_path);
+    }
+}


### PR DESCRIPTION
## Summary

- New \`App\\Jobs\\PurgeExpiredExportsJob\` walks every audit row whose \`expires_at < now()\` **and** still has a \`storage_path\`, deletes the file from the \`local\` disk, and nulls \`storage_path\`. Audit row stays intact for GDPR \"who exported what, when\".
- Idempotent by query — rows with \`storage_path\` already null are filtered out, so a second run within the same six-hour window does no extra work.
- Walks via \`chunkById(100)\` so a backlog doesn't load every row into memory.
- Scheduled in \`routes/console.php\` every six hours (\`->everySixHours()->withoutOverlapping()\`), matching the established \`PruneFailedEmailImportsJob\` daily-3am cleanup convention.

## Why

Issue #241 — closes the storage side of PRD-009 by making sure expired artefacts don't pile up on disk. The signed download URL the operator gets is valid for 24h; this job runs every 6h so a stale file stays on disk for at most 6 hours past its TTL.

Closes #241

## Test plan

- [x] \`php artisan test --filter=PurgeExpiredExportsJobTest\` (6 passed, 12 assertions)
- [x] \`php artisan test\` (779 passed)
- [x] \`./vendor/bin/pint --test\`

Test cases: deletes expired files; keeps audit row; nulls \`storage_path\`; skips fresh audits; second run is a no-op; processes audits across multiple users / restaurants in one pass.