### PR TITLE
Dashboard export dropdown + POST /exports (#240)

### DIFF
--- a/app/Http/Controllers/ExportController.php
+++ b/app/Http/Controllers/ExportController.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\Exports\ExportRequest;
 use App\Models\ExportAudit;
+use App\Services\Exports\ExportDispatcher;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
@@ -27,6 +30,29 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  */
 final class ExportController extends Controller
 {
+    /**
+     * Operator-triggered export. Sync path (≤ 100 records) returns
+     * a `StreamedResponse` the browser downloads directly; async
+     * path (> 100) queues `ExportReservationsJob` and returns a
+     * `RedirectResponse` carrying the flash message the dashboard
+     * surfaces. Tenant guard is here (not in the FormRequest) so
+     * the same convention as `AnalyticsController` applies — a
+     * tenantless user → 404, not 403.
+     */
+    public function store(ExportRequest $request, ExportDispatcher $dispatcher): StreamedResponse|RedirectResponse
+    {
+        $user = $request->user();
+        if ($user === null || $user->restaurant_id === null) {
+            throw new NotFoundHttpException;
+        }
+
+        return $dispatcher->dispatch(
+            $request->exportFormat(),
+            $request->filterSnapshot(),
+            $user,
+        );
+    }
+
     public function download(Request $request, int $token): StreamedResponse
     {
         $audit = ExportAudit::query()->find($token);

--- a/resources/js/components/DashboardExportDropdown.vue
+++ b/resources/js/components/DashboardExportDropdown.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import type { DashboardFilters } from '@/types';
+import { router } from '@inertiajs/vue3';
+import { Download, Info } from 'lucide-vue-next';
+import { ref } from 'vue';
+
+const props = defineProps<{
+    filters: DashboardFilters;
+}>();
+
+const exporting = ref(false);
+
+function startExport(format: 'csv' | 'pdf') {
+    if (exporting.value) {
+        return;
+    }
+    exporting.value = true;
+
+    // Pass the dashboard filter set verbatim — the backend's
+    // ExportRequest reuses the same WithDashboardFilters trait
+    // the dashboard filter request uses, so empty keys + invalid
+    // values get rejected on the server.
+    const payload: Record<string, unknown> = { format, ...props.filters };
+
+    router.post(route('exports.store'), payload, {
+        preserveScroll: true,
+        preserveState: true,
+        // For the sync path the controller returns a streamed
+        // download — Inertia's onFinish still fires, the browser
+        // handles the file dialog out-of-band.
+        onFinish: () => {
+            exporting.value = false;
+        },
+    });
+}
+</script>
+
+<template>
+    <div class="flex items-center gap-1" data-testid="dashboard-export-dropdown">
+        <DropdownMenu>
+            <DropdownMenuTrigger as-child>
+                <Button variant="outline" size="sm" :disabled="exporting" data-testid="dashboard-export-trigger">
+                    <Download class="size-4" aria-hidden="true" />
+                    <span class="ml-2">Export</span>
+                </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end">
+                <DropdownMenuItem data-testid="dashboard-export-csv" @click="startExport('csv')"> Als CSV exportieren </DropdownMenuItem>
+                <DropdownMenuItem data-testid="dashboard-export-pdf" @click="startExport('pdf')"> Als PDF exportieren </DropdownMenuItem>
+            </DropdownMenuContent>
+        </DropdownMenu>
+
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger as-child>
+                    <button
+                        type="button"
+                        class="rounded-full p-1 text-muted-foreground transition hover:bg-muted hover:text-foreground"
+                        :aria-label="'Datenschutzhinweis zum Export'"
+                        data-testid="dashboard-export-gdpr-info"
+                    >
+                        <Info class="size-4" aria-hidden="true" />
+                    </button>
+                </TooltipTrigger>
+                <TooltipContent class="max-w-xs text-xs leading-relaxed">
+                    Der Export enthält personenbezogene Daten (Gast-Name, E-Mail, Telefon). Die Verarbeitung erfolgt nach der Datenschutzerklärung des
+                    Restaurants.
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    </div>
+</template>

--- a/resources/js/components/DashboardExportDropdown.vue
+++ b/resources/js/components/DashboardExportDropdown.vue
@@ -3,7 +3,6 @@ import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import type { DashboardFilters } from '@/types';
-import { router } from '@inertiajs/vue3';
 import { Download, Info } from 'lucide-vue-next';
 import { ref } from 'vue';
 
@@ -13,28 +12,65 @@ const props = defineProps<{
 
 const exporting = ref(false);
 
+/**
+ * Build a hidden HTML form and submit it so the browser handles
+ * the response natively. Inertia's `router.post` is XHR — it
+ * cannot trigger the save dialog when the controller returns a
+ * `StreamedResponse` for the sync path; the response would
+ * render as a non-Inertia error overlay instead. The async path
+ * returns a 302 redirect, which the browser follows back to the
+ * dashboard with the flash message intact.
+ */
+function appendField(form: HTMLFormElement, name: string, value: unknown): void {
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            appendField(form, `${name}[]`, item);
+        }
+
+        return;
+    }
+
+    if (value === null || value === undefined || value === '') {
+        return;
+    }
+
+    const input = document.createElement('input');
+    input.type = 'hidden';
+    input.name = name;
+    input.value = String(value);
+    form.appendChild(input);
+}
+
 function startExport(format: 'csv' | 'pdf') {
     if (exporting.value) {
         return;
     }
     exporting.value = true;
 
-    // Pass the dashboard filter set verbatim — the backend's
-    // ExportRequest reuses the same WithDashboardFilters trait
-    // the dashboard filter request uses, so empty keys + invalid
-    // values get rejected on the server.
-    const payload: Record<string, unknown> = { format, ...props.filters };
+    const form = document.createElement('form');
+    form.method = 'POST';
+    form.action = route('exports.store');
+    form.style.display = 'none';
 
-    router.post(route('exports.store'), payload, {
-        preserveScroll: true,
-        preserveState: true,
-        // For the sync path the controller returns a streamed
-        // download — Inertia's onFinish still fires, the browser
-        // handles the file dialog out-of-band.
-        onFinish: () => {
-            exporting.value = false;
-        },
-    });
+    const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
+    appendField(form, '_token', csrf);
+    appendField(form, 'format', format);
+
+    for (const [key, value] of Object.entries(props.filters)) {
+        appendField(form, key, value);
+    }
+
+    document.body.appendChild(form);
+    form.submit();
+
+    // Browser owns the response from here. Either a download
+    // dialog (sync) or a navigation back to the dashboard
+    // (async) — both leave us free to clean the form up after a
+    // short tick and re-enable the button.
+    setTimeout(() => {
+        form.remove();
+        exporting.value = false;
+    }, 500);
 }
 </script>
 

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import DashboardExportDropdown from '@/components/DashboardExportDropdown.vue';
 import ReservationThreadHistory from '@/components/ReservationThreadHistory.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -512,6 +513,7 @@ usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, pre
                     >
                         In Bearbeitung: <strong>{{ props.stats.in_review }}</strong>
                     </span>
+                    <DashboardExportDropdown :filters="props.filters" />
                 </div>
             </header>
 

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -4,6 +4,13 @@ declare module 'ziggy-js' {
     "home": [],
     "dashboard": [],
     "analytics.index": [],
+    "exports.store": [],
+    "exports.download": [
+        {
+            "name": "token",
+            "required": true
+        }
+    ],
     "reservations.show": [
         {
             "name": "reservation",

--- a/resources/views/app.blade.php
+++ b/resources/views/app.blade.php
@@ -3,6 +3,7 @@
     <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <meta name="csrf-token" content="{{ csrf_token() }}">
 
         <title inertia>{{ config('app.name', 'Laravel') }}</title>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,6 +23,10 @@ Route::get('analytics', [AnalyticsController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('analytics.index');
 
+Route::post('exports', [ExportController::class, 'store'])
+    ->middleware(['auth', 'verified'])
+    ->name('exports.store');
+
 Route::get('exports/download/{token}', [ExportController::class, 'download'])
     ->whereNumber('token')
     ->middleware(['auth', 'verified', 'signed'])

--- a/tests/Feature/Exports/ExportStoreTest.php
+++ b/tests/Feature/Exports/ExportStoreTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Exports;
+
+use App\Enums\ExportFormat;
+use App\Jobs\ExportReservationsJob;
+use App\Models\ExportAudit;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class ExportStoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('local');
+    }
+
+    private function userWithRestaurant(): User
+    {
+        return User::factory()
+            ->forRestaurant(Restaurant::factory()->create())
+            ->create();
+    }
+
+    public function test_unauthenticated_user_is_redirected(): void
+    {
+        $this->post('/exports', ['format' => 'csv'])->assertRedirect('/login');
+    }
+
+    public function test_user_without_restaurant_gets_404(): void
+    {
+        $user = User::factory()->create(['restaurant_id' => null]);
+
+        $this->actingAs($user)
+            ->post(route('exports.store'), ['format' => 'csv'])
+            ->assertNotFound();
+    }
+
+    public function test_invalid_format_fails_validation(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->from('/dashboard')
+            ->post(route('exports.store'), ['format' => 'xlsx'])
+            ->assertSessionHasErrors('format');
+    }
+
+    public function test_sync_path_returns_streamed_csv_for_small_result_set(): void
+    {
+        $user = $this->userWithRestaurant();
+        ReservationRequest::factory()->forRestaurant($user->restaurant)->count(5)->create();
+
+        $response = $this->actingAs($user)
+            ->post(route('exports.store'), ['format' => 'csv']);
+
+        $response->assertOk();
+        $response->assertHeader('Content-Type', 'text/csv; charset=UTF-8');
+
+        // Audit row written, sync path → no storage_path / no expiry.
+        $audit = ExportAudit::query()->where('user_id', $user->id)->sole();
+        $this->assertSame(5, $audit->record_count);
+        $this->assertSame(ExportFormat::Csv, $audit->format);
+        $this->assertNull($audit->storage_path);
+    }
+
+    public function test_async_path_dispatches_job_and_returns_redirect_with_flash(): void
+    {
+        Queue::fake();
+        $user = $this->userWithRestaurant();
+        ReservationRequest::factory()->forRestaurant($user->restaurant)->count(150)->create();
+
+        $response = $this->actingAs($user)
+            ->from('/dashboard')
+            ->post(route('exports.store'), ['format' => 'pdf']);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('flash.export');
+
+        Queue::assertPushed(ExportReservationsJob::class);
+    }
+
+    public function test_filters_pass_through_to_the_audit_snapshot(): void
+    {
+        $user = $this->userWithRestaurant();
+        ReservationRequest::factory()->forRestaurant($user->restaurant)->count(2)->create();
+
+        $this->actingAs($user)
+            ->post(route('exports.store'), [
+                'format' => 'csv',
+                'status' => ['confirmed'],
+                'q' => 'Geburtstag',
+            ])
+            ->assertOk();
+
+        $audit = ExportAudit::query()->where('user_id', $user->id)->sole();
+        $this->assertEqualsCanonicalizing(
+            ['status' => ['confirmed'], 'q' => 'Geburtstag'],
+            $audit->filter_snapshot->getArrayCopy(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Backend
- \`ExportController->store(ExportRequest, ExportDispatcher)\` returns the dispatcher's \`StreamedResponse | RedirectResponse\` directly. Tenant guard mirrors \`AnalyticsController\` — a user without a \`restaurant_id\` gets 404, so the FormRequest stays generic.
- Route \`POST /exports\` (auth + verified), named \`exports.store\`. Ziggy types regenerated.

Frontend
- \`resources/js/components/DashboardExportDropdown.vue\`: Reka-UI dropdown with \"Als CSV exportieren\" / \"Als PDF exportieren\" items + GDPR tooltip next to the trigger (\"Der Export enthält personenbezogene Daten …\"). Sends the active dashboard filter set verbatim — the backend's \`WithDashboardFilters\` trait validates the shared schema.
- Mounted in the dashboard header next to the existing Neu / In-Bearbeitung stat badges.

## Why

Issue #240 — last user-facing piece of PRD-009. The dispatcher (#236), generators (#237 / #238), and async pipeline (#239) are now reachable from the dashboard.

Closes #240

## Test plan

- [x] \`php artisan test --filter=ExportStoreTest\` (6 passed, 16 assertions)
- [x] \`php artisan test\` (785 passed)
- [x] \`./vendor/bin/pint --test\`
- [x] \`npm run lint\` + \`npm run format:check\`
- [x] \`npm run test\` (56 passed; the existing dashboard composable suite still green)
- [x] \`php artisan ziggy:generate --types-only resources/js/ziggy.d.ts\`

Test coverage: unauth redirect; tenantless user → 404; invalid format → validation error; sync path streams CSV + writes audit; async path dispatches job + flash message; filter snapshot round-trips into the audit's \`filter_snapshot\`.