### PR TITLE
Cross-tenant export tests at the controller boundary (#242)

### DIFF
--- a/tests/Feature/Exports/ExportStoreTest.php
+++ b/tests/Feature/Exports/ExportStoreTest.php
@@ -135,7 +135,9 @@ class ExportStoreTest extends TestCase
         ReservationRequest::factory()->forRestaurant($foreign)->count(50)->create();
 
         $this->actingAs($own)
-            ->post(route('exports.store'), ['format' => 'pdf']);
+            ->from('/dashboard')
+            ->post(route('exports.store'), ['format' => 'pdf'])
+            ->assertRedirect();
 
         $audit = ExportAudit::query()->where('user_id', $own->id)->sole();
         $this->assertSame($own->restaurant_id, $audit->restaurant_id);

--- a/tests/Feature/Exports/ExportStoreTest.php
+++ b/tests/Feature/Exports/ExportStoreTest.php
@@ -90,6 +90,63 @@ class ExportStoreTest extends TestCase
         Queue::assertPushed(ExportReservationsJob::class);
     }
 
+    public function test_sync_export_does_not_include_rows_from_another_restaurant(): void
+    {
+        $own = $this->userWithRestaurant();
+        ReservationRequest::factory()
+            ->forRestaurant($own->restaurant)
+            ->create(['guest_name' => 'OwnGuest_'.uniqid()]);
+
+        // Foreign tenant's data must NOT appear in the export
+        // payload, even though both restaurants live in the same
+        // table — the generator runs through `withoutGlobalScopes`
+        // + explicit `where('restaurant_id', ...)` from the user's
+        // restaurant.
+        $foreign = Restaurant::factory()->create();
+        ReservationRequest::factory()
+            ->forRestaurant($foreign)
+            ->count(3)
+            ->create(['guest_name' => 'ForeignGuest_'.uniqid()]);
+
+        $response = $this->actingAs($own)
+            ->post(route('exports.store'), ['format' => 'csv']);
+
+        $response->assertOk();
+
+        ob_start();
+        $response->sendContent();
+        $payload = (string) ob_get_clean();
+
+        $this->assertStringContainsString('OwnGuest_', $payload);
+        $this->assertStringNotContainsString('ForeignGuest_', $payload);
+    }
+
+    public function test_async_export_audit_carries_only_the_callers_restaurant_id(): void
+    {
+        Queue::fake();
+
+        $own = $this->userWithRestaurant();
+        ReservationRequest::factory()->forRestaurant($own->restaurant)->count(150)->create();
+
+        // A foreign restaurant exists in the table; the audit row
+        // and the queued job's `restaurantId` must reference the
+        // caller's tenant only.
+        $foreign = Restaurant::factory()->create();
+        ReservationRequest::factory()->forRestaurant($foreign)->count(50)->create();
+
+        $this->actingAs($own)
+            ->post(route('exports.store'), ['format' => 'pdf']);
+
+        $audit = ExportAudit::query()->where('user_id', $own->id)->sole();
+        $this->assertSame($own->restaurant_id, $audit->restaurant_id);
+        $this->assertSame(150, $audit->record_count);
+
+        Queue::assertPushed(
+            ExportReservationsJob::class,
+            fn ($job) => $job->restaurantId === $own->restaurant_id,
+        );
+    }
+
     public function test_filters_pass_through_to_the_audit_snapshot(): void
     {
         $user = $this->userWithRestaurant();


### PR DESCRIPTION
## Summary

Consolidation closure for PRD-009. Every test-file required by the issue's AC already exists from the upstream PRs (#234 model, #235 request, #236 dispatcher, #237 CSV, #238 PDF, #239 async, #241 purge). The remaining gap was an explicit cross-tenant assertion at the **controller** boundary — the existing generator-level tests cover SQL scoping but didn't exercise the auth → \`ExportRequest\` → \`ExportController\` → \`ExportDispatcher\` → \`ExportAudit::open\` chain that resolves \`restaurant_id\` from the authenticated user.

Two new cases in \`tests/Feature/Exports/ExportStoreTest.php\`:

- \`test_sync_export_does_not_include_rows_from_another_restaurant\` — seeds rows in restaurant A and B, posts as A's user, asserts the streamed CSV payload contains A's guest names but not B's.
- \`test_async_export_audit_carries_only_the_callers_restaurant_id\` — same shape on the async path; the queued \`ExportReservationsJob\` must carry A's \`restaurantId\` even when B has rows in the same table.

These tests guard against a regression where someone might (e.g.) pull \`restaurant_id\` off the request body instead of off the user.

## Why

Issue #242 — closes the umbrella, completes PRD-009.

Closes #242

## Test plan

- [x] \`php artisan test --filter=ExportStoreTest\` (8 passed, 22 assertions)
- [x] \`php artisan test\` (787 passed)
- [x] \`./vendor/bin/pint --test\`