### PR TITLE
useNotifications composable for dashboard push/sound (#245)

### DIFF
--- a/resources/js/composables/useNotifications.test.ts
+++ b/resources/js/composables/useNotifications.test.ts
@@ -1,0 +1,186 @@
+import type { NotificationSettings } from '@/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { useNotifications } from './useNotifications';
+
+function makeSettings(overrides: Partial<NotificationSettings> = {}): NotificationSettings {
+    return {
+        browser_notifications: false,
+        sound_alerts: false,
+        sound: 'default',
+        volume: 70,
+        daily_digest: true,
+        daily_digest_at: '18:00',
+        ...overrides,
+    };
+}
+
+const NotificationConstructor = vi.fn();
+const requestPermissionMock = vi.fn();
+
+class FakeAudio {
+    public volume = 1;
+    public src: string;
+
+    private resolution: 'fulfilled' | 'rejected' = 'fulfilled';
+
+    static lastInstance: FakeAudio | null = null;
+
+    static rejectNext = false;
+
+    constructor(src: string) {
+        this.src = src;
+        FakeAudio.lastInstance = this;
+        if (FakeAudio.rejectNext) {
+            this.resolution = 'rejected';
+            FakeAudio.rejectNext = false;
+        }
+    }
+
+    play(): Promise<void> {
+        return this.resolution === 'rejected' ? Promise.reject(new Error('NotAllowedError: user gesture missing')) : Promise.resolve();
+    }
+}
+
+beforeEach(() => {
+    NotificationConstructor.mockReset();
+    requestPermissionMock.mockReset();
+    FakeAudio.lastInstance = null;
+    FakeAudio.rejectNext = false;
+
+    // Wire a Notification stub so `new Notification(...)` records
+    // the constructor args, and `.permission` / `.requestPermission`
+    // can be controlled per-test.
+    const stub = function Notification(this: unknown, title: string, options?: NotificationOptions) {
+        NotificationConstructor(title, options);
+    } as unknown as typeof window.Notification & {
+        permission: Permission;
+        requestPermission: () => Promise<Permission>;
+    };
+    type Permission = 'default' | 'granted' | 'denied';
+    stub.permission = 'default';
+    stub.requestPermission = requestPermissionMock;
+
+    Object.defineProperty(window, 'Notification', {
+        configurable: true,
+        writable: true,
+        value: stub,
+    });
+
+    Object.defineProperty(window, 'Audio', {
+        configurable: true,
+        writable: true,
+        value: FakeAudio,
+    });
+});
+
+afterEach(() => {
+    // happy-dom keeps the property between tests; explicit delete
+    // is the cleanest way to model "Notification API unavailable".
+    Reflect.deleteProperty(window, 'Notification');
+    Reflect.deleteProperty(window, 'Audio');
+});
+
+describe('useNotifications', () => {
+    it('does not call Notification when browser_notifications is off', () => {
+        (window.Notification as unknown as { permission: string }).permission = 'granted';
+        const settings = ref(makeSettings({ browser_notifications: false }));
+
+        const handle = useNotifications(settings);
+        handle.notify('hi');
+
+        expect(NotificationConstructor).not.toHaveBeenCalled();
+    });
+
+    it('does not call Notification when permission is not granted', () => {
+        (window.Notification as unknown as { permission: string }).permission = 'denied';
+        const settings = ref(makeSettings({ browser_notifications: true }));
+
+        const handle = useNotifications(settings);
+        handle.notify('hi');
+
+        expect(NotificationConstructor).not.toHaveBeenCalled();
+    });
+
+    it('triggers Notification with correct title when allowed', () => {
+        (window.Notification as unknown as { permission: string }).permission = 'granted';
+        const settings = ref(makeSettings({ browser_notifications: true }));
+
+        const handle = useNotifications(settings);
+        handle.notify('Neue Reservierung', { body: 'Anna Müller, 4 Personen' });
+
+        expect(NotificationConstructor).toHaveBeenCalledTimes(1);
+        expect(NotificationConstructor).toHaveBeenCalledWith('Neue Reservierung', { body: 'Anna Müller, 4 Personen' });
+    });
+
+    it('returns denied permission when Notification API is undefined', () => {
+        Reflect.deleteProperty(window, 'Notification');
+        const settings = ref(makeSettings({ browser_notifications: true }));
+
+        const handle = useNotifications(settings);
+
+        expect(handle.permission.value).toBe('denied');
+        // notify() must also no-op without throwing.
+        handle.notify('hi');
+        expect(NotificationConstructor).not.toHaveBeenCalled();
+    });
+
+    it('updates the permission ref when the user grants the request', async () => {
+        (window.Notification as unknown as { permission: string }).permission = 'default';
+        requestPermissionMock.mockResolvedValueOnce('granted');
+        const settings = ref(makeSettings());
+
+        const handle = useNotifications(settings);
+        const result = await handle.requestPermission();
+
+        expect(result).toBe('granted');
+        expect(handle.permission.value).toBe('granted');
+    });
+
+    it('does not throw when audio.play rejects', async () => {
+        FakeAudio.rejectNext = true;
+        const settings = ref(makeSettings({ sound_alerts: true }));
+
+        const handle = useNotifications(settings);
+
+        expect(() => handle.playSound()).not.toThrow();
+        // Flush microtasks so the swallowed rejection settles
+        // before the test ends — without this, vitest's
+        // unhandledRejection guard could still fire.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    it('does not call Audio when sound_alerts is off', () => {
+        const settings = ref(makeSettings({ sound_alerts: false }));
+
+        const handle = useNotifications(settings);
+        handle.playSound();
+
+        expect(FakeAudio.lastInstance).toBeNull();
+    });
+
+    it('clamps volume to [0, 1]', () => {
+        const settings = ref(makeSettings({ sound_alerts: true, volume: 150 }));
+
+        useNotifications(settings).playSound();
+        expect(FakeAudio.lastInstance?.volume).toBe(1);
+
+        FakeAudio.lastInstance = null;
+        settings.value = makeSettings({ sound_alerts: true, volume: -25 });
+        useNotifications(settings).playSound();
+        expect(FakeAudio.lastInstance?.volume).toBe(0);
+
+        FakeAudio.lastInstance = null;
+        settings.value = makeSettings({ sound_alerts: true, volume: 50 });
+        useNotifications(settings).playSound();
+        expect(FakeAudio.lastInstance?.volume).toBe(0.5);
+    });
+
+    it('uses the soundKey override when supplied', () => {
+        const settings = ref(makeSettings({ sound_alerts: true, sound: 'default' }));
+
+        useNotifications(settings).playSound('chime');
+
+        expect(FakeAudio.lastInstance?.src).toBe('/sounds/chime.mp3');
+    });
+});

--- a/resources/js/composables/useNotifications.ts
+++ b/resources/js/composables/useNotifications.ts
@@ -1,0 +1,112 @@
+import type { NotificationSettings } from '@/types';
+import { ref, type Ref } from 'vue';
+
+type Permission = 'default' | 'granted' | 'denied';
+
+export interface UseNotificationsHandle {
+    /** Reactive snapshot of the browser's Notification permission. */
+    permission: Ref<Permission>;
+    /**
+     * Request browser-notification permission from the user. Resolves
+     * to the new permission state. No-ops (and resolves to `'denied'`)
+     * when the Notification API isn't available — happy-dom in tests,
+     * older Safari versions, etc.
+     */
+    requestPermission(): Promise<Permission>;
+    /**
+     * Show a browser notification — but only when the user opted in
+     * (`settings.browser_notifications`) AND the browser actually
+     * granted permission. All other cases are silent so the
+     * dashboard polling loop can call `notify()` unconditionally
+     * without checking guards itself.
+     */
+    notify(title: string, options?: NotificationOptions): void;
+    /**
+     * Play one of the bundled `/sounds/{key}.mp3` files. Silent when
+     * the user opted out via `settings.sound_alerts`. The volume from
+     * settings is clamped to [0, 1] so a corrupt JSON value can't
+     * blow out the user's speakers.
+     *
+     * `audio.play()` returns a Promise that rejects when the browser
+     * blocks the playback (typically: no user gesture has happened
+     * yet). The rejection is intentionally swallowed — surfacing it
+     * as a UI error would be louder than the silence the user
+     * experiences.
+     */
+    playSound(soundKey?: string): void;
+}
+
+function readPermission(): Permission {
+    if (typeof window === 'undefined' || typeof window.Notification === 'undefined') {
+        return 'denied';
+    }
+
+    return window.Notification.permission as Permission;
+}
+
+function clampVolume(percent: number): number {
+    if (Number.isNaN(percent)) {
+        return 0;
+    }
+
+    const ratio = percent / 100;
+    if (ratio < 0) return 0;
+    if (ratio > 1) return 1;
+    return ratio;
+}
+
+export function useNotifications(settings: Ref<NotificationSettings>): UseNotificationsHandle {
+    const permission = ref<Permission>(readPermission());
+
+    async function requestPermission(): Promise<Permission> {
+        if (typeof window === 'undefined' || typeof window.Notification === 'undefined') {
+            permission.value = 'denied';
+            return 'denied';
+        }
+
+        const next = await window.Notification.requestPermission();
+        permission.value = next as Permission;
+        return permission.value;
+    }
+
+    function notify(title: string, options?: NotificationOptions): void {
+        if (!settings.value.browser_notifications) {
+            return;
+        }
+        if (typeof window === 'undefined' || typeof window.Notification === 'undefined') {
+            return;
+        }
+        if (permission.value !== 'granted') {
+            return;
+        }
+
+        // Construct directly — Notification is a side-effect API,
+        // we don't need the instance for anything.
+        new window.Notification(title, options);
+    }
+
+    function playSound(soundKey?: string): void {
+        if (!settings.value.sound_alerts) {
+            return;
+        }
+        if (typeof window === 'undefined' || typeof window.Audio === 'undefined') {
+            return;
+        }
+
+        const key = soundKey ?? settings.value.sound ?? 'default';
+        const audio = new window.Audio(`/sounds/${key}.mp3`);
+        audio.volume = clampVolume(settings.value.volume);
+
+        const result = audio.play();
+        if (result && typeof result.then === 'function') {
+            result.catch(() => {
+                // Browser blocked playback (no user gesture yet,
+                // hidden tab, autoplay policy). The composable's
+                // contract is "fire and forget" — do not surface
+                // a UI error here.
+            });
+        }
+    }
+
+    return { permission, requestPermission, notify, playSound };
+}

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -104,6 +104,15 @@ export interface DashboardStats {
     in_review: number;
 }
 
+export interface NotificationSettings {
+    browser_notifications: boolean;
+    sound_alerts: boolean;
+    sound: string;
+    volume: number;
+    daily_digest: boolean;
+    daily_digest_at: string;
+}
+
 export type ReservationReplyStatus = 'draft' | 'approved' | 'sent' | 'failed' | 'shadow' | 'scheduled_auto_send' | 'cancelled_auto';
 
 export type SendMode = 'manual' | 'shadow' | 'auto';


### PR DESCRIPTION
## Summary

- New \`resources/js/composables/useNotifications.ts\` wraps the Browser Notifications API and \`HTMLAudioElement\` for the dashboard's PRD-010 layer. Returns \`{ permission, requestPermission, notify, playSound }\`.
- Defensive on three axes:
  1. Missing API (test environments / older Safari): \`Notification\` / \`Audio\` may be undefined. The composable falls back to \`'denied'\` and no-ops instead of throwing.
  2. User opt-out: \`notify\` is silent when \`settings.browser_notifications === false\`; \`playSound\` is silent when \`settings.sound_alerts === false\`. The dashboard polling loop can call them unconditionally.
  3. Browser autoplay policy: \`audio.play()\` rejection is intentionally swallowed (no UI error).
- Volume clamped to \`[0, 1]\` so a corrupt \`volume\` JSON value can't blow out the user's speakers.
- New \`NotificationSettings\` interface in \`resources/js/types/index.ts\`.

## Why

Issue #245 — the frontend wrapper that #248 (dashboard polling diff trigger) and #246 (settings page test-sound button) will both call.

Closes #245

## Test plan

- [x] \`npx vitest run resources/js/composables/useNotifications.test.ts\` (9 passed)
- [x] \`npm run test\` (65 passed; the existing composable suites still green)
- [x] \`npm run lint\` + \`npm run format:check\`
- [x] \`php artisan test\` (793 passed; backend unaffected)
- [x] \`./vendor/bin/pint --test\`

Test cases: opt-out short-circuits; permission-not-granted short-circuit; happy-path notification; missing Notification API returns \`denied\`; \`requestPermission\` updates the ref; \`audio.play\` rejection is swallowed; sound_alerts opt-out skips Audio instantiation; volume clamp on \`>100\` / \`<0\` / mid range; soundKey override picks the right \`/sounds/{key}.mp3\` path.