### PR TITLE
Notification-settings backend + stub Vue page (#247)

### DIFF
--- a/app/Http/Controllers/Settings/NotificationSettingsController.php
+++ b/app/Http/Controllers/Settings/NotificationSettingsController.php
@@ -40,12 +40,23 @@ final class NotificationSettingsController extends Controller
             abort(403);
         }
 
-        // Merge over the defaults so future PRD-010 keys land
-        // gracefully without rewriting this controller every time
-        // a sibling issue extends the settings shape.
+        // Merge the validated form fields over the *existing*
+        // stored value (read raw to bypass the accessor's
+        // default-merge), then layer NotificationSettings::merge
+        // for the default-floor on top. Without the existing-value
+        // step, a future sibling issue that adds a new key (e.g.
+        // an `email_digest` flag) would silently lose its value
+        // every time the operator saves the 6-field UI — the form
+        // payload wouldn't carry the new key, and merge-over-
+        // defaults would drop the stored value.
+        $existing = (array) json_decode(
+            (string) ($user->getRawOriginal('notification_settings') ?? '{}'),
+            true,
+        );
+
         $user->forceFill([
             'notification_settings' => NotificationSettings::merge(
-                $request->validated()
+                [...$existing, ...$request->validated()],
             ),
         ])->save();
 

--- a/app/Http/Controllers/Settings/NotificationSettingsController.php
+++ b/app/Http/Controllers/Settings/NotificationSettingsController.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\UpdateNotificationSettingsRequest;
+use App\Services\Notifications\NotificationSettings;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * PRD-010 § Datenmodell + Permission-Flow.
+ *
+ * Lets the authenticated user view and update their own
+ * notification preferences. Cross-user edits are structurally
+ * impossible — the controller never reads a target id off the
+ * request body; it always operates on `$request->user()`.
+ */
+final class NotificationSettingsController extends Controller
+{
+    public function edit(): Response
+    {
+        $user = auth()->user();
+
+        return Inertia::render('settings/Notifications', [
+            'settings' => $user?->notification_settings ?? NotificationSettings::default(),
+        ]);
+    }
+
+    public function update(UpdateNotificationSettingsRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        if ($user === null) {
+            // Should be unreachable because the route is auth-gated;
+            // the explicit guard makes the type narrowing
+            // unambiguous for static analysis.
+            abort(403);
+        }
+
+        // Merge over the defaults so future PRD-010 keys land
+        // gracefully without rewriting this controller every time
+        // a sibling issue extends the settings shape.
+        $user->forceFill([
+            'notification_settings' => NotificationSettings::merge(
+                $request->validated()
+            ),
+        ])->save();
+
+        return back()->with('status', 'notification-settings-updated');
+    }
+}

--- a/app/Http/Requests/Settings/UpdateNotificationSettingsRequest.php
+++ b/app/Http/Requests/Settings/UpdateNotificationSettingsRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a partial update to the authenticated user's
+ * notification preferences (PRD-010).
+ *
+ * Authorization is implicit: the route only ever updates
+ * `auth()->user()`, so there's no target id to gate. Cross-user
+ * edits are mathematically impossible because the controller
+ * never reads a user id off the request body.
+ */
+class UpdateNotificationSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'browser_notifications' => ['required', 'boolean'],
+            'sound_alerts' => ['required', 'boolean'],
+            'sound' => ['required', Rule::in(['default', 'chime', 'tap'])],
+            'volume' => ['required', 'integer', 'min:0', 'max:100'],
+            'daily_digest' => ['required', 'boolean'],
+            // HH:MM in 24-hour format. Per PRD-010 the digest job
+            // wakes hourly and matches against this string, so the
+            // `:` separator and zero-padding are part of the contract.
+            'daily_digest_at' => ['required', 'string', 'regex:/^([01]\d|2[0-3]):[0-5]\d$/'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'sound.in' => 'Diese Sound-Auswahl ist nicht verfügbar.',
+            'volume.integer' => 'Die Lautstärke muss eine ganze Zahl sein.',
+            'volume.min' => 'Die Lautstärke darf nicht negativ sein.',
+            'volume.max' => 'Die Lautstärke darf höchstens 100 % betragen.',
+            'daily_digest_at.regex' => 'Bitte eine Uhrzeit im Format HH:MM angeben.',
+        ];
+    }
+}

--- a/resources/js/pages/settings/Notifications.vue
+++ b/resources/js/pages/settings/Notifications.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import AppLayout from '@/layouts/AppLayout.vue';
+import { type BreadcrumbItem, type NotificationSettings } from '@/types';
+import { Head } from '@inertiajs/vue3';
+
+defineProps<{
+    settings: NotificationSettings;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [
+    { title: 'Einstellungen', href: '/settings/profile' },
+    { title: 'Benachrichtigungen', href: '/settings/notifications' },
+];
+</script>
+
+<template>
+    <Head title="Benachrichtigungen" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="flex flex-col gap-4 p-6">
+            <h1 class="text-2xl font-semibold">Benachrichtigungen</h1>
+            <p class="text-sm text-muted-foreground">
+                Browser-Push, Sound-Alerts und der tägliche Digest. Die Detail-UI mit dem "Sound testen"-Button und dem Permission-Flow landet in
+                #246.
+            </p>
+            <pre class="rounded-md bg-muted p-3 text-xs">{{ JSON.stringify(settings, null, 2) }}</pre>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -81,6 +81,8 @@ declare module 'ziggy-js' {
     "appearance": [],
     "settings.send-mode.edit": [],
     "settings.send-mode.update": [],
+    "settings.notifications.edit": [],
+    "settings.notifications.update": [],
     "register": [],
     "login": [],
     "password.request": [],

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\NotificationSettingsController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SendModeSettingsController;
@@ -24,4 +25,9 @@ Route::middleware('auth')->group(function () {
         ->name('settings.send-mode.edit');
     Route::patch('settings/send-mode', [SendModeSettingsController::class, 'update'])
         ->name('settings.send-mode.update');
+
+    Route::get('settings/notifications', [NotificationSettingsController::class, 'edit'])
+        ->name('settings.notifications.edit');
+    Route::put('settings/notifications', [NotificationSettingsController::class, 'update'])
+        ->name('settings.notifications.update');
 });

--- a/tests/Feature/Notifications/SettingsTest.php
+++ b/tests/Feature/Notifications/SettingsTest.php
@@ -146,6 +146,35 @@ class SettingsTest extends TestCase
             ->assertSessionHasErrors('daily_digest_at');
     }
 
+    public function test_save_preserves_unknown_stored_keys_from_future_features(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        // Simulate a forward-compat scenario: a future PRD-010
+        // sibling issue stored a key (`email_digest`) that the
+        // current 6-field form doesn't surface. The save flow
+        // must keep that value intact.
+        $user->forceFill([
+            'notification_settings' => [
+                'browser_notifications' => true,
+                'email_digest' => true,
+                'email_digest_at' => '07:30',
+            ],
+        ])->save();
+
+        $this->actingAs($user)
+            ->put(route('settings.notifications.update'), $this->payload([
+                'browser_notifications' => false,
+            ]))
+            ->assertRedirect();
+
+        $stored = User::query()->find($user->id)->notification_settings;
+        $this->assertFalse($stored['browser_notifications']);
+        // Unknown stored keys still present after the save.
+        $this->assertTrue($stored['email_digest']);
+        $this->assertSame('07:30', $stored['email_digest_at']);
+    }
+
     public function test_authenticated_user_only_modifies_their_own_settings(): void
     {
         $own = $this->userWithRestaurant();

--- a/tests/Feature/Notifications/SettingsTest.php
+++ b/tests/Feature/Notifications/SettingsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function userWithRestaurant(): User
+    {
+        return User::factory()
+            ->forRestaurant(Restaurant::factory()->create())
+            ->create();
+    }
+
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'browser_notifications' => true,
+            'sound_alerts' => true,
+            'sound' => 'chime',
+            'volume' => 60,
+            'daily_digest' => true,
+            'daily_digest_at' => '09:30',
+        ], $overrides);
+    }
+
+    public function test_guests_are_redirected_to_login(): void
+    {
+        $this->put(route('settings.notifications.update'), $this->payload())
+            ->assertRedirect('/login');
+    }
+
+    public function test_it_persists_notification_settings(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->from(route('settings.notifications.edit'))
+            ->put(route('settings.notifications.update'), $this->payload([
+                'browser_notifications' => true,
+                'sound_alerts' => true,
+                'sound' => 'tap',
+                'volume' => 45,
+                'daily_digest' => false,
+                'daily_digest_at' => '20:00',
+            ]))
+            ->assertRedirect()
+            ->assertSessionHas('status', 'notification-settings-updated');
+
+        $stored = User::query()->find($user->id)->notification_settings;
+        $this->assertTrue($stored['browser_notifications']);
+        $this->assertTrue($stored['sound_alerts']);
+        $this->assertSame('tap', $stored['sound']);
+        $this->assertSame(45, $stored['volume']);
+        $this->assertFalse($stored['daily_digest']);
+        $this->assertSame('20:00', $stored['daily_digest_at']);
+    }
+
+    public function test_it_merges_defaults_for_missing_keys_in_storage(): void
+    {
+        $user = $this->userWithRestaurant();
+        $user->forceFill([
+            'notification_settings' => ['sound_alerts' => true],
+        ])->save();
+        $user->refresh();
+
+        // The accessor backfills the missing keys from defaults.
+        $this->assertTrue($user->notification_settings['sound_alerts']);
+        $this->assertFalse($user->notification_settings['browser_notifications']);
+        $this->assertSame(70, $user->notification_settings['volume']);
+        $this->assertSame('18:00', $user->notification_settings['daily_digest_at']);
+    }
+
+    public function test_settings_page_renders_defaults_for_a_fresh_user(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->get(route('settings.notifications.edit'))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('settings/Notifications')
+                ->where('settings.browser_notifications', false)
+                ->where('settings.sound_alerts', false)
+                ->where('settings.daily_digest', true)
+                ->where('settings.daily_digest_at', '18:00')
+                ->etc()
+            );
+    }
+
+    public function test_validation_rejects_volume_above_100(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->from(route('settings.notifications.edit'))
+            ->put(route('settings.notifications.update'), $this->payload(['volume' => 250]))
+            ->assertSessionHasErrors('volume');
+    }
+
+    public function test_validation_rejects_negative_volume(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->from(route('settings.notifications.edit'))
+            ->put(route('settings.notifications.update'), $this->payload(['volume' => -5]))
+            ->assertSessionHasErrors('volume');
+    }
+
+    public function test_validation_rejects_unknown_sound_choice(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->from(route('settings.notifications.edit'))
+            ->put(route('settings.notifications.update'), $this->payload(['sound' => 'siren']))
+            ->assertSessionHasErrors('sound');
+    }
+
+    public function test_validation_rejects_invalid_time_format(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->from(route('settings.notifications.edit'))
+            ->put(route('settings.notifications.update'), $this->payload(['daily_digest_at' => '7am']))
+            ->assertSessionHasErrors('daily_digest_at');
+    }
+
+    public function test_validation_rejects_25_00_as_daily_digest_at(): void
+    {
+        $user = $this->userWithRestaurant();
+
+        $this->actingAs($user)
+            ->from(route('settings.notifications.edit'))
+            ->put(route('settings.notifications.update'), $this->payload(['daily_digest_at' => '25:00']))
+            ->assertSessionHasErrors('daily_digest_at');
+    }
+
+    public function test_authenticated_user_only_modifies_their_own_settings(): void
+    {
+        $own = $this->userWithRestaurant();
+        $other = $this->userWithRestaurant();
+
+        $this->actingAs($own)
+            ->put(route('settings.notifications.update'), $this->payload([
+                'browser_notifications' => true,
+            ]));
+
+        $own->refresh();
+        $other->refresh();
+
+        $this->assertTrue($own->notification_settings['browser_notifications']);
+        // Sibling user's settings stay at defaults — false — even
+        // though the request body had no user id at all (the
+        // controller only ever updates auth()->user()).
+        $this->assertFalse($other->notification_settings['browser_notifications']);
+    }
+}


### PR DESCRIPTION
## Summary

- Routes \`GET\` / \`PUT /settings/notifications\` (auth-gated), named \`settings.notifications.edit\` / \`.update\`.
- \`App\\Http\\Controllers\\Settings\\NotificationSettingsController\`: \`edit()\` renders the settings page with the merged shape; \`update()\` merges validated input through \`NotificationSettings::merge\` and persists. Cross-user edits are structurally impossible — the controller never reads a target id off the request, only operates on \`\$request->user()\`.
- \`UpdateNotificationSettingsRequest\` validates the six PRD-010 keys: booleans for opt-in flags, sound \`Rule::in([default, chime, tap])\`, volume \`0..100\`, \`daily_digest_at\` HH:MM regex.
- Stub \`settings/Notifications.vue\` so the GET route renders an Inertia page; the full UI (permission flow, sound-test button, save form) lands in #246.
- Ziggy types regenerated.

## Why

Issue #247 — backend foundation for the PRD-010 settings page. Sibling #246 will replace the stub with the real UI.

Closes #247

## Test plan

- [x] \`php artisan test --filter=Tests\\Feature\\Notifications\\SettingsTest\` (10 passed, 44 assertions)
- [x] \`php artisan test\` (803 passed)
- [x] \`./vendor/bin/pint --test\`
- [x] \`npm run lint\` + \`npm run format:check\`
- [x] \`npm run test\` (65 passed; existing composable / page suites still green)

Test coverage: guest redirect; happy path persists + flashes status; the User model's accessor merges defaults for missing storage keys; \`edit()\` renders defaults for a fresh user; volume range (>100, <0); unknown sound rejected; HH:MM regex rejects \`7am\` and \`25:00\`; cross-user edit attempt only updates the caller's row.