### PR TITLE
Add dashboard polling diff trigger for notifications + sound (#248)

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -42,6 +42,18 @@ class User extends Authenticatable
     ];
 
     /**
+     * Accessors that should always appear in the array / JSON shape.
+     * `notification_settings` is read by the dashboard composable
+     * (PRD-010 #248) and the settings page; both require the merged
+     * shape, not the raw column.
+     *
+     * @var list<string>
+     */
+    protected $appends = [
+        'notification_settings',
+    ];
+
+    /**
      * Get the attributes that should be cast.
      *
      * @return array<string, string>

--- a/resources/js/composables/useReservationDiffTrigger.test.ts
+++ b/resources/js/composables/useReservationDiffTrigger.test.ts
@@ -112,6 +112,29 @@ describe('useReservationDiffTrigger', () => {
         });
     });
 
+    it('notifies when the very first reservation arrives on an empty dashboard', async () => {
+        // Regression: an earlier `previousIds.size === 0` check treated
+        // the second watcher fire as another "first load" if the page
+        // started empty, swallowing the most important alert.
+        rowIds.value = [];
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+
+        rowIds.value = [42];
+        await nextTick();
+
+        expect(handle._notify).toHaveBeenCalledTimes(1);
+        expect(handle._notify).toHaveBeenCalledWith('Neue Reservierungsanfrage', {
+            body: '1 neue Anfrage – jetzt anschauen',
+            tag: 'reservation-agent-new-request',
+        });
+        expect(handle._play).toHaveBeenCalledTimes(1);
+    });
+
     it('does not notify when the same ids are polled again (no diff)', async () => {
         rowIds.value = [1, 2, 3];
         useReservationDiffTrigger(

--- a/resources/js/composables/useReservationDiffTrigger.test.ts
+++ b/resources/js/composables/useReservationDiffTrigger.test.ts
@@ -1,0 +1,175 @@
+import type { UseNotificationsHandle } from '@/composables/useNotifications';
+import type { DashboardFilters } from '@/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick, ref } from 'vue';
+import { useReservationDiffTrigger } from './useReservationDiffTrigger';
+
+function fakeHandle(): UseNotificationsHandle & { _notify: ReturnType<typeof vi.fn>; _play: ReturnType<typeof vi.fn> } {
+    const notify = vi.fn();
+    const play = vi.fn();
+    return {
+        permission: ref('granted') as unknown as UseNotificationsHandle['permission'],
+        requestPermission: vi.fn(),
+        notify: notify as UseNotificationsHandle['notify'],
+        playSound: play as UseNotificationsHandle['playSound'],
+        _notify: notify,
+        _play: play,
+    } as UseNotificationsHandle & { _notify: ReturnType<typeof vi.fn>; _play: ReturnType<typeof vi.fn> };
+}
+
+describe('useReservationDiffTrigger', () => {
+    let rowIds: ReturnType<typeof ref<readonly number[]>>;
+    let filters: ReturnType<typeof ref<DashboardFilters>>;
+    let handle: ReturnType<typeof fakeHandle>;
+
+    beforeEach(() => {
+        rowIds = ref<readonly number[]>([]);
+        filters = ref<DashboardFilters>({});
+        handle = fakeHandle();
+    });
+
+    it('does not notify on initial load', async () => {
+        rowIds.value = [10, 11, 12];
+
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+
+        expect(handle._notify).not.toHaveBeenCalled();
+        expect(handle._play).not.toHaveBeenCalled();
+    });
+
+    it('notifies when polling adds new request ids', async () => {
+        rowIds.value = [10, 11];
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+        expect(handle._notify).not.toHaveBeenCalled();
+
+        // Simulate the next poll cycle returning a freshly inserted row.
+        rowIds.value = [10, 11, 42];
+        await nextTick();
+
+        expect(handle._notify).toHaveBeenCalledTimes(1);
+        expect(handle._notify).toHaveBeenCalledWith('Neue Reservierungsanfrage', {
+            body: '1 neue Anfrage – jetzt anschauen',
+            tag: 'reservation-agent-new-request',
+        });
+        expect(handle._play).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses the plural body when more than one new id arrives', async () => {
+        rowIds.value = [1];
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+
+        rowIds.value = [1, 2, 3, 4];
+        await nextTick();
+
+        expect(handle._notify).toHaveBeenCalledWith('Neue Reservierungsanfrage', {
+            body: '3 neue Anfragen – jetzt anschauen',
+            tag: 'reservation-agent-new-request',
+        });
+    });
+
+    it('does not notify on filter change even when the id set differs', async () => {
+        rowIds.value = [10, 11];
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+
+        // Operator switches a status chip — server returns a new id set
+        // (rows that already existed but were filtered out before).
+        filters.value = { status: ['confirmed'] };
+        rowIds.value = [50, 51, 52];
+        await nextTick();
+
+        expect(handle._notify).not.toHaveBeenCalled();
+        expect(handle._play).not.toHaveBeenCalled();
+
+        // After the filter is stable again, a polling cycle that adds a
+        // new id should notify normally.
+        rowIds.value = [50, 51, 52, 99];
+        await nextTick();
+
+        expect(handle._notify).toHaveBeenCalledTimes(1);
+        expect(handle._notify).toHaveBeenCalledWith('Neue Reservierungsanfrage', {
+            body: '1 neue Anfrage – jetzt anschauen',
+            tag: 'reservation-agent-new-request',
+        });
+    });
+
+    it('does not notify when the same ids are polled again (no diff)', async () => {
+        rowIds.value = [1, 2, 3];
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+
+        // Polling cycle with identical ids — common case in steady state.
+        rowIds.value = [1, 2, 3];
+        await nextTick();
+
+        expect(handle._notify).not.toHaveBeenCalled();
+        expect(handle._play).not.toHaveBeenCalled();
+    });
+
+    it('treats filter array reorder as no change (stable serializer)', async () => {
+        rowIds.value = [10];
+        filters.value = { status: ['new', 'confirmed'] };
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+
+        // Reorder the array — semantically identical filter snapshot.
+        filters.value = { status: ['confirmed', 'new'] };
+        rowIds.value = [10, 20];
+        await nextTick();
+
+        // The new id (20) must still trigger a notification because the
+        // filter snapshot did NOT change in any meaningful way.
+        expect(handle._notify).toHaveBeenCalledTimes(1);
+    });
+
+    it('notifies via the composable guards (suppression handled inside notify())', async () => {
+        // The composable always calls notify(); the guard against
+        // disabled browser_notifications lives inside the
+        // useNotifications handle. We verify the boundary here by
+        // simulating a handle whose `notify` is a no-op stub — the
+        // diff trigger calls it regardless, and the suppression test
+        // sits at the useNotifications layer.
+        rowIds.value = [1];
+        useReservationDiffTrigger(
+            rowIds as unknown as Parameters<typeof useReservationDiffTrigger>[0],
+            filters as unknown as Parameters<typeof useReservationDiffTrigger>[1],
+            handle,
+        );
+        await nextTick();
+
+        rowIds.value = [1, 2];
+        await nextTick();
+
+        // Both calls fire — the composable doesn't gate; the
+        // useNotifications handle does.
+        expect(handle._notify).toHaveBeenCalledTimes(1);
+        expect(handle._play).toHaveBeenCalledTimes(1);
+    });
+});

--- a/resources/js/composables/useReservationDiffTrigger.ts
+++ b/resources/js/composables/useReservationDiffTrigger.ts
@@ -1,0 +1,102 @@
+import type { UseNotificationsHandle } from '@/composables/useNotifications';
+import type { DashboardFilters } from '@/types';
+import { watch, type Ref } from 'vue';
+
+/**
+ * PRD-010 § Trigger im Dashboard.
+ *
+ * Watches a paginated list of reservation rows for *new* IDs that
+ * appeared between two server reloads (the dashboard polls every 30 s).
+ * Whenever a poll surfaces ids the previous snapshot did not contain
+ * AND the filter snapshot is unchanged, the operator gets a browser
+ * notification + the configured sound.
+ *
+ * Two intentional silences:
+ *
+ * 1. **First load.** `previousIds.size === 0` after mount means we have
+ *    nothing to diff against — populate the snapshot and stay quiet.
+ *    Without this guard every fresh dashboard tab would shout
+ *    "Neue Reservierungsanfrage" for every row already on screen.
+ *
+ * 2. **Filter change.** A status/source/date filter switch produces
+ *    a different ID set, but those rows are not "new" — they were
+ *    already in the database. We compare a stable JSON snapshot of
+ *    the filter object between calls; on change, we refresh the
+ *    `previousIds` snapshot and skip the diff evaluation entirely.
+ *
+ * The `tag` field on the notification is fixed (`'reservation-agent-new-request'`)
+ * so a slow operator doesn't accumulate a stack of system toasts —
+ * the OS replaces the previous one.
+ */
+export function useReservationDiffTrigger(
+    rowIds: Ref<readonly number[]>,
+    filters: Ref<DashboardFilters>,
+    notifications: UseNotificationsHandle,
+): void {
+    const previousIds = new Set<number>();
+    let previousFilterKey: string | null = null;
+
+    watch(
+        // Watch a stable string of ids so polling that returns the
+        // *same* ids doesn't fire a no-op diff over and over.
+        () => rowIds.value.join(','),
+        () => {
+            const currentIds = new Set(rowIds.value);
+            const filterKey = serializeFilters(filters.value);
+
+            const isFirstLoad = previousIds.size === 0;
+            // Treat filter changes as a snapshot reset, never as a
+            // notification trigger. The `previousFilterKey === null`
+            // guard makes the very first poll behave the same way:
+            // populate the baseline silently.
+            const filtersChanged = previousFilterKey !== null && previousFilterKey !== filterKey;
+
+            if (!isFirstLoad && !filtersChanged) {
+                const newIds: number[] = [];
+                for (const id of currentIds) {
+                    if (!previousIds.has(id)) {
+                        newIds.push(id);
+                    }
+                }
+                if (newIds.length > 0) {
+                    notifications.notify('Neue Reservierungsanfrage', {
+                        body: bodyForCount(newIds.length),
+                        tag: 'reservation-agent-new-request',
+                    });
+                    notifications.playSound();
+                }
+            }
+
+            previousIds.clear();
+            for (const id of currentIds) {
+                previousIds.add(id);
+            }
+            previousFilterKey = filterKey;
+        },
+        { immediate: true },
+    );
+}
+
+function bodyForCount(count: number): string {
+    if (count === 1) {
+        return '1 neue Anfrage – jetzt anschauen';
+    }
+    return `${count} neue Anfragen – jetzt anschauen`;
+}
+
+function serializeFilters(filters: DashboardFilters): string {
+    // JSON.stringify is order-sensitive; we explicitly sort the keys
+    // so a server response that re-orders them between polls (Laravel
+    // does, depending on how the DTO is built) doesn't read as a
+    // filter change and silently swallow a real diff trigger.
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(filters).sort()) {
+        const value = (filters as Record<string, unknown>)[key];
+        if (Array.isArray(value)) {
+            sorted[key] = [...value].sort();
+        } else {
+            sorted[key] = value;
+        }
+    }
+    return JSON.stringify(sorted);
+}

--- a/resources/js/composables/useReservationDiffTrigger.ts
+++ b/resources/js/composables/useReservationDiffTrigger.ts
@@ -13,10 +13,11 @@ import { watch, type Ref } from 'vue';
  *
  * Two intentional silences:
  *
- * 1. **First load.** `previousIds.size === 0` after mount means we have
- *    nothing to diff against — populate the snapshot and stay quiet.
- *    Without this guard every fresh dashboard tab would shout
- *    "Neue Reservierungsanfrage" for every row already on screen.
+ * 1. **First load.** A `hasBaseline` flag — *not* `previousIds.size === 0` —
+ *    delineates the very first watcher invocation from any later one.
+ *    The size-based check would silence the first reservation that
+ *    ever arrives on a dashboard that started empty, exactly the
+ *    scenario the operator most needs to hear about.
  *
  * 2. **Filter change.** A status/source/date filter switch produces
  *    a different ID set, but those rows are not "new" — they were
@@ -35,23 +36,31 @@ export function useReservationDiffTrigger(
 ): void {
     const previousIds = new Set<number>();
     let previousFilterKey: string | null = null;
+    // Explicit baseline flag instead of `previousIds.size === 0`.
+    // The dashboard regularly starts empty (a brand-new restaurant
+    // or an aggressive filter), and `Set.size` would lie about
+    // "first load" again on every subsequent empty-or-near-empty
+    // poll — silencing the first reservation that ever arrives.
+    let hasBaseline = false;
 
     watch(
         // Watch a stable string of ids so polling that returns the
-        // *same* ids doesn't fire a no-op diff over and over.
+        // *same* ids doesn't re-execute the diff. Filter-only
+        // changes that produce identical id sets fall through to the
+        // next genuine row change, which still detects the stale
+        // filter snapshot and resets the baseline silently.
         () => rowIds.value.join(','),
         () => {
             const currentIds = new Set(rowIds.value);
             const filterKey = serializeFilters(filters.value);
 
-            const isFirstLoad = previousIds.size === 0;
             // Treat filter changes as a snapshot reset, never as a
             // notification trigger. The `previousFilterKey === null`
             // guard makes the very first poll behave the same way:
             // populate the baseline silently.
             const filtersChanged = previousFilterKey !== null && previousFilterKey !== filterKey;
 
-            if (!isFirstLoad && !filtersChanged) {
+            if (hasBaseline && !filtersChanged) {
                 const newIds: number[] = [];
                 for (const id of currentIds) {
                     if (!previousIds.has(id)) {
@@ -72,6 +81,7 @@ export function useReservationDiffTrigger(
                 previousIds.add(id);
             }
             previousFilterKey = filterKey;
+            hasBaseline = true;
         },
         { immediate: true },
     );

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -8,7 +8,9 @@ import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { useCountdown } from '@/composables/useCountdown';
+import { useNotifications } from '@/composables/useNotifications';
 import { usePagePolling } from '@/composables/usePagePolling';
+import { useReservationDiffTrigger } from '@/composables/useReservationDiffTrigger';
 import { useRowSelection } from '@/composables/useRowSelection';
 import AppLayout from '@/layouts/AppLayout.vue';
 import { formatDateTime } from '@/lib/format-datetime';
@@ -17,6 +19,7 @@ import {
     type BreadcrumbItem,
     type DashboardFilters,
     type DashboardStats,
+    type NotificationSettings,
     type PaginatedReservationRequests,
     type ReservationRequestDetail,
     type ReservationSource,
@@ -456,6 +459,15 @@ function pollOnly(): string[] {
 }
 
 usePagePolling(() => router.reload({ only: pollOnly(), preserveScroll: true, preserveState: true }), POLL_MS);
+
+// PRD-010 § Trigger im Dashboard. Hooks the polling-driven row updates
+// into a notification + sound trigger. The composable refuses to fire
+// on the initial page load and on filter changes — see its docblock.
+const liveNotificationSettings = computed<NotificationSettings>(() => page.props.auth.user.notification_settings);
+const notifications = useNotifications(liveNotificationSettings);
+const dashboardRowIds = computed<readonly number[]>(() => props.requests.data.map((row) => row.id));
+const dashboardFilters = computed<DashboardFilters>(() => props.filters);
+useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
 </script>
 
 <template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -47,6 +47,7 @@ export interface User {
     email_verified_at: string | null;
     restaurant_id: number | null;
     role: UserRole;
+    notification_settings: NotificationSettings;
     created_at: string;
     updated_at: string;
 }

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -56,6 +56,28 @@ class DashboardTest extends TestCase
             );
     }
 
+    public function test_authenticated_user_payload_carries_notification_settings_for_diff_trigger(): void
+    {
+        // PRD-010 #248: Dashboard.vue reads `auth.user.notification_settings`
+        // to wire the polling diff trigger into useNotifications. The shared
+        // prop has to expose the merged shape, not the raw JSON column —
+        // otherwise a fresh user would crash the composable on first poll.
+        $user = User::factory()->forRestaurant(Restaurant::factory()->create())->create();
+
+        $this->actingAs($user);
+
+        $this->get('/dashboard')
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Dashboard')
+                ->where('auth.user.notification_settings.browser_notifications', false)
+                ->where('auth.user.notification_settings.sound_alerts', false)
+                ->where('auth.user.notification_settings.daily_digest', true)
+                ->where('auth.user.notification_settings.daily_digest_at', '18:00')
+                ->etc()
+            );
+    }
+
     public function test_dashboard_emits_desired_at_as_utc_iso_for_restaurant_timezone_rendering(): void
     {
         // The client renders desired_at in restaurant-local time using the shared


### PR DESCRIPTION
## Summary

Implements PRD-010 § Trigger im Dashboard:

- New composable `resources/js/composables/useReservationDiffTrigger.ts`. Watches a `Ref<readonly number[]>` of the currently visible reservation IDs plus the active filter snapshot. When a poll cycle surfaces new IDs **and** the filter is unchanged, calls `notifications.notify()` (with the fixed `tag: 'reservation-agent-new-request'`) and `notifications.playSound()`.
- First load + filter changes are silent — they only refresh the baseline.
- Notification body switches German singular/plural based on count.
- Filter snapshot is serialized with sorted keys so server-side reordering does not register as a change.
- Wired into `Dashboard.vue` together with `useNotifications`, fed by `auth.user.notification_settings`.
- `User` model now appends `notification_settings` via `$appends` so the Inertia-shared user carries the merged shape.
- `User` TypeScript interface gains `notification_settings: NotificationSettings`.
- New Pest assertion: `auth.user.notification_settings` is present in the dashboard response with default values.
- Vitest covers all four issue acceptance scenarios + plural body + reorder-safe filter snapshot.

## Why

PRD-010 #248 acceptance: the operator must not be flooded by notifications during routine filter switches or initial dashboard loads. The diff guard plus filter-stable comparison achieves this without server-side bookkeeping.

## Test plan

- [x] `npx vitest run` — 80 tests, all passing
- [x] `php artisan test` — 805 passed
- [x] `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check` — clean
- [x] `npm run build` — passes (TypeScript)

Closes #248