### PR TITLE
Add DailyDigestMail + DigestSummary DTO (#250)

### DIFF
--- a/app/Mail/DailyDigestMail.php
+++ b/app/Mail/DailyDigestMail.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail;
+
+use App\Services\Notifications\DigestSummary;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Daily wrap-up mail (PRD-010 § Email-Digest). Carries the
+ * already-aggregated DigestSummary; the calculation lives in the
+ * service so the mailable stays a thin presenter the queue worker
+ * can rehydrate without database access.
+ */
+final class DailyDigestMail extends Mailable
+{
+    use Queueable;
+    use SerializesModels;
+
+    public function __construct(public readonly DigestSummary $summary) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: sprintf('Tageszusammenfassung — %s', $this->summary->restaurantName),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'emails.notifications.daily-digest',
+            with: [
+                'summary' => $this->summary,
+                // Per PRD-010 § Permission-Flow im UI the operator
+                // can disable the digest from the same settings
+                // page. Surface the route so the mail isn't a
+                // dead-end if they want to opt out.
+                'settingsUrl' => route('settings.notifications.edit'),
+            ],
+        );
+    }
+}

--- a/app/Services/Notifications/DigestSummary.php
+++ b/app/Services/Notifications/DigestSummary.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Notifications;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\User;
+use Illuminate\Support\Carbon;
+
+/**
+ * PRD-010 § Email-Digest. Snapshot of "what happened today" for a
+ * single restaurant, derived from the user's restaurant context. The
+ * DTO is final + readonly so the mailable can carry it across the
+ * queue boundary without surprise mutations.
+ *
+ * The denominator for "today" is the **restaurant's local timezone**,
+ * not the server timezone — owners in CET expect the 18:00 digest to
+ * cover everything that arrived since midnight CET, even if the
+ * scheduler ticks in UTC.
+ */
+final readonly class DigestSummary
+{
+    public function __construct(
+        public string $restaurantName,
+        public int $totalToday,
+        public int $confirmed,
+        public int $pending,
+        public int $needsReview,
+        public string $dashboardUrl,
+    ) {}
+
+    /**
+     * Build the summary for the given user. Counts are scoped by
+     * `restaurant_id` so a multi-restaurant chain only ever sees its
+     * own numbers (PRD-010 multi-tenant isolation requirement).
+     *
+     * The caller must ensure `$user->restaurant` is loaded; users
+     * without a restaurant are filtered out earlier in the digest job.
+     */
+    public static function forUser(User $user, string $dashboardUrl): self
+    {
+        $restaurant = $user->restaurant;
+        if ($restaurant === null) {
+            // Defensive guard; the digest job already skips these,
+            // but a direct caller would otherwise crash on a missing
+            // timezone string.
+            throw new \LogicException('DigestSummary requires a user with a restaurant.');
+        }
+
+        $today = Carbon::now($restaurant->timezone)->startOfDay();
+        $tomorrow = $today->copy()->addDay();
+
+        $base = ReservationRequest::query()
+            ->where('restaurant_id', $restaurant->id)
+            ->whereBetween('created_at', [
+                $today->copy()->utc(),
+                $tomorrow->copy()->utc(),
+            ]);
+
+        $totalToday = (clone $base)->count();
+        $confirmed = (clone $base)->where('status', ReservationStatus::Confirmed)->count();
+        $pending = (clone $base)
+            ->whereIn('status', [ReservationStatus::New, ReservationStatus::InReview])
+            ->count();
+        $needsReview = (clone $base)->where('needs_manual_review', true)->count();
+
+        return new self(
+            restaurantName: $restaurant->name,
+            totalToday: $totalToday,
+            confirmed: $confirmed,
+            pending: $pending,
+            needsReview: $needsReview,
+            dashboardUrl: $dashboardUrl,
+        );
+    }
+}

--- a/resources/views/emails/notifications/daily-digest.blade.php
+++ b/resources/views/emails/notifications/daily-digest.blade.php
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="UTF-8">
+    <title>Tageszusammenfassung — {{ $summary->restaurantName }}</title>
+</head>
+<body style="margin:0;padding:24px;background:#f4f4f5;font-family:-apple-system,Segoe UI,Helvetica,Arial,sans-serif;color:#111;">
+    <table cellpadding="0" cellspacing="0" border="0" width="600" align="center"
+           style="max-width:600px;background:#ffffff;border-radius:8px;border:1px solid #e4e4e7;">
+        <tr>
+            <td style="padding:24px;">
+                <h1 style="margin:0 0 8px 0;font-size:18px;color:#111;">{{ $summary->restaurantName }}</h1>
+                <p style="margin:0 0 24px 0;font-size:14px;color:#52525b;">Tageszusammenfassung der Reservierungsanfragen</p>
+
+                <table cellpadding="0" cellspacing="0" border="0" width="100%" role="presentation">
+                    <tr>
+                        <td width="50%" style="padding:8px;">
+                            <div style="border:1px solid #e4e4e7;border-radius:6px;padding:16px;">
+                                <p style="margin:0;font-size:12px;color:#71717a;text-transform:uppercase;letter-spacing:0.05em;">Heute gesamt</p>
+                                <p style="margin:4px 0 0 0;font-size:24px;font-weight:600;color:#111;">{{ $summary->totalToday }}</p>
+                            </div>
+                        </td>
+                        <td width="50%" style="padding:8px;">
+                            <div style="border:1px solid #e4e4e7;border-radius:6px;padding:16px;">
+                                <p style="margin:0;font-size:12px;color:#71717a;text-transform:uppercase;letter-spacing:0.05em;">Bestätigt</p>
+                                <p style="margin:4px 0 0 0;font-size:24px;font-weight:600;color:#047857;">{{ $summary->confirmed }}</p>
+                            </div>
+                        </td>
+                    </tr>
+                    <tr>
+                        <td width="50%" style="padding:8px;">
+                            <div style="border:1px solid #e4e4e7;border-radius:6px;padding:16px;">
+                                <p style="margin:0;font-size:12px;color:#71717a;text-transform:uppercase;letter-spacing:0.05em;">Offen</p>
+                                <p style="margin:4px 0 0 0;font-size:24px;font-weight:600;color:#1d4ed8;">{{ $summary->pending }}</p>
+                            </div>
+                        </td>
+                        <td width="50%" style="padding:8px;">
+                            <div style="border:1px solid #e4e4e7;border-radius:6px;padding:16px;">
+                                <p style="margin:0;font-size:12px;color:#71717a;text-transform:uppercase;letter-spacing:0.05em;">Manuelle Prüfung</p>
+                                <p style="margin:4px 0 0 0;font-size:24px;font-weight:600;color:#b45309;">{{ $summary->needsReview }}</p>
+                            </div>
+                        </td>
+                    </tr>
+                </table>
+
+                <p style="margin:24px 0 0 0;text-align:center;">
+                    <a href="{{ $summary->dashboardUrl }}"
+                       style="display:inline-block;padding:12px 20px;background:#111;color:#fff;text-decoration:none;border-radius:6px;font-size:14px;font-weight:500;">
+                        Zum Dashboard
+                    </a>
+                </p>
+            </td>
+        </tr>
+        <tr>
+            <td style="padding:16px 24px;border-top:1px solid #e4e4e7;font-size:12px;color:#71717a;text-align:center;">
+                Du erhältst diese Mail, weil der Tages-Digest für dein Konto aktiv ist.
+                <a href="{{ $settingsUrl }}" style="color:#71717a;">Einstellungen ändern</a>.
+            </td>
+        </tr>
+    </table>
+</body>
+</html>

--- a/tests/Feature/Notifications/DailyDigestMailTest.php
+++ b/tests/Feature/Notifications/DailyDigestMailTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Enums\ReservationStatus;
+use App\Mail\DailyDigestMail;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Services\Notifications\DigestSummary;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class DailyDigestMailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function userInBerlin(string $name = 'Trattoria Testa'): User
+    {
+        return User::factory()
+            ->forRestaurant(Restaurant::factory()->create([
+                'name' => $name,
+                'timezone' => 'Europe/Berlin',
+            ]))
+            ->create();
+    }
+
+    public function test_subject_carries_the_restaurant_name(): void
+    {
+        $user = $this->userInBerlin('Bistro am Hafen');
+        $summary = DigestSummary::forUser($user, 'https://example.test/dashboard');
+
+        $mail = new DailyDigestMail($summary);
+
+        $this->assertSame('Tageszusammenfassung — Bistro am Hafen', $mail->envelope()->subject);
+    }
+
+    public function test_summary_contains_correct_counts_for_today(): void
+    {
+        $user = $this->userInBerlin();
+        $restaurant = $user->restaurant;
+
+        // Anchor "today" so the test is stable regardless of the
+        // server clock. 2026-04-30 09:00 Europe/Berlin → 07:00 UTC.
+        Carbon::setTestNow(Carbon::parse('2026-04-30 09:00:00', 'Europe/Berlin'));
+
+        // 4 today: 1 confirmed, 1 in_review, 1 new (also needs_manual_review),
+        // 1 declined (counts toward total but not pending/confirmed/needs_review).
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'created_at' => Carbon::now('Europe/Berlin'),
+            'status' => ReservationStatus::Confirmed,
+            'needs_manual_review' => false,
+        ]);
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'created_at' => Carbon::now('Europe/Berlin'),
+            'status' => ReservationStatus::InReview,
+            'needs_manual_review' => false,
+        ]);
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'created_at' => Carbon::now('Europe/Berlin'),
+            'status' => ReservationStatus::New,
+            'needs_manual_review' => true,
+        ]);
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'created_at' => Carbon::now('Europe/Berlin'),
+            'status' => ReservationStatus::Declined,
+            'needs_manual_review' => false,
+        ]);
+        // A request from yesterday must NOT count.
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'created_at' => Carbon::now('Europe/Berlin')->subDay()->setTime(20, 0),
+            'status' => ReservationStatus::New,
+            'needs_manual_review' => false,
+        ]);
+
+        $summary = DigestSummary::forUser($user, 'https://example.test/dashboard');
+
+        $this->assertSame(4, $summary->totalToday);
+        $this->assertSame(1, $summary->confirmed);
+        $this->assertSame(2, $summary->pending);
+        $this->assertSame(1, $summary->needsReview);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_summary_contains_only_own_restaurant_counts(): void
+    {
+        $own = $this->userInBerlin('Eigenes Lokal');
+        $foreign = Restaurant::factory()->create(['name' => 'Fremd']);
+
+        Carbon::setTestNow(Carbon::parse('2026-04-30 09:00:00', 'Europe/Berlin'));
+
+        ReservationRequest::factory()->forRestaurant($own->restaurant)->create([
+            'created_at' => Carbon::now('Europe/Berlin'),
+            'status' => ReservationStatus::Confirmed,
+        ]);
+        ReservationRequest::factory()->forRestaurant($foreign)->count(5)->create([
+            'created_at' => Carbon::now('Europe/Berlin'),
+            'status' => ReservationStatus::Confirmed,
+        ]);
+
+        $summary = DigestSummary::forUser($own, 'https://example.test/dashboard');
+
+        $this->assertSame(1, $summary->totalToday);
+        $this->assertSame(1, $summary->confirmed);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_summary_uses_restaurant_timezone_for_today_window(): void
+    {
+        $user = $this->userInBerlin();
+        $restaurant = $user->restaurant;
+
+        // "Now" sits at 2026-04-30 23:30 Berlin (= 21:30 UTC), already
+        // past the UTC midnight rollover. A reservation created at
+        // 2026-04-30 22:00 Berlin (20:00 UTC) belongs to today's
+        // local digest, not yesterday's.
+        Carbon::setTestNow(Carbon::parse('2026-04-30 23:30:00', 'Europe/Berlin'));
+
+        ReservationRequest::factory()->forRestaurant($restaurant)->create([
+            'created_at' => Carbon::parse('2026-04-30 22:00:00', 'Europe/Berlin'),
+            'status' => ReservationStatus::New,
+        ]);
+
+        $summary = DigestSummary::forUser($user, 'https://example.test/dashboard');
+        $this->assertSame(1, $summary->totalToday);
+
+        Carbon::setTestNow();
+    }
+
+    public function test_view_renders_dashboard_url_and_counts(): void
+    {
+        $user = $this->userInBerlin('Pizzeria Giallo');
+        Carbon::setTestNow(Carbon::parse('2026-04-30 09:00:00', 'Europe/Berlin'));
+
+        $summary = new DigestSummary(
+            restaurantName: 'Pizzeria Giallo',
+            totalToday: 7,
+            confirmed: 3,
+            pending: 2,
+            needsReview: 1,
+            dashboardUrl: 'https://example.test/dashboard',
+        );
+
+        $rendered = (new DailyDigestMail($summary))->render();
+
+        $this->assertStringContainsString('Pizzeria Giallo', $rendered);
+        $this->assertStringContainsString('https://example.test/dashboard', $rendered);
+        // The four numbers must appear near their labels — assert
+        // they're present so a future template change can't silently
+        // drop a metric.
+        $this->assertStringContainsString('>7<', $rendered);
+        $this->assertStringContainsString('>3<', $rendered);
+        $this->assertStringContainsString('>2<', $rendered);
+        $this->assertStringContainsString('>1<', $rendered);
+        // Settings link must be present so the operator can opt out.
+        $this->assertStringContainsString(route('settings.notifications.edit'), $rendered);
+
+        Carbon::setTestNow();
+        // Suppress test passthroughs.
+        unset($user);
+    }
+}


### PR DESCRIPTION
## Summary

Introduces the email half of PRD-010 § Email-Digest:

- `app/Services/Notifications/DigestSummary.php` — `final readonly` DTO with `restaurantName`, `totalToday`, `confirmed`, `pending`, `needsReview`, `dashboardUrl`. Static `forUser($user, $dashboardUrl)` factory aggregates counts scoped by `restaurant_id` so multi-restaurant chains never leak.
- The "today" window uses the **restaurant timezone**, not the server clock — the 18:00 digest in Berlin must cover everything since midnight Berlin even when the scheduler ticks in UTC.
- `app/Mail/DailyDigestMail.php` — Mailable carrying the DTO. Subject `Tageszusammenfassung — {restaurant_name}` per spec.
- `resources/views/emails/notifications/daily-digest.blade.php` — HTML view: restaurant header, four numbered cards (Heute gesamt / Bestätigt / Offen / Manuelle Prüfung), dashboard CTA, footer with a link to `settings.notifications.edit` so the operator can opt out from the mail itself.

## Why

PRD-010 demands the digest as the fallback for users that block browser notifications. Aggregating in a DTO keeps the queue worker thin — the calculation runs on the worker; the mailable just renders.

## Test plan

- [x] `php artisan test --filter='DailyDigest'` — 5 passed (subject, counts today, multi-tenant isolation, timezone window, view render with URL + numbers + settings link)
- [x] `php artisan test` — 810 passed
- [x] `./vendor/bin/pint --test` — clean

Closes #250