### PR TITLE
Add SendDailyDigestJob with hourly tick + timezone-aware shouldSendNow (#249)

### DIFF
--- a/app/Jobs/SendDailyDigestJob.php
+++ b/app/Jobs/SendDailyDigestJob.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Mail\DailyDigestMail;
+use App\Models\User;
+use App\Services\Notifications\DigestSummary;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Mail;
+
+/**
+ * PRD-010 § Email-Digest. Hourly fan-out job.
+ *
+ * The scheduler ticks once per hour (registered in `routes/console.php`,
+ * sister issue #251). Each tick inspects every user that opted into the
+ * daily digest and dispatches a `DailyDigestMail` to those whose
+ * configured `daily_digest_at` matches the current hour:minute in their
+ * restaurant's timezone.
+ *
+ * Hourly + per-user filter is the simplest robust approach for a
+ * multi-timezone deployment: a single cron line covers the world; the
+ * per-user clock comparison handles the offset. At thousands of
+ * restaurants this would warrant a per-timezone cron (PRD-010 § Risiken).
+ *
+ * Idempotency is enforced by a cache lock keyed `digest-sent:{user_id}:{YYYY-MM-DD}`
+ * with a 23-hour TTL — short enough to release before tomorrow's window,
+ * long enough that a job re-run within the same minute cannot send twice.
+ * Cache::add() is the atomic primitive (returns false if the key already
+ * exists), which beats the read-then-write pattern under concurrent workers.
+ */
+final class SendDailyDigestJob implements ShouldQueue
+{
+    use Queueable;
+
+    public function handle(): void
+    {
+        $users = User::query()
+            ->whereNotNull('restaurant_id')
+            ->with('restaurant')
+            ->get()
+            ->filter(static fn (User $user): bool => ($user->notification_settings['daily_digest'] ?? false) === true);
+
+        foreach ($users as $user) {
+            if (! $this->shouldSendNow($user)) {
+                continue;
+            }
+
+            $today = Carbon::now($user->restaurant->timezone)->toDateString();
+            $lockKey = sprintf('digest-sent:%d:%s', $user->id, $today);
+
+            // 23-hour TTL: long enough to deduplicate a re-run, short
+            // enough that the lock has expired before tomorrow's
+            // window opens. Cache::add() is the atomic check-and-set;
+            // a parallel worker that races us simply gets `false` and
+            // skips.
+            if (! Cache::add($lockKey, true, now()->addHours(23))) {
+                continue;
+            }
+
+            $summary = DigestSummary::forUser($user, route('dashboard'));
+            Mail::to($user)->send(new DailyDigestMail($summary));
+        }
+    }
+
+    private function shouldSendNow(User $user): bool
+    {
+        $configured = $user->notification_settings['daily_digest_at'] ?? '18:00';
+        $localNow = Carbon::now($user->restaurant->timezone)->format('H:i');
+
+        return $localNow === $configured;
+    }
+}

--- a/tests/Feature/Notifications/DailyDigestJobTest.php
+++ b/tests/Feature/Notifications/DailyDigestJobTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Notifications;
+
+use App\Jobs\SendDailyDigestJob;
+use App\Mail\DailyDigestMail;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class DailyDigestJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Mail::fake();
+    }
+
+    private function userWithRestaurant(string $timezone = 'Europe/Berlin', string $sendAt = '18:00', bool $digestEnabled = true): User
+    {
+        $restaurant = Restaurant::factory()->create(['timezone' => $timezone]);
+
+        return User::factory()->forRestaurant($restaurant)->create([
+            'notification_settings' => [
+                'daily_digest' => $digestEnabled,
+                'daily_digest_at' => $sendAt,
+            ],
+        ]);
+    }
+
+    public function test_sends_digest_at_user_configured_time_in_restaurant_timezone(): void
+    {
+        $user = $this->userWithRestaurant('Europe/Berlin', '18:00');
+
+        // 2026-04-30 18:00 Berlin = 16:00 UTC.
+        Carbon::setTestNow(Carbon::parse('2026-04-30 16:00:00', 'UTC'));
+
+        (new SendDailyDigestJob)->handle();
+
+        Mail::assertSent(DailyDigestMail::class, fn (DailyDigestMail $mail) => $mail->hasTo($user->email));
+
+        Carbon::setTestNow();
+    }
+
+    public function test_does_not_send_when_clock_misses_configured_minute(): void
+    {
+        $this->userWithRestaurant('Europe/Berlin', '18:00');
+
+        Carbon::setTestNow(Carbon::parse('2026-04-30 17:30:00', 'UTC')); // 19:30 Berlin
+
+        (new SendDailyDigestJob)->handle();
+
+        Mail::assertNothingSent();
+
+        Carbon::setTestNow();
+    }
+
+    public function test_does_not_send_digest_when_setting_is_off(): void
+    {
+        $this->userWithRestaurant('Europe/Berlin', '18:00', digestEnabled: false);
+
+        Carbon::setTestNow(Carbon::parse('2026-04-30 16:00:00', 'UTC')); // 18:00 Berlin
+
+        (new SendDailyDigestJob)->handle();
+
+        Mail::assertNothingSent();
+
+        Carbon::setTestNow();
+    }
+
+    public function test_skips_users_without_restaurant_id(): void
+    {
+        User::factory()->create([
+            'restaurant_id' => null,
+            'notification_settings' => ['daily_digest' => true, 'daily_digest_at' => '18:00'],
+        ]);
+
+        Carbon::setTestNow(Carbon::parse('2026-04-30 16:00:00', 'UTC'));
+
+        (new SendDailyDigestJob)->handle();
+
+        Mail::assertNothingSent();
+
+        Carbon::setTestNow();
+    }
+
+    public function test_sends_digest_only_once_per_user_per_day(): void
+    {
+        $user = $this->userWithRestaurant('Europe/Berlin', '18:00');
+
+        Carbon::setTestNow(Carbon::parse('2026-04-30 16:00:00', 'UTC'));
+
+        (new SendDailyDigestJob)->handle();
+        // Same minute, second invocation — must not double-send.
+        (new SendDailyDigestJob)->handle();
+
+        Mail::assertSent(DailyDigestMail::class, 1);
+
+        // Sanity-check the lock key is what subsequent debugging will look for.
+        $expectedKey = sprintf('digest-sent:%d:%s', $user->id, '2026-04-30');
+        $this->assertTrue(Cache::has($expectedKey));
+
+        Carbon::setTestNow();
+    }
+
+    public function test_runs_independently_for_users_in_different_timezones(): void
+    {
+        $berlin = $this->userWithRestaurant('Europe/Berlin', '18:00');
+        $newYork = $this->userWithRestaurant('America/New_York', '18:00');
+
+        // 16:00 UTC == 18:00 Berlin (CEST), == 12:00 New York → only Berlin matches.
+        Carbon::setTestNow(Carbon::parse('2026-04-30 16:00:00', 'UTC'));
+        (new SendDailyDigestJob)->handle();
+
+        Mail::assertSent(DailyDigestMail::class, 1);
+        Mail::assertSent(DailyDigestMail::class, fn (DailyDigestMail $mail) => $mail->hasTo($berlin->email));
+
+        // Six hours later → 22:00 UTC == 18:00 New York → New York digest fires.
+        Carbon::setTestNow(Carbon::parse('2026-04-30 22:00:00', 'UTC'));
+        (new SendDailyDigestJob)->handle();
+
+        Mail::assertSent(DailyDigestMail::class, 2);
+        Mail::assertSent(DailyDigestMail::class, fn (DailyDigestMail $mail) => $mail->hasTo($newYork->email));
+
+        Carbon::setTestNow();
+    }
+}


### PR DESCRIPTION
## Summary

Implements PRD-010 § Email-Digest job:

- `app/Jobs/SendDailyDigestJob.php` — `final` class implementing `ShouldQueue`.
- `handle()` loads every user with a `restaurant_id`, eager-loads the restaurant, and filters in-memory to those with `notification_settings.daily_digest === true`.
- `shouldSendNow($user)` compares `Carbon::now($user->restaurant->timezone)->format('H:i')` against the configured `daily_digest_at`. Hourly cadence + per-user filter is the simplest robust approach for multi-timezone deployments.
- **Idempotency**: `Cache::add('digest-sent:{user_id}:{YYYY-MM-DD}', true, 23h)`. Atomic check-and-set; a parallel worker that races simply gets `false` and skips. The 23-hour TTL clears before tomorrow's window opens.
- Mail dispatched via `DigestSummary::forUser($user, route('dashboard'))` + `Mail::to($user)->send(new DailyDigestMail(...))`.

## Why

Hourly + per-user clock filter means a single cron line covers every restaurant timezone — no cron-per-zone configuration. The cache lock makes the job safe to invoke twice within a minute (e.g. CI re-tests, replay).

## Test plan

- [x] `php artisan test --filter='DailyDigest'` — 11 passed (mail + job)
- [x] `php artisan test` — 816 passed
- [x] `./vendor/bin/pint --test` — clean

Test cases cover: restaurant-tz match, off-by-30min skip, `daily_digest = false` skip, no `restaurant_id` skip, idempotency (twice in same minute → 1 send + lock present), and two restaurants in different timezones firing in their respective windows.

Closes #249