### PR TITLE
docs: defer PRD-010 sound assets to V3.0 in roadmap (#305)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ Detail-Begründung & Versions-Themen für V3+ stehen im V3–V7-Roadmap-Spec: [`
 | Automatischer Mailversand (opt-in mit Hard-Gates)| V2.0    | scoped → [PRD-007](docs/PRD-007-auto-send-trust-modes.md)           |
 | Analytics / Reporting                            | V2.0    | scoped → [PRD-008](docs/PRD-008-dashboard-analytics.md)             |
 | Export CSV/PDF                                   | V2.0    | scoped → [PRD-009](docs/PRD-009-export-csv-pdf.md)                  |
-| Push / Sound-Alerts / Daily Digest               | V2.0    | scoped → [PRD-010](docs/PRD-010-push-and-sound-alerts.md)           |
+| Push / Sound-Alerts / Daily Digest (Code-Pfad)   | V2.0    | scoped → [PRD-010](docs/PRD-010-push-and-sound-alerts.md) (Sound-Assets nach V3.0 verschoben) |
+| PRD-010 CC0-Sound-Assets                         | V3.0    | aus V2.0 verschoben (Asset-Auswahl, kein Code-Blocker)              |
 | Tisch-Liste mit Belegungsstatus                  | V3.0    | (Operative Vollständigkeit)                                         |
 | Manuelle Erfassung (Telefon / Walk-in)           | V3.0    |                                                                     |
 | Warteliste passiv                                | V3.0    | aktive Warteliste mit Notify in V4                                  |


### PR DESCRIPTION
## Summary

Split the PRD-010 roadmap row in `README.md` into two: V2.0 covers the merged code path, V3.0 covers the still-pending CC0 sound asset bundle (#244).

## Why

The PRD-010 code (migration, composable, settings UI, polling diff, daily digest job, tests — #243, #245–#252) is fully merged on `dev`. The remaining work is asset selection for #244 (three CC0 sounds + LICENSE.txt). It was deferred to V3.0 because:

- The code degrades gracefully without sound files (`useNotifications` has defensive checks).
- Asset selection benefits from a deliberate pass rather than blocking the V2.0 release window.
- Consistent with other "scoped → V3.0" roadmap entries.

Issues #200 and #244 already carry the `v3` label; this PR aligns the README so it stops contradicting that state.

Closes #305

## Test plan

- [x] `git diff` reviewed — only the roadmap row split, nothing else
- [x] No code paths touched (pure docs)
- [ ] Self-review via `code-review:code-review` before merge