### PR TITLE
PRD-011: schema – tables, reservation_table_assignments, slot_buffer_minutes

### DIFF
--- a/database/migrations/2026_05_01_000001_create_tables_table.php
+++ b/database/migrations/2026_05_01_000001_create_tables_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tables', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('label');
+            $table->unsignedTinyInteger('seats');
+            $table->string('room_tag')->nullable();
+            $table->unsignedSmallInteger('sort_order')->default(0);
+            $table->boolean('active')->default(true);
+            $table->json('combinable_with')->nullable();
+            $table->timestamps();
+
+            $table->index(['restaurant_id', 'active', 'sort_order']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tables');
+    }
+};

--- a/database/migrations/2026_05_01_000002_create_reservation_table_assignments_table.php
+++ b/database/migrations/2026_05_01_000002_create_reservation_table_assignments_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('reservation_table_assignments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('reservation_request_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->foreignId('table_id')
+                ->constrained('tables')
+                ->restrictOnDelete();
+            $table->dateTime('assigned_at');
+            $table->foreignId('assigned_by_user_id')
+                ->nullable()
+                ->constrained('users')
+                ->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['reservation_request_id', 'table_id']);
+            $table->index('table_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('reservation_table_assignments');
+    }
+};

--- a/database/migrations/2026_05_01_000003_add_slot_buffer_minutes_to_restaurants_table.php
+++ b/database/migrations/2026_05_01_000003_add_slot_buffer_minutes_to_restaurants_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->unsignedSmallInteger('slot_buffer_minutes')->default(90);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->dropColumn('slot_buffer_minutes');
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- Adds `tables` master-data schema (label, seats, room_tag, sort_order, active, combinable_with) with cascade delete from `restaurants`.
- Adds `reservation_table_assignments` M:N link between reservation requests and tables, restrict-on-delete from `tables`, with `assigned_at` and optional `assigned_by_user_id`.
- Adds `slot_buffer_minutes` (default 90) on `restaurants` so the upcoming SlotAvailability service can compute buffer-aware occupancy per restaurant.

## Why

Foundation for PRD-011 (Verfügbarkeits-Modell + Tisch-Liste). Subsequent issues add the Eloquent models, the `SlotAvailability` service, the policy, the controller, and the UI. Splitting the schema into its own PR keeps the diff reviewable and lets later PRs build on a stable schema.

Refs #309.

## Test plan

- [x] `php artisan migrate` runs cleanly on a fresh database
- [x] `php artisan migrate:rollback --step=3 && php artisan migrate` round-trips successfully
- [x] `composer test` — existing suite stays green
- [x] `./vendor/bin/pint --test` — clean