### PR TITLE
PRD-011: DefaultTableSeeder for restaurants without tables (#311)

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -97,5 +97,7 @@ class DatabaseSeeder extends Seeder
                     'source' => ReservationSource::WebForm,
                 ]);
         }
+
+        $this->call(DefaultTableSeeder::class);
     }
 }

--- a/database/seeders/DefaultTableSeeder.php
+++ b/database/seeders/DefaultTableSeeder.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\Table;
+use Illuminate\Database\Seeder;
+
+class DefaultTableSeeder extends Seeder
+{
+    private const int FALLBACK_PARTY_SIZE = 4;
+
+    private const int SEAT_HEADROOM = 4;
+
+    public function run(): void
+    {
+        Restaurant::query()
+            ->whereDoesntHave('tables')
+            ->each(function (Restaurant $restaurant): void {
+                $maxParty = (int) (ReservationRequest::query()
+                    ->withoutGlobalScopes()
+                    ->where('restaurant_id', $restaurant->id)
+                    ->max('party_size') ?? self::FALLBACK_PARTY_SIZE);
+
+                Table::create([
+                    'restaurant_id' => $restaurant->id,
+                    'label' => 'Tisch 1',
+                    'seats' => $maxParty + self::SEAT_HEADROOM,
+                    'sort_order' => 1,
+                    'active' => true,
+                ]);
+            });
+    }
+}

--- a/tests/Feature/Seeders/DefaultTableSeederTest.php
+++ b/tests/Feature/Seeders/DefaultTableSeederTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\Seeders;
+
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\Table;
+use Database\Seeders\DefaultTableSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DefaultTableSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creates_a_default_table_for_a_restaurant_without_tables(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        (new DefaultTableSeeder)->run();
+
+        $this->assertSame(1, Table::where('restaurant_id', $restaurant->id)->count());
+
+        $table = Table::where('restaurant_id', $restaurant->id)->sole();
+        $this->assertSame('Tisch 1', $table->label);
+        $this->assertSame(1, $table->sort_order);
+        $this->assertTrue($table->active);
+    }
+
+    public function test_skips_restaurants_that_already_have_a_table(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        Table::factory()->for($restaurant)->create(['label' => 'Existing']);
+
+        (new DefaultTableSeeder)->run();
+
+        $this->assertSame(1, Table::where('restaurant_id', $restaurant->id)->count());
+        $this->assertSame('Existing', Table::where('restaurant_id', $restaurant->id)->sole()->label);
+    }
+
+    public function test_is_idempotent_on_repeated_runs(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        (new DefaultTableSeeder)->run();
+        (new DefaultTableSeeder)->run();
+        (new DefaultTableSeeder)->run();
+
+        $this->assertSame(1, Table::where('restaurant_id', $restaurant->id)->count());
+    }
+
+    public function test_sizes_the_default_table_by_max_historical_party_size_plus_four(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        ReservationRequest::factory()->forRestaurant($restaurant)->create(['party_size' => 6]);
+        ReservationRequest::factory()->forRestaurant($restaurant)->create(['party_size' => 9]);
+
+        (new DefaultTableSeeder)->run();
+
+        $table = Table::where('restaurant_id', $restaurant->id)->sole();
+        $this->assertSame(13, $table->seats);
+    }
+
+    public function test_uses_fallback_seats_when_restaurant_has_no_reservations(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        (new DefaultTableSeeder)->run();
+
+        $table = Table::where('restaurant_id', $restaurant->id)->sole();
+        $this->assertSame(8, $table->seats);
+    }
+
+    public function test_only_seeds_restaurants_that_lack_tables(): void
+    {
+        $hasTable = Restaurant::factory()->create();
+        Table::factory()->for($hasTable)->create();
+
+        $needsTable = Restaurant::factory()->create();
+
+        (new DefaultTableSeeder)->run();
+
+        $this->assertSame(1, Table::where('restaurant_id', $hasTable->id)->count());
+        $this->assertSame(1, Table::where('restaurant_id', $needsTable->id)->count());
+    }
+}


### PR DESCRIPTION
## Summary

Idempotent backfill seeder for the new `tables` schema:

- `DefaultTableSeeder` creates exactly one `Tisch 1` per restaurant that has zero tables — `seats = max(historic party_size) + 4`, fallback `8` when no reservations exist
- Wired into `DatabaseSeeder` so `migrate:fresh --seed` provisions a usable default table for the demo tenant (verified: demo gets `Tisch 1`, seats=9 from max party_size 5 + 4)
- `DefaultTableSeederTest` covers: creation when missing, no-op when present, idempotence on repeat runs, party-size sizing, fallback sizing, and mixed populations

## Why

Existing tenants need at least one table after PRD-011 lands so SlotAvailability has something to assign — the seeder gives them a sensible starting point sized to their actual booking history rather than a hardcoded magic number.

## Test plan

- [x] `php artisan test --filter=DefaultTableSeederTest` — 6 pass
- [x] `php artisan test` — 832 pass (was 826 + 6 new)
- [x] `php artisan migrate:fresh --seed` — clean run, demo restaurant gets `Tisch 1` with seats=9
- [x] `./vendor/bin/pint --test` — clean

Closes #311