### PR TITLE
PRD-011: SlotState enum + availability DTOs (#312)

### DIFF
--- a/app/Enums/SlotState.php
+++ b/app/Enums/SlotState.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Availability state of a single slot (PRD-011).
+ *
+ * Computed deterministically by the SlotAvailability service; the AI never
+ * decides this — it only phrases the result. `tight` means a slot is still
+ * bookable but ≤ 25 % of the restaurant's active capacity remains.
+ */
+enum SlotState: string
+{
+    case Free = 'free';
+    case Tight = 'tight';
+    case Full = 'full';
+}

--- a/app/Services/Availability/DTOs/DayAvailability.php
+++ b/app/Services/Availability/DTOs/DayAvailability.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Availability\DTOs;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+/**
+ * Full-day availability grid for one restaurant (PRD-011).
+ *
+ * Produced by SlotAvailability::forDay(): one SlotAvailabilityResult per
+ * 30-minute slot within opening hours. `totalCapacity` is the summed seats of
+ * active tables; `reservedSeats` is the seats occupied by active reservations
+ * that day, for the occupancy headline.
+ */
+final readonly class DayAvailability
+{
+    /**
+     * @param  Collection<int, SlotAvailabilityResult>  $slots
+     */
+    public function __construct(
+        public CarbonImmutable $date,
+        public Collection $slots,
+        public int $totalCapacity,
+        public int $reservedSeats,
+    ) {}
+}

--- a/app/Services/Availability/DTOs/SlotAvailabilityResult.php
+++ b/app/Services/Availability/DTOs/SlotAvailabilityResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Availability\DTOs;
+
+use App\Enums\SlotState;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+/**
+ * Deterministic availability verdict for one slot (PRD-011).
+ *
+ * Produced by SlotAvailability::forSlot(). `suggestedTableId` / `combination`
+ * are the table proposal (null when full); `alternativeSlots` is populated with
+ * up to three later free slots when the requested slot is full, so consumer UIs
+ * (PRD-012) can offer next-best times.
+ */
+final readonly class SlotAvailabilityResult
+{
+    /**
+     * @param  Collection<int, CarbonImmutable>  $alternativeSlots
+     */
+    public function __construct(
+        public CarbonImmutable $slotStart,
+        public SlotState $state,
+        public ?int $suggestedTableId,
+        public ?TableCombination $combination,
+        public Collection $alternativeSlots,
+    ) {}
+}

--- a/app/Services/Availability/DTOs/TableCombination.php
+++ b/app/Services/Availability/DTOs/TableCombination.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Availability\DTOs;
+
+/**
+ * A table assignment proposal for a slot (PRD-011).
+ *
+ * Either a single fitting table (`tableIds` has one entry) or a two-table
+ * combination via `combinable_with` (`tableIds` has two). V3 caps combinations
+ * at two tables; 3+ is out of scope. `primaryTableId` is the table the UI
+ * highlights first; `totalSeats` is the summed capacity of all `tableIds`.
+ */
+final readonly class TableCombination
+{
+    /**
+     * @param  list<int>  $tableIds
+     */
+    public function __construct(
+        public int $primaryTableId,
+        public array $tableIds,
+        public int $totalSeats,
+    ) {}
+}

--- a/tests/Unit/Availability/DTOTest.php
+++ b/tests/Unit/Availability/DTOTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Availability;
+
+use App\Enums\SlotState;
+use App\Services\Availability\DTOs\DayAvailability;
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use App\Services\Availability\DTOs\TableCombination;
+use Carbon\CarbonImmutable;
+use Error;
+use Illuminate\Support\Collection;
+use Tests\TestCase;
+
+class DTOTest extends TestCase
+{
+    public function test_slot_state_enum_has_three_string_backed_cases(): void
+    {
+        $this->assertCount(3, SlotState::cases());
+        $this->assertSame('free', SlotState::Free->value);
+        $this->assertSame('tight', SlotState::Tight->value);
+        $this->assertSame('full', SlotState::Full->value);
+    }
+
+    public function test_slot_availability_result_is_constructible(): void
+    {
+        $result = new SlotAvailabilityResult(
+            slotStart: CarbonImmutable::parse('2026-06-15 19:00'),
+            state: SlotState::Free,
+            suggestedTableId: 7,
+            combination: null,
+            alternativeSlots: collect(),
+        );
+
+        $this->assertSame(SlotState::Free, $result->state);
+        $this->assertSame(7, $result->suggestedTableId);
+        $this->assertNull($result->combination);
+        $this->assertInstanceOf(Collection::class, $result->alternativeSlots);
+        $this->assertSame('2026-06-15 19:00', $result->slotStart->format('Y-m-d H:i'));
+    }
+
+    public function test_slot_availability_result_carries_a_table_combination(): void
+    {
+        $combination = new TableCombination(primaryTableId: 5, tableIds: [5, 6], totalSeats: 8);
+
+        $result = new SlotAvailabilityResult(
+            slotStart: CarbonImmutable::parse('2026-06-15 19:00'),
+            state: SlotState::Free,
+            suggestedTableId: 5,
+            combination: $combination,
+            alternativeSlots: collect(),
+        );
+
+        $this->assertSame($combination, $result->combination);
+        $this->assertSame([5, 6], $result->combination->tableIds);
+    }
+
+    public function test_table_combination_exposes_primary_table_and_total_seats(): void
+    {
+        $combo = new TableCombination(primaryTableId: 5, tableIds: [5, 6], totalSeats: 8);
+
+        $this->assertSame(5, $combo->primaryTableId);
+        $this->assertSame([5, 6], $combo->tableIds);
+        $this->assertSame(8, $combo->totalSeats);
+    }
+
+    public function test_day_availability_holds_slot_collection_and_totals(): void
+    {
+        $day = new DayAvailability(
+            date: CarbonImmutable::parse('2026-06-15'),
+            slots: collect(),
+            totalCapacity: 50,
+            reservedSeats: 12,
+        );
+
+        $this->assertSame(50, $day->totalCapacity);
+        $this->assertSame(12, $day->reservedSeats);
+        $this->assertInstanceOf(Collection::class, $day->slots);
+        $this->assertSame('2026-06-15', $day->date->format('Y-m-d'));
+    }
+
+    public function test_dtos_are_readonly_and_reject_mutation(): void
+    {
+        $combo = new TableCombination(primaryTableId: 1, tableIds: [1], totalSeats: 4);
+
+        $this->expectException(Error::class);
+        // @phpstan-ignore-next-line — intentionally violating readonly to assert immutability
+        $combo->totalSeats = 99;
+    }
+}


### PR DESCRIPTION
## Summary

Type-safe building blocks for the upcoming `SlotAvailability` service (PRD-011, plan Task 4):

- `app/Enums/SlotState.php` — string-backed enum `free` / `tight` / `full`
- `app/Services/Availability/DTOs/SlotAvailabilityResult.php` — `readonly`: `slotStart`, `state`, `suggestedTableId`, `combination`, `alternativeSlots`
- `app/Services/Availability/DTOs/DayAvailability.php` — `readonly`: `date`, `slots`, `totalCapacity`, `reservedSeats`
- `app/Services/Availability/DTOs/TableCombination.php` — `readonly`: `primaryTableId`, `tableIds`, `totalSeats`
- `tests/Unit/Availability/DTOTest.php` — enum cases/values + DTO construction + immutability

All DTOs are `final readonly class` with `declare(strict_types=1)`, matching the existing `AutoSendDecision` / `TrendBucket` DTO style.

## Why

These are the foundation Phase A leaves behind so the keystone `SlotAvailability` methods (#313–#316) and the day grid have stable value objects to return. PRD-011 keeps availability **deterministic** — the AI only phrases these results, it never computes them.

## Note on the spec

The DTO field set follows the **refined design in the plan (`docs/superpowers/plans/2026-05-01-prd-011-availability-and-tables.md` § Task 4)**, which the issue itself references as the spec. That intentionally differs from the older placeholder bullet list in issue #312 (`party_size`, `free_table_ids`, `total_capacity`, `restaurant_id`): the plan's signatures are the ones the keystone service in Tasks 5–8 actually constructs and consumes, so following the issue draft literally would have produced DTOs the service can't use.

Tests were written as **plain PHPUnit classes** (`extends Tests\TestCase`, `test_*` methods), matching all 112 existing test files — this repo does not actually have Pest installed despite the docs mentioning "Pest 3".

## Test plan

- [x] `php artisan test tests/Unit/Availability/DTOTest.php` — 6 pass (19 assertions)
- [x] `php artisan test` — 838 pass (832 + 6 new), no regressions
- [x] `./vendor/bin/pint --test` on touched paths — clean
- [x] No JS/TS changes → ESLint/Prettier not applicable

Closes #312