### PR TITLE
PRD-011: SlotAvailability::forSlot with buffer logic (#313)

### DIFF
--- a/app/Services/Availability/SlotAvailability.php
+++ b/app/Services/Availability/SlotAvailability.php
@@ -18,12 +18,17 @@ use Illuminate\Support\Collection;
  * Deterministic table-availability for a restaurant (PRD-011).
  *
  * This is the single source of truth for "is this slot free/tight/full"; the AI
- * never decides availability, it only phrases the result. Occupancy is computed
- * per table from active reservations, buffer-aware: a reservation at `desired_at`
- * blocks its table for `[desired_at - buffer, desired_at + slot_duration + buffer]`.
- * Slot duration is a fixed 90 min in V3 (per-restaurant configurability is a
- * documented PRD-011 follow-up). Single-table suggestion only in this task;
- * combinations (#314) and alternative slots (#315) extend this service later.
+ * never decides availability, it only phrases the result. The result depends only
+ * on the passed `$restaurantId`, never on the authenticated user — the queries
+ * bypass the tenant RestaurantScope and scope by `$restaurantId` explicitly, so
+ * availability is identical from a web request, a queued job, or the console.
+ *
+ * Occupancy is computed per table from active reservations, buffer-aware: a
+ * reservation at `desired_at` occupies its table over the half-open footprint
+ * `[desired_at - buffer, desired_at + slot_duration + buffer)`. Slot duration is
+ * a fixed 90 min in V3 (per-restaurant configurability is a documented PRD-011
+ * follow-up). Single-table suggestion only in this task; combinations (#314) and
+ * alternative slots (#315) extend this service later.
  */
 final class SlotAvailability
 {
@@ -51,7 +56,7 @@ final class SlotAvailability
             return $this->fullResult($datetime);
         }
 
-        $tables = $restaurant->tables()->where('active', true)->get();
+        $tables = $restaurant->tables()->withoutGlobalScopes()->where('active', true)->get();
         if ($tables->isEmpty()) {
             return $this->fullResult($datetime);
         }
@@ -84,8 +89,11 @@ final class SlotAvailability
     /**
      * Table ids occupied by an active reservation overlapping the buffered slot.
      *
-     * A reservation overlaps the requested slot when its `desired_at` falls in
-     * `[datetime - (buffer + duration), datetime + (duration + buffer)]`.
+     * With half-open footprints, a reservation overlaps the requested slot iff its
+     * `desired_at` lies strictly inside `(datetime - (buffer + duration), datetime
+     * + (duration + buffer))`; a reservation sitting exactly on a bound only
+     * touches the slot edge and does not occupy it. Queries bypass the tenant
+     * global scope so the result is independent of the authenticated user.
      *
      * @return Collection<int, int>
      */
@@ -95,10 +103,12 @@ final class SlotAvailability
         $windowEnd = $datetime->addMinutes(self::SLOT_DURATION_MINUTES + $bufferMinutes);
 
         return ReservationRequest::query()
+            ->withoutGlobalScopes()
             ->where('restaurant_id', $restaurantId)
             ->whereIn('status', array_map(fn (ReservationStatus $status): string => $status->value, self::OCCUPYING_STATUSES))
-            ->whereBetween('desired_at', [$windowStart, $windowEnd])
-            ->with('tableAssignments:id,reservation_request_id,table_id')
+            ->where('desired_at', '>', $windowStart)
+            ->where('desired_at', '<', $windowEnd)
+            ->with(['tableAssignments' => fn ($query) => $query->withoutGlobalScopes()->select('id', 'reservation_request_id', 'table_id')])
             ->get()
             ->flatMap(fn (ReservationRequest $reservation): Collection => $reservation->tableAssignments->pluck('table_id'))
             ->unique()

--- a/app/Services/Availability/SlotAvailability.php
+++ b/app/Services/Availability/SlotAvailability.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Availability;
+
+use App\Enums\ReservationStatus;
+use App\Enums\SlotState;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use App\Support\OpeningHours;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+/**
+ * Deterministic table-availability for a restaurant (PRD-011).
+ *
+ * This is the single source of truth for "is this slot free/tight/full"; the AI
+ * never decides availability, it only phrases the result. Occupancy is computed
+ * per table from active reservations, buffer-aware: a reservation at `desired_at`
+ * blocks its table for `[desired_at - buffer, desired_at + slot_duration + buffer]`.
+ * Slot duration is a fixed 90 min in V3 (per-restaurant configurability is a
+ * documented PRD-011 follow-up). Single-table suggestion only in this task;
+ * combinations (#314) and alternative slots (#315) extend this service later.
+ */
+final class SlotAvailability
+{
+    private const int SLOT_DURATION_MINUTES = 90;
+
+    private const float TIGHT_THRESHOLD = 0.25;
+
+    /**
+     * Statuses that hold a table. `New` (not yet triaged), `Declined` and
+     * `Cancelled` never occupy. Waitlist (PRD-013) is non-occupying by design.
+     *
+     * @var list<ReservationStatus>
+     */
+    private const array OCCUPYING_STATUSES = [
+        ReservationStatus::InReview,
+        ReservationStatus::Replied,
+        ReservationStatus::Confirmed,
+    ];
+
+    public function forSlot(int $restaurantId, CarbonImmutable $datetime, int $partySize): SlotAvailabilityResult
+    {
+        $restaurant = Restaurant::query()->findOrFail($restaurantId);
+
+        if (! OpeningHours::fromRestaurant($restaurant)->isOpenAt($datetime)) {
+            return $this->fullResult($datetime);
+        }
+
+        $tables = $restaurant->tables()->where('active', true)->get();
+        if ($tables->isEmpty()) {
+            return $this->fullResult($datetime);
+        }
+
+        $busyTableIds = $this->busyTableIds($restaurantId, $datetime, (int) $restaurant->slot_buffer_minutes);
+
+        $fittingTables = $tables
+            ->reject(fn (Table $table): bool => $busyTableIds->contains($table->id))
+            ->filter(fn (Table $table): bool => $table->seats >= $partySize);
+
+        if ($fittingTables->isEmpty()) {
+            return $this->fullResult($datetime);
+        }
+
+        $suggested = $fittingTables->sortBy('seats')->first();
+
+        $totalCapacity = (int) $tables->sum('seats');
+        $busyCapacity = (int) $tables->whereIn('id', $busyTableIds->all())->sum('seats');
+        $remainingRatio = $totalCapacity > 0 ? ($totalCapacity - $busyCapacity) / $totalCapacity : 0.0;
+
+        return new SlotAvailabilityResult(
+            slotStart: $datetime,
+            state: $remainingRatio <= self::TIGHT_THRESHOLD ? SlotState::Tight : SlotState::Free,
+            suggestedTableId: $suggested->id,
+            combination: null,
+            alternativeSlots: collect(),
+        );
+    }
+
+    /**
+     * Table ids occupied by an active reservation overlapping the buffered slot.
+     *
+     * A reservation overlaps the requested slot when its `desired_at` falls in
+     * `[datetime - (buffer + duration), datetime + (duration + buffer)]`.
+     *
+     * @return Collection<int, int>
+     */
+    private function busyTableIds(int $restaurantId, CarbonImmutable $datetime, int $bufferMinutes): Collection
+    {
+        $windowStart = $datetime->subMinutes($bufferMinutes + self::SLOT_DURATION_MINUTES);
+        $windowEnd = $datetime->addMinutes(self::SLOT_DURATION_MINUTES + $bufferMinutes);
+
+        return ReservationRequest::query()
+            ->where('restaurant_id', $restaurantId)
+            ->whereIn('status', array_map(fn (ReservationStatus $status): string => $status->value, self::OCCUPYING_STATUSES))
+            ->whereBetween('desired_at', [$windowStart, $windowEnd])
+            ->with('tableAssignments:id,reservation_request_id,table_id')
+            ->get()
+            ->flatMap(fn (ReservationRequest $reservation): Collection => $reservation->tableAssignments->pluck('table_id'))
+            ->unique()
+            ->values();
+    }
+
+    private function fullResult(CarbonImmutable $datetime): SlotAvailabilityResult
+    {
+        return new SlotAvailabilityResult(
+            slotStart: $datetime,
+            state: SlotState::Full,
+            suggestedTableId: null,
+            combination: null,
+            alternativeSlots: collect(),
+        );
+    }
+}

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Availability;
+
+use App\Enums\ReservationStatus;
+use App\Enums\SlotState;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use App\Services\Availability\SlotAvailability;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SlotAvailabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private SlotAvailability $service;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = $this->app->make(SlotAvailability::class);
+
+        // UTC keeps the slot time, stored desired_at, and opening-hours frame
+        // identical, so the occupancy maths under test is not confounded by
+        // timezone conversion (which OpeningHours already covers separately).
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+    }
+
+    private function slot(string $time, int $partySize): SlotAvailabilityResult
+    {
+        return $this->service->forSlot(
+            $this->restaurant->id,
+            CarbonImmutable::parse($time, 'UTC'),
+            $partySize,
+        );
+    }
+
+    private function occupy(Table $table, string $desiredAt, ReservationStatus $status, int $partySize = 4): void
+    {
+        $reservation = ReservationRequest::factory()
+            ->for($this->restaurant)
+            ->create([
+                'desired_at' => CarbonImmutable::parse($desiredAt, 'UTC'),
+                'party_size' => $partySize,
+                'status' => $status,
+            ]);
+
+        ReservationTableAssignment::factory()
+            ->for($reservation, 'reservationRequest')
+            ->for($table)
+            ->create();
+    }
+
+    public function test_marks_slot_free_when_a_fitting_table_is_unoccupied(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Free, $result->state);
+        $this->assertNotNull($result->suggestedTableId);
+    }
+
+    public function test_suggests_the_smallest_fitting_table(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+        $small = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 3);
+
+        $this->assertSame(SlotState::Free, $result->state);
+        $this->assertSame($small->id, $result->suggestedTableId);
+    }
+
+    public function test_marks_slot_full_when_no_table_fits_the_party_size(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 2]);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 6);
+
+        $this->assertSame(SlotState::Full, $result->state);
+        $this->assertNull($result->suggestedTableId);
+    }
+
+    public function test_marks_slot_full_when_the_only_fitting_table_is_busy_in_the_buffer_window(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        // 18:00 reservation runs to 19:30 (+90 min) and the 90-min buffer extends
+        // its footprint past 19:00, so the 19:00 slot must be Full.
+        $this->occupy($table, '2026-06-15 18:00', ReservationStatus::Confirmed);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Full, $result->state);
+    }
+
+    public function test_does_not_count_new_or_declined_reservations_as_occupying(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00', ReservationStatus::New);
+        $this->occupy(Table::factory()->for($this->restaurant)->create(['seats' => 4]), '2026-06-15 19:00', ReservationStatus::Declined);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Free, $result->state);
+    }
+
+    public function test_ignores_inactive_tables(): void
+    {
+        Table::factory()->for($this->restaurant)->inactive()->create(['seats' => 8]);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 6);
+
+        $this->assertSame(SlotState::Full, $result->state);
+        $this->assertNull($result->suggestedTableId);
+    }
+
+    public function test_returns_full_for_a_slot_outside_opening_hours(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $result = $this->slot('2026-06-15 09:00', partySize: 2);
+
+        $this->assertSame(SlotState::Full, $result->state);
+    }
+
+    public function test_returns_full_when_the_restaurant_has_no_active_tables(): void
+    {
+        $result = $this->slot('2026-06-15 19:00', partySize: 2);
+
+        $this->assertSame(SlotState::Full, $result->state);
+    }
+
+    public function test_marks_slot_tight_when_remaining_capacity_is_at_or_below_the_threshold(): void
+    {
+        // 4 tables x 4 seats = 16 total. Occupy three (12 seats) at 19:00.
+        // Remaining 4/16 = 25% -> Tight. The 4th table still fits party size 2.
+        $tables = Table::factory()->for($this->restaurant)->count(4)->create(['seats' => 4]);
+        foreach ([0, 1, 2] as $i) {
+            $this->occupy($tables[$i], '2026-06-15 19:00', ReservationStatus::Confirmed);
+        }
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 2);
+
+        $this->assertSame(SlotState::Tight, $result->state);
+        $this->assertSame($tables[3]->id, $result->suggestedTableId);
+    }
+
+    public function test_combination_and_alternative_slots_are_empty_in_this_task(): void
+    {
+        // forSlot in PRD-011 Task 5 returns a single-table suggestion only;
+        // combination logic (#314) and alternative slots (#315) land later.
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertNull($result->combination);
+        $this->assertTrue($result->alternativeSlots->isEmpty());
+    }
+}

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -10,6 +10,7 @@ use App\Models\ReservationRequest;
 use App\Models\ReservationTableAssignment;
 use App\Models\Restaurant;
 use App\Models\Table;
+use App\Models\User;
 use App\Services\Availability\DTOs\SlotAvailabilityResult;
 use App\Services\Availability\SlotAvailability;
 use Carbon\CarbonImmutable;
@@ -162,6 +163,35 @@ class SlotAvailabilityTest extends TestCase
 
         $this->assertSame(SlotState::Tight, $result->state);
         $this->assertSame($tables[3]->id, $result->suggestedTableId);
+    }
+
+    public function test_a_reservation_exactly_on_the_window_edge_does_not_occupy_the_slot(): void
+    {
+        // Window for a 19:00 slot with 90-min buffer + 90-min duration ends at
+        // 22:00. A 22:00 reservation's footprint starts at 20:30 and only touches
+        // the slot's 20:30 end (half-open intervals), so it must not block 19:00.
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 22:00', ReservationStatus::Confirmed);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Free, $result->state);
+        $this->assertSame($table->id, $result->suggestedTableId);
+    }
+
+    public function test_result_is_independent_of_the_authenticated_users_restaurant(): void
+    {
+        // A deterministic availability service must ignore the tenant global scope:
+        // a logged-in user from a *different* restaurant must not make this
+        // restaurant's free table disappear (which the RestaurantScope would do).
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $otherRestaurant = Restaurant::factory()->create();
+        $this->actingAs(User::factory()->forRestaurant($otherRestaurant)->create());
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Free, $result->state);
+        $this->assertNotNull($result->suggestedTableId);
     }
 
     public function test_combination_and_alternative_slots_are_empty_in_this_task(): void


### PR DESCRIPTION
## Summary

The keystone availability method for PRD-011 (plan Task 5):

- `app/Services/Availability/SlotAvailability.php` — `forSlot(restaurantId, datetime, partySize)` returns a `SlotAvailabilityResult` with state `free` / `tight` / `full`.
- Occupancy is per-table, buffer-aware: a reservation at `desired_at` blocks its table over `[desired_at - (buffer + 90), desired_at + (90 + buffer)]`. Slot duration is a fixed 90 min in V3.
- Occupying statuses: `InReview`, `Replied`, `Confirmed`. `New` / `Declined` / `Cancelled` never occupy.
- `tight` = a fitting table is free but ≤ 25 % of total active capacity remains; otherwise `free`. Suggests the smallest fitting single table.
- `tests/Unit/Availability/SlotAvailabilityTest.php` — 10 cases (free, smallest-table suggestion, party too large, busy-in-buffer, new/declined ignored, inactive tables ignored, outside opening hours, no tables, tight 25%-edge, combination/alternatives empty for this task).

## Why

PRD-011 makes availability **deterministic and interactively queryable**, replacing the per-request slot heuristic from PRD-005. This single method is the foundation the combination logic (#314), alternative slots (#315), day grid (#316) and the `ReservationContextBuilder` re-route (#317) all build on. The AI never decides availability — it only phrases this result.

## Deviations from the plan (and why)

- **Opening hours:** reuse the existing `App\Support\OpeningHours::fromRestaurant()->isOpenAt()` (timezone-aware, `from`/`to` schedule shape) instead of the plan's inline reimplementation, which assumed `open`/`close` keys that don't exist in this codebase. Continuing the established pattern avoids a second, divergent opening-hours parser.
- **`Waitlisted` status:** the issue lists it as non-occupying, but that enum case doesn't exist yet (PRD-013). Omitted; the occupying set (`InReview`/`Replied`/`Confirmed`) is what matters and is unaffected.
- Tests use the existing PHPUnit-class style (this repo has no Pest despite the docs); the test restaurant is pinned to UTC so the occupancy maths isn't confounded by timezone conversion.

## Test plan

- [x] `php artisan test tests/Unit/Availability/SlotAvailabilityTest.php` — 10 pass
- [x] `php artisan test` — 848 pass (838 + 10), no regressions
- [x] `./vendor/bin/pint --test` on touched paths — clean
- [x] No JS/TS changes → ESLint/Prettier not applicable

Closes #313