### PR TITLE
PRD-011: SlotAvailability::suggestTableCombination (single + 2-table combo) (#314)

### DIFF
--- a/app/Services/Availability/SlotAvailability.php
+++ b/app/Services/Availability/SlotAvailability.php
@@ -108,11 +108,20 @@ final class SlotAvailability
     /**
      * Active tables of the restaurant, independent of the tenant global scope.
      *
+     * Ordered by `sort_order` then `id` so that downstream tie-breaks — most
+     * notably which table becomes the primary of a symmetric combination — are
+     * deterministic regardless of database row order or engine.
+     *
      * @return Collection<int, Table>
      */
     private function activeTables(Restaurant $restaurant): Collection
     {
-        return $restaurant->tables()->withoutGlobalScopes()->where('active', true)->get();
+        return $restaurant->tables()
+            ->withoutGlobalScopes()
+            ->where('active', true)
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
     }
 
     /**

--- a/app/Services/Availability/SlotAvailability.php
+++ b/app/Services/Availability/SlotAvailability.php
@@ -10,6 +10,7 @@ use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Models\Table;
 use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use App\Services\Availability\DTOs\TableCombination;
 use App\Support\OpeningHours;
 use Carbon\CarbonImmutable;
 use Illuminate\Support\Collection;
@@ -27,8 +28,9 @@ use Illuminate\Support\Collection;
  * reservation at `desired_at` occupies its table over the half-open footprint
  * `[desired_at - buffer, desired_at + slot_duration + buffer)`. Slot duration is
  * a fixed 90 min in V3 (per-restaurant configurability is a documented PRD-011
- * follow-up). Single-table suggestion only in this task; combinations (#314) and
- * alternative slots (#315) extend this service later.
+ * follow-up). A party that fits no single table can be seated on a two-table
+ * combination via `combinable_with` (max two tables in V3); alternative slots
+ * (#315) extend this service later.
  */
 final class SlotAvailability
 {
@@ -56,34 +58,109 @@ final class SlotAvailability
             return $this->fullResult($datetime);
         }
 
-        $tables = $restaurant->tables()->withoutGlobalScopes()->where('active', true)->get();
+        $tables = $this->activeTables($restaurant);
         if ($tables->isEmpty()) {
             return $this->fullResult($datetime);
         }
 
         $busyTableIds = $this->busyTableIds($restaurantId, $datetime, (int) $restaurant->slot_buffer_minutes);
-
-        $fittingTables = $tables
-            ->reject(fn (Table $table): bool => $busyTableIds->contains($table->id))
-            ->filter(fn (Table $table): bool => $table->seats >= $partySize);
-
-        if ($fittingTables->isEmpty()) {
-            return $this->fullResult($datetime);
-        }
-
-        $suggested = $fittingTables->sortBy('seats')->first();
+        $freeTables = $tables->reject(fn (Table $table): bool => $busyTableIds->contains($table->id));
 
         $totalCapacity = (int) $tables->sum('seats');
         $busyCapacity = (int) $tables->whereIn('id', $busyTableIds->all())->sum('seats');
         $remainingRatio = $totalCapacity > 0 ? ($totalCapacity - $busyCapacity) / $totalCapacity : 0.0;
+        $state = $remainingRatio <= self::TIGHT_THRESHOLD ? SlotState::Tight : SlotState::Free;
+
+        $fitting = $this->combinationFrom($freeTables, $partySize);
+        if ($fitting === null) {
+            return $this->fullResult($datetime);
+        }
 
         return new SlotAvailabilityResult(
             slotStart: $datetime,
-            state: $remainingRatio <= self::TIGHT_THRESHOLD ? SlotState::Tight : SlotState::Free,
-            suggestedTableId: $suggested->id,
-            combination: null,
+            state: $state,
+            suggestedTableId: $fitting->primaryTableId,
+            combination: count($fitting->tableIds) > 1 ? $fitting : null,
             alternativeSlots: collect(),
         );
+    }
+
+    /**
+     * Smallest table assignment that seats `$partySize` in the given slot, or
+     * null if neither a single table nor a two-table combination fits. Prefers a
+     * single table; falls back to the smallest compatible `combinable_with` pair.
+     */
+    public function suggestTableCombination(int $restaurantId, CarbonImmutable $datetime, int $partySize): ?TableCombination
+    {
+        $restaurant = Restaurant::query()->findOrFail($restaurantId);
+        $tables = $this->activeTables($restaurant);
+
+        if ($tables->isEmpty()) {
+            return null;
+        }
+
+        $busyTableIds = $this->busyTableIds($restaurantId, $datetime, (int) $restaurant->slot_buffer_minutes);
+        $freeTables = $tables->reject(fn (Table $table): bool => $busyTableIds->contains($table->id));
+
+        return $this->combinationFrom($freeTables, $partySize);
+    }
+
+    /**
+     * Active tables of the restaurant, independent of the tenant global scope.
+     *
+     * @return Collection<int, Table>
+     */
+    private function activeTables(Restaurant $restaurant): Collection
+    {
+        return $restaurant->tables()->withoutGlobalScopes()->where('active', true)->get();
+    }
+
+    /**
+     * Pick a table assignment for `$partySize` from already-resolved free tables:
+     * the smallest fitting single table, else the smallest compatible two-table
+     * combination, else null. V3 caps combinations at two tables.
+     *
+     * @param  Collection<int, Table>  $freeTables
+     */
+    private function combinationFrom(Collection $freeTables, int $partySize): ?TableCombination
+    {
+        $single = $freeTables
+            ->filter(fn (Table $table): bool => $table->seats >= $partySize)
+            ->sortBy('seats')
+            ->first();
+
+        if ($single !== null) {
+            return new TableCombination(
+                primaryTableId: $single->id,
+                tableIds: [$single->id],
+                totalSeats: (int) $single->seats,
+            );
+        }
+
+        $best = null;
+        foreach ($freeTables as $primary) {
+            foreach ($primary->combinable_with ?? [] as $partnerId) {
+                $partner = $freeTables->firstWhere('id', $partnerId);
+                if ($partner === null || $partner->id === $primary->id) {
+                    continue;
+                }
+
+                $total = (int) $primary->seats + (int) $partner->seats;
+                if ($total < $partySize) {
+                    continue;
+                }
+
+                if ($best === null || $total < $best->totalSeats) {
+                    $best = new TableCombination(
+                        primaryTableId: $primary->id,
+                        tableIds: [$primary->id, $partner->id],
+                        totalSeats: $total,
+                    );
+                }
+            }
+        }
+
+        return $best;
     }
 
     /**

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -194,15 +194,104 @@ class SlotAvailabilityTest extends TestCase
         $this->assertNotNull($result->suggestedTableId);
     }
 
-    public function test_combination_and_alternative_slots_are_empty_in_this_task(): void
+    public function test_no_combination_when_a_single_table_already_fits(): void
     {
-        // forSlot in PRD-011 Task 5 returns a single-table suggestion only;
-        // combination logic (#314) and alternative slots (#315) land later.
+        // A single fitting table is suggested as suggestedTableId; the combination
+        // slot stays null. Alternative slots arrive in #315.
         Table::factory()->for($this->restaurant)->create(['seats' => 4]);
 
         $result = $this->slot('2026-06-15 19:00', partySize: 4);
 
         $this->assertNull($result->combination);
         $this->assertTrue($result->alternativeSlots->isEmpty());
+    }
+
+    public function test_suggest_combination_prefers_the_smallest_fitting_single_table(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8, 'sort_order' => 1]);
+        $small = Table::factory()->for($this->restaurant)->create(['seats' => 4, 'sort_order' => 2]);
+
+        $combo = $this->service->suggestTableCombination(
+            $this->restaurant->id,
+            CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            partySize: 3,
+        );
+
+        $this->assertNotNull($combo);
+        $this->assertSame([$small->id], $combo->tableIds);
+        $this->assertSame($small->id, $combo->primaryTableId);
+        $this->assertSame(4, $combo->totalSeats);
+    }
+
+    public function test_suggest_combination_returns_a_two_table_combo_when_no_single_table_fits(): void
+    {
+        [$a, $b] = $this->combinablePair(4, 4);
+
+        $combo = $this->service->suggestTableCombination(
+            $this->restaurant->id,
+            CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            partySize: 6,
+        );
+
+        $this->assertNotNull($combo);
+        $this->assertCount(2, $combo->tableIds);
+        $this->assertEqualsCanonicalizing([$a->id, $b->id], $combo->tableIds);
+        $this->assertSame(8, $combo->totalSeats);
+    }
+
+    public function test_suggest_combination_returns_null_when_no_single_or_compatible_combo_fits(): void
+    {
+        // Two small tables that are NOT combinable with each other.
+        Table::factory()->for($this->restaurant)->create(['seats' => 2]);
+        Table::factory()->for($this->restaurant)->create(['seats' => 2]);
+
+        $combo = $this->service->suggestTableCombination(
+            $this->restaurant->id,
+            CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            partySize: 8,
+        );
+
+        $this->assertNull($combo);
+    }
+
+    public function test_suggest_combination_does_not_combine_a_busy_table(): void
+    {
+        [$a, $b] = $this->combinablePair(4, 4);
+        $this->occupy($a, '2026-06-15 19:00', ReservationStatus::Confirmed);
+
+        $combo = $this->service->suggestTableCombination(
+            $this->restaurant->id,
+            CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            partySize: 6,
+        );
+
+        $this->assertNull($combo);
+    }
+
+    public function test_for_slot_returns_a_combination_when_no_single_table_fits(): void
+    {
+        $this->combinablePair(4, 4);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 6);
+
+        $this->assertSame(SlotState::Free, $result->state);
+        $this->assertNotNull($result->combination);
+        $this->assertCount(2, $result->combination->tableIds);
+        $this->assertSame($result->combination->primaryTableId, $result->suggestedTableId);
+    }
+
+    /**
+     * Create two tables of the restaurant that can be combined with each other.
+     *
+     * @return array{0: Table, 1: Table}
+     */
+    private function combinablePair(int $seatsA, int $seatsB): array
+    {
+        $a = Table::factory()->for($this->restaurant)->create(['seats' => $seatsA, 'sort_order' => 1]);
+        $b = Table::factory()->for($this->restaurant)->create(['seats' => $seatsB, 'sort_order' => 2]);
+        $a->update(['combinable_with' => [$b->id]]);
+        $b->update(['combinable_with' => [$a->id]]);
+
+        return [$a, $b];
     }
 }

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -237,6 +237,8 @@ class SlotAvailabilityTest extends TestCase
         $this->assertCount(2, $combo->tableIds);
         $this->assertEqualsCanonicalizing([$a->id, $b->id], $combo->tableIds);
         $this->assertSame(8, $combo->totalSeats);
+        // Lower sort_order wins the primary slot deterministically (a before b).
+        $this->assertSame($a->id, $combo->primaryTableId);
     }
 
     public function test_suggest_combination_returns_null_when_no_single_or_compatible_combo_fits(): void
@@ -270,13 +272,14 @@ class SlotAvailabilityTest extends TestCase
 
     public function test_for_slot_returns_a_combination_when_no_single_table_fits(): void
     {
-        $this->combinablePair(4, 4);
+        [$a] = $this->combinablePair(4, 4);
 
         $result = $this->slot('2026-06-15 19:00', partySize: 6);
 
         $this->assertSame(SlotState::Free, $result->state);
         $this->assertNotNull($result->combination);
         $this->assertCount(2, $result->combination->tableIds);
+        $this->assertSame($a->id, $result->combination->primaryTableId);
         $this->assertSame($result->combination->primaryTableId, $result->suggestedTableId);
     }
 


### PR DESCRIPTION
## Summary

Adds combination support to the availability service (PRD-011, plan Task 6):

- `suggestTableCombination(restaurantId, datetime, partySize): ?TableCombination` — smallest fitting single table; else the smallest compatible two-table combination via `combinable_with` (max two tables in V3); else `null`. Busy tables are excluded.
- `forSlot` now falls back to a combination when no single table fits the party size: it returns `free`/`tight` with the `combination` field set and `suggestedTableId` = the combination's primary table.
- Extracted shared private helpers `activeTables()` and `combinationFrom()` so `forSlot` and `suggestTableCombination` share occupancy logic without re-querying.
- 6 new test cases (single-table preference, two-table combo, no-fit → null, busy table excluded from combo, forSlot combination fallback, single-fit → no combination).

## Why

Restaurants frequently seat larger parties by pushing two tables together. PRD-011 models this deterministically so the AI can phrase "we can seat you on a combined table" without ever deciding availability itself. Capping at two tables keeps V3 scope tight (3+ is deferred).

## Notes

- State for a combination slot is computed from the same remaining-capacity ratio as the single-table path (not hardcoded), so a busy restaurant offering only a combination is still correctly reported as `tight`.
- Inherits the deterministic, tenant-scope-independent querying and half-open occupancy window from #313.

## Test plan

- [x] `php artisan test tests/Unit/Availability/SlotAvailabilityTest.php` — 17 pass
- [x] `php artisan test` — 855 pass, no regressions
- [x] `./vendor/bin/pint --test` on touched paths — clean
- [x] No JS/TS changes → ESLint/Prettier not applicable

Closes #314