### PR TITLE
PRD-011: SlotAvailability::freeTablesAt + alternative slot suggestions (#315)

### DIFF
--- a/app/Services/Availability/SlotAvailability.php
+++ b/app/Services/Availability/SlotAvailability.php
@@ -36,6 +36,10 @@ final class SlotAvailability
 {
     private const int SLOT_DURATION_MINUTES = 90;
 
+    private const int SLOT_INCREMENT_MINUTES = 30;
+
+    private const int MAX_ALTERNATIVE_SLOTS = 3;
+
     private const float TIGHT_THRESHOLD = 0.25;
 
     /**
@@ -51,6 +55,40 @@ final class SlotAvailability
     ];
 
     public function forSlot(int $restaurantId, CarbonImmutable $datetime, int $partySize): SlotAvailabilityResult
+    {
+        $result = $this->evaluateSlot($restaurantId, $datetime, $partySize);
+
+        if ($result->state !== SlotState::Full) {
+            return $result;
+        }
+
+        // Only a full slot needs next-best times; evaluateSlot itself never
+        // recurses into the alternative search, so this stays bounded.
+        return new SlotAvailabilityResult(
+            slotStart: $result->slotStart,
+            state: $result->state,
+            suggestedTableId: $result->suggestedTableId,
+            combination: $result->combination,
+            alternativeSlots: $this->findAlternativeSlots($restaurantId, $datetime, $partySize),
+        );
+    }
+
+    /**
+     * Active tables free for the buffered slot, ordered for deterministic output.
+     *
+     * @return Collection<int, Table>
+     */
+    public function freeTablesAt(int $restaurantId, CarbonImmutable $datetime): Collection
+    {
+        $restaurant = Restaurant::query()->findOrFail($restaurantId);
+        $busyTableIds = $this->busyTableIds($restaurantId, $datetime, (int) $restaurant->slot_buffer_minutes);
+
+        return $this->activeTables($restaurant)
+            ->reject(fn (Table $table): bool => $busyTableIds->contains($table->id))
+            ->values();
+    }
+
+    private function evaluateSlot(int $restaurantId, CarbonImmutable $datetime, int $partySize): SlotAvailabilityResult
     {
         $restaurant = Restaurant::query()->findOrFail($restaurantId);
 
@@ -199,6 +237,30 @@ final class SlotAvailability
             ->flatMap(fn (ReservationRequest $reservation): Collection => $reservation->tableAssignments->pluck('table_id'))
             ->unique()
             ->values();
+    }
+
+    /**
+     * Up to three later same-day slots (30-min steps) that are not full, used to
+     * offer next-best times when the requested slot is full. Closed and full
+     * candidates are skipped because evaluateSlot reports them as full.
+     *
+     * @return Collection<int, CarbonImmutable>
+     */
+    private function findAlternativeSlots(int $restaurantId, CarbonImmutable $after, int $partySize): Collection
+    {
+        $alternatives = collect();
+        $candidate = $after->addMinutes(self::SLOT_INCREMENT_MINUTES);
+        $endOfDay = $after->setTime(23, 59, 59);
+
+        while ($alternatives->count() < self::MAX_ALTERNATIVE_SLOTS && $candidate->lte($endOfDay)) {
+            if ($this->evaluateSlot($restaurantId, $candidate, $partySize)->state !== SlotState::Full) {
+                $alternatives->push($candidate);
+            }
+
+            $candidate = $candidate->addMinutes(self::SLOT_INCREMENT_MINUTES);
+        }
+
+        return $alternatives->values();
     }
 
     private function fullResult(CarbonImmutable $datetime): SlotAvailabilityResult

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -283,6 +283,64 @@ class SlotAvailabilityTest extends TestCase
         $this->assertSame($result->combination->primaryTableId, $result->suggestedTableId);
     }
 
+    public function test_free_tables_at_returns_unbooked_active_tables_only(): void
+    {
+        $busyTable = Table::factory()->for($this->restaurant)->create(['seats' => 4, 'sort_order' => 1]);
+        $freeTable = Table::factory()->for($this->restaurant)->create(['seats' => 4, 'sort_order' => 2]);
+        Table::factory()->for($this->restaurant)->inactive()->create(['seats' => 4, 'sort_order' => 3]);
+        $this->occupy($busyTable, '2026-06-15 19:00', ReservationStatus::Confirmed);
+
+        $free = $this->service->freeTablesAt(
+            $this->restaurant->id,
+            CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+        );
+
+        $this->assertSame([$freeTable->id], $free->pluck('id')->all());
+    }
+
+    public function test_for_slot_fills_alternative_slots_with_next_free_slots_when_full(): void
+    {
+        // One table booked at 19:00. With 90-min buffer + 90-min duration the
+        // table is busy until 22:00; the next 30-min slots inside the 17:00-23:00
+        // window are 22:00 and 22:30, then 23:00 is closed.
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00', ReservationStatus::Confirmed);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Full, $result->state);
+        $this->assertSame(
+            ['22:00', '22:30'],
+            $result->alternativeSlots->map(fn ($slot) => $slot->format('H:i'))->all(),
+        );
+    }
+
+    public function test_alternative_slots_are_capped_at_three(): void
+    {
+        // Free all evening: an early-afternoon full slot (outside hours) yields the
+        // first three open 30-min slots from 17:00.
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $result = $this->slot('2026-06-15 09:00', partySize: 4);
+
+        $this->assertSame(SlotState::Full, $result->state);
+        $this->assertCount(3, $result->alternativeSlots);
+        $this->assertSame(
+            ['17:00', '17:30', '18:00'],
+            $result->alternativeSlots->map(fn ($slot) => $slot->format('H:i'))->all(),
+        );
+    }
+
+    public function test_alternative_slots_stay_empty_for_a_free_slot(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Free, $result->state);
+        $this->assertTrue($result->alternativeSlots->isEmpty());
+    }
+
     /**
      * Create two tables of the restaurant that can be combined with each other.
      *


### PR DESCRIPTION
## Summary

Completes the availability service surface for PRD-011 (plan Task 7):

- `freeTablesAt(restaurantId, datetime): Collection<int, Table>` — the active, unbooked tables for a buffered slot, ordered by `sort_order`/`id` for deterministic output.
- `forSlot` now populates `alternativeSlots` with up to three later **same-day** slots (30-minute steps within opening hours) when the requested slot is `full`. Closed/full candidates are skipped naturally because `evaluateSlot` reports them as full.
- Refactor: `forSlot` is split into the public entry point and a private `evaluateSlot`, so the alternative search reuses slot evaluation without recursion.
- 4 new tests (free tables exclude busy + inactive; alternatives `[22:00, 22:30]` after a full 19:00; cap at three `[17:00, 17:30, 18:00]`; free slot keeps alternatives empty).

## Why

When a caller's desired time is full, the consumer surfaces (the Belegungs-Tab in #321 and PRD-012's phone/walk-in entry) need ready next-best times to offer the guest — still computed deterministically by Laravel, never by the AI.

## Notes

- Inherits the determinism (`withoutGlobalScopes`, ordered tables) and half-open occupancy window from #313/#314 via the shared `activeTables()`/`busyTableIds()` helpers — `freeTablesAt` uses `activeTables()` rather than the raw relationship (the plan sketch omitted `withoutGlobalScopes`, which would have re-introduced the tenant-scope bug).
- The alternative search is bounded: it stops at three results or end-of-day, and `evaluateSlot` never recurses into it.

## Test plan

- [x] `php artisan test tests/Unit/Availability/SlotAvailabilityTest.php` — 21 pass
- [x] `php artisan test` — 859 pass, no regressions
- [x] `./vendor/bin/pint --test` on touched paths — clean
- [x] No JS/TS changes → ESLint/Prettier not applicable

Closes #315