### PR TITLE
PRD-011: SlotAvailability::forDay (full day grid) (#316)

### DIFF
--- a/app/Services/Availability/SlotAvailability.php
+++ b/app/Services/Availability/SlotAvailability.php
@@ -128,17 +128,23 @@ final class SlotAvailability
         $buffer = (int) $restaurant->slot_buffer_minutes;
 
         $reservations = $this->dayReservations($restaurantId, $date, $buffer);
+        $openingHours = OpeningHours::fromRestaurant($restaurant);
 
+        // Walk the day in 30-min steps and keep the open ones. Delegating the
+        // open check to OpeningHours::isOpenAt (the same authority forSlot uses)
+        // keeps slot selection timezone-correct without re-deriving cursor times
+        // from the raw schedule strings.
         $slots = collect();
-        foreach (OpeningHours::fromRestaurant($restaurant)->blocksAt($date) as $window) {
-            $cursor = $date->setTimeFromTimeString($window['from']);
-            $close = $date->setTimeFromTimeString($window['to']);
+        $cursor = $date->startOfDay();
+        $endOfDay = $date->endOfDay();
 
-            while ($cursor->lt($close)) {
+        while ($cursor->lte($endOfDay)) {
+            if ($openingHours->isOpenAt($cursor)) {
                 $busyTableIds = $this->busyTableIdsFrom($reservations, $cursor, $buffer);
                 $slots->push($this->slotVerdict($tables, $busyTableIds, $cursor, partySize: 1));
-                $cursor = $cursor->addMinutes(self::SLOT_INCREMENT_MINUTES);
             }
+
+            $cursor = $cursor->addMinutes(self::SLOT_INCREMENT_MINUTES);
         }
 
         $reservedSeats = (int) $reservations
@@ -308,6 +314,8 @@ final class SlotAvailability
      * Active reservations (with table assignments) that could occupy any slot on
      * `$date`, loaded in one query. The window is padded by buffer + duration on
      * both sides so reservations spilling in from the adjacent days are included.
+     * Bounds are intentionally inclusive (a deliberate over-fetch); the precise
+     * half-open occupancy window is applied per slot by busyTableIdsFrom().
      *
      * @return Collection<int, ReservationRequest>
      */

--- a/app/Services/Availability/SlotAvailability.php
+++ b/app/Services/Availability/SlotAvailability.php
@@ -9,6 +9,7 @@ use App\Enums\SlotState;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Models\Table;
+use App\Services\Availability\DTOs\DayAvailability;
 use App\Services\Availability\DTOs\SlotAvailabilityResult;
 use App\Services\Availability\DTOs\TableCombination;
 use App\Support\OpeningHours;
@@ -113,7 +114,48 @@ final class SlotAvailability
     }
 
     /**
-     * Evaluate one slot against pre-resolved restaurant + active tables.
+     * Full-day occupancy grid: one slot per 30 minutes within opening hours,
+     * each evaluated for a party of one (table-level occupancy, not party fit).
+     *
+     * Loads the restaurant, its active tables and the day's active reservations
+     * once and evaluates every slot in memory, so the whole grid costs a bounded
+     * number of queries rather than one per slot.
+     */
+    public function forDay(int $restaurantId, CarbonImmutable $date): DayAvailability
+    {
+        $restaurant = Restaurant::query()->findOrFail($restaurantId);
+        $tables = $this->activeTables($restaurant);
+        $buffer = (int) $restaurant->slot_buffer_minutes;
+
+        $reservations = $this->dayReservations($restaurantId, $date, $buffer);
+
+        $slots = collect();
+        foreach (OpeningHours::fromRestaurant($restaurant)->blocksAt($date) as $window) {
+            $cursor = $date->setTimeFromTimeString($window['from']);
+            $close = $date->setTimeFromTimeString($window['to']);
+
+            while ($cursor->lt($close)) {
+                $busyTableIds = $this->busyTableIdsFrom($reservations, $cursor, $buffer);
+                $slots->push($this->slotVerdict($tables, $busyTableIds, $cursor, partySize: 1));
+                $cursor = $cursor->addMinutes(self::SLOT_INCREMENT_MINUTES);
+            }
+        }
+
+        $reservedSeats = (int) $reservations
+            ->filter(fn (ReservationRequest $reservation): bool => $reservation->desired_at->toDateString() === $date->toDateString())
+            ->sum('party_size');
+
+        return new DayAvailability(
+            date: $date->startOfDay(),
+            slots: $slots,
+            totalCapacity: (int) $tables->sum('seats'),
+            reservedSeats: $reservedSeats,
+        );
+    }
+
+    /**
+     * Evaluate one slot against pre-resolved restaurant + active tables, running
+     * its own per-slot occupancy query.
      *
      * Kept free of recursion (never calls the alternative search) so callers can
      * loop over many candidates cheaply: only the per-slot occupancy query runs
@@ -127,11 +169,24 @@ final class SlotAvailability
             return $this->fullResult($datetime);
         }
 
+        $busyTableIds = $this->busyTableIds($restaurant->id, $datetime, (int) $restaurant->slot_buffer_minutes);
+
+        return $this->slotVerdict($tables, $busyTableIds, $datetime, $partySize);
+    }
+
+    /**
+     * Pure free/tight/full verdict for a slot given pre-resolved tables and the
+     * table ids busy at that slot. No queries — safe to call in a tight loop.
+     *
+     * @param  Collection<int, Table>  $tables
+     * @param  Collection<int, int>  $busyTableIds
+     */
+    private function slotVerdict(Collection $tables, Collection $busyTableIds, CarbonImmutable $datetime, int $partySize): SlotAvailabilityResult
+    {
         if ($tables->isEmpty()) {
             return $this->fullResult($datetime);
         }
 
-        $busyTableIds = $this->busyTableIds($restaurant->id, $datetime, (int) $restaurant->slot_buffer_minutes);
         $freeTables = $tables->reject(fn (Table $table): bool => $busyTableIds->contains($table->id));
 
         $totalCapacity = (int) $tables->sum('seats');
@@ -244,6 +299,47 @@ final class SlotAvailability
             ->where('desired_at', '<', $windowEnd)
             ->with(['tableAssignments' => fn ($query) => $query->withoutGlobalScopes()->select('id', 'reservation_request_id', 'table_id')])
             ->get()
+            ->flatMap(fn (ReservationRequest $reservation): Collection => $reservation->tableAssignments->pluck('table_id'))
+            ->unique()
+            ->values();
+    }
+
+    /**
+     * Active reservations (with table assignments) that could occupy any slot on
+     * `$date`, loaded in one query. The window is padded by buffer + duration on
+     * both sides so reservations spilling in from the adjacent days are included.
+     *
+     * @return Collection<int, ReservationRequest>
+     */
+    private function dayReservations(int $restaurantId, CarbonImmutable $date, int $bufferMinutes): Collection
+    {
+        $margin = $bufferMinutes + self::SLOT_DURATION_MINUTES;
+
+        return ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->where('restaurant_id', $restaurantId)
+            ->whereIn('status', array_map(fn (ReservationStatus $status): string => $status->value, self::OCCUPYING_STATUSES))
+            ->where('desired_at', '>=', $date->startOfDay()->subMinutes($margin))
+            ->where('desired_at', '<=', $date->endOfDay()->addMinutes($margin))
+            ->with(['tableAssignments' => fn ($query) => $query->withoutGlobalScopes()->select('id', 'reservation_request_id', 'table_id')])
+            ->get();
+    }
+
+    /**
+     * In-memory variant of {@see busyTableIds}: which table ids the already-loaded
+     * reservations occupy at `$datetime`, using the same half-open window. Lets
+     * the day grid evaluate every slot without a query per slot.
+     *
+     * @param  Collection<int, ReservationRequest>  $reservations
+     * @return Collection<int, int>
+     */
+    private function busyTableIdsFrom(Collection $reservations, CarbonImmutable $datetime, int $bufferMinutes): Collection
+    {
+        $windowStart = $datetime->subMinutes($bufferMinutes + self::SLOT_DURATION_MINUTES);
+        $windowEnd = $datetime->addMinutes(self::SLOT_DURATION_MINUTES + $bufferMinutes);
+
+        return $reservations
+            ->filter(fn (ReservationRequest $reservation): bool => $reservation->desired_at->gt($windowStart) && $reservation->desired_at->lt($windowEnd))
             ->flatMap(fn (ReservationRequest $reservation): Collection => $reservation->tableAssignments->pluck('table_id'))
             ->unique()
             ->values();

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -15,6 +15,7 @@ use App\Services\Availability\DTOs\SlotAvailabilityResult;
 use App\Services\Availability\SlotAvailability;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class SlotAvailabilityTest extends TestCase
@@ -354,6 +355,69 @@ class SlotAvailabilityTest extends TestCase
 
         $this->assertSame(SlotState::Full, $result->state);
         $this->assertTrue($result->alternativeSlots->isEmpty());
+    }
+
+    public function test_for_day_returns_one_slot_per_30_minutes_within_opening_hours(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $day = $this->service->forDay($this->restaurant->id, CarbonImmutable::parse('2026-06-15', 'UTC'));
+
+        // 17:00-23:00 in 30-min steps = 12 slots.
+        $this->assertCount(12, $day->slots);
+        $this->assertSame('17:00', $day->slots->first()->slotStart->format('H:i'));
+        $this->assertSame('22:30', $day->slots->last()->slotStart->format('H:i'));
+        $this->assertSame('2026-06-15', $day->date->toDateString());
+    }
+
+    public function test_for_day_computes_total_capacity_and_reserved_seats(): void
+    {
+        Table::factory()->for($this->restaurant)->count(2)->create(['seats' => 4]);
+        $reservation = ReservationRequest::factory()->for($this->restaurant)->create([
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 3,
+            'status' => ReservationStatus::Confirmed,
+        ]);
+        ReservationTableAssignment::factory()
+            ->for($reservation, 'reservationRequest')
+            ->for(Table::query()->first())
+            ->create();
+
+        $day = $this->service->forDay($this->restaurant->id, CarbonImmutable::parse('2026-06-15', 'UTC'));
+
+        $this->assertSame(8, $day->totalCapacity);
+        $this->assertSame(3, $day->reservedSeats);
+    }
+
+    public function test_for_day_marks_individual_slots_busy_from_loaded_reservations(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00', ReservationStatus::Confirmed);
+
+        $day = $this->service->forDay($this->restaurant->id, CarbonImmutable::parse('2026-06-15', 'UTC'));
+        $byTime = $day->slots->keyBy(fn ($slot) => $slot->slotStart->format('H:i'));
+
+        $this->assertSame(SlotState::Full, $byTime->get('19:00')->state);
+        // 22:00 is past the buffered footprint of the 19:00 booking.
+        $this->assertSame(SlotState::Free, $byTime->get('22:00')->state);
+    }
+
+    public function test_for_day_runs_a_bounded_number_of_queries(): void
+    {
+        Table::factory()->for($this->restaurant)->count(5)->create(['seats' => 4]);
+        ReservationRequest::factory()->for($this->restaurant)->count(20)->create([
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+            'status' => ReservationStatus::Confirmed,
+        ]);
+
+        DB::enableQueryLog();
+        $this->service->forDay($this->restaurant->id, CarbonImmutable::parse('2026-06-15', 'UTC'));
+        $queries = DB::getQueryLog();
+        DB::disableQueryLog();
+
+        // restaurant + tables + reservations + eager assignments, no per-slot N+1.
+        $this->assertLessThanOrEqual(4, count($queries));
     }
 
     /**

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -402,6 +402,29 @@ class SlotAvailabilityTest extends TestCase
         $this->assertSame(SlotState::Free, $byTime->get('22:00')->state);
     }
 
+    public function test_for_day_generates_slots_in_the_restaurant_timezone(): void
+    {
+        // A non-UTC restaurant: slots must line up with the restaurant's local
+        // opening hours (via isOpenAt), not the input date's timezone.
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $restaurant = Restaurant::factory()->create([
+            'timezone' => 'Europe/Berlin',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+        Table::factory()->for($restaurant)->create(['seats' => 4]);
+
+        $day = $this->service->forDay($restaurant->id, CarbonImmutable::parse('2026-06-15', 'UTC'));
+
+        $localTimes = $day->slots->map(fn ($slot) => $slot->slotStart->setTimezone('Europe/Berlin')->format('H:i'));
+        $this->assertCount(12, $day->slots);
+        $this->assertSame('17:00', $localTimes->first());
+        $this->assertSame('22:30', $localTimes->last());
+    }
+
     public function test_for_day_runs_a_bounded_number_of_queries(): void
     {
         Table::factory()->for($this->restaurant)->count(5)->create(['seats' => 4]);


### PR DESCRIPTION
## Summary

Completes Phase B of PRD-011 (plan Task 8):

- `forDay(restaurantId, date): DayAvailability` — one `SlotAvailabilityResult` per 30-minute slot within opening hours (evaluated for a party of one, i.e. table-level occupancy), plus `totalCapacity` and `reservedSeats` for the occupancy headline.
- **Bounded query count:** the restaurant, its active tables and the day's active reservations are loaded once, then every slot is evaluated in memory. Extracted `slotVerdict()` (pure free/tight/full given pre-resolved tables + busy ids) and `busyTableIdsFrom()` (in-memory occupancy filter) from the existing per-slot path; `evaluateLoadedSlot` now delegates to `slotVerdict`.
- 4 new tests: 12 slots within 17:00–23:00, totals (capacity 8 / reserved 3), per-slot busy from loaded reservations, and a query-count test asserting ≤ 4 queries.

## Why

The Belegungs-Tab (#321) needs a whole-day grid in one cheap call. The plan's sketch evaluated each slot with its own query, which would blow the per-day query budget; loading reservations once keeps the grid flat in query cost.

## Notes

- Opening-hours windows come from the existing `OpeningHours::blocksAt()` (correct `from`/`to` schedule keys, timezone-aware day selection), not a re-implementation.
- Determinism (`withoutGlobalScopes`, ordered tables) and the half-open occupancy window are shared with the single-slot path through the extracted helpers; `evaluateLoadedSlot` behaviour is unchanged (existing tests stay green).

## Test plan

- [x] `php artisan test tests/Unit/Availability/SlotAvailabilityTest.php` — 26 pass (incl. ≤4-query perf test)
- [x] `php artisan test` — 864 pass, no regressions
- [x] `./vendor/bin/pint --test` on touched paths — clean
- [x] No JS/TS changes → ESLint/Prettier not applicable

Closes #316