### PR TITLE
PRD-011: TablePolicy with tenant + role checks (#318)

### DIFF
--- a/app/Policies/TablePolicy.php
+++ b/app/Policies/TablePolicy.php
@@ -27,6 +27,11 @@ final class TablePolicy
         return $this->belongsToSameRestaurant($user, $table);
     }
 
+    /**
+     * `create` has no table instance yet, so it can only gate by role +
+     * membership; the controller is responsible for assigning the table to the
+     * acting user's own restaurant_id (never trusting a client-supplied one).
+     */
     public function create(User $user): bool
     {
         return $user->restaurant_id !== null && $user->role === UserRole::Owner;

--- a/app/Policies/TablePolicy.php
+++ b/app/Policies/TablePolicy.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\Table;
+use App\Models\User;
+
+/**
+ * Authorization for table master data (PRD-011).
+ *
+ * Tenant isolation lives here, not in the controller: view/update/delete are
+ * scoped to the user's own restaurant. Mutations additionally require the owner
+ * role; staff may only read.
+ */
+final class TablePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->restaurant_id !== null;
+    }
+
+    public function view(User $user, Table $table): bool
+    {
+        return $this->belongsToSameRestaurant($user, $table);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->restaurant_id !== null && $user->role === UserRole::Owner;
+    }
+
+    public function update(User $user, Table $table): bool
+    {
+        return $this->belongsToSameRestaurant($user, $table) && $user->role === UserRole::Owner;
+    }
+
+    public function delete(User $user, Table $table): bool
+    {
+        return $this->belongsToSameRestaurant($user, $table) && $user->role === UserRole::Owner;
+    }
+
+    private function belongsToSameRestaurant(User $user, Table $table): bool
+    {
+        return $user->restaurant_id !== null && $user->restaurant_id === $table->restaurant_id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,8 +6,10 @@ namespace App\Providers;
 
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
+use App\Models\Table;
 use App\Policies\ReservationRequestPolicy;
 use App\Policies\RestaurantPolicy;
+use App\Policies\TablePolicy;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
@@ -19,6 +21,7 @@ final class AuthServiceProvider extends ServiceProvider
     public static array $policies = [
         Restaurant::class => RestaurantPolicy::class,
         ReservationRequest::class => ReservationRequestPolicy::class,
+        Table::class => TablePolicy::class,
     ];
 
     public function boot(): void

--- a/tests/Feature/Policies/TablePolicyTest.php
+++ b/tests/Feature/Policies/TablePolicyTest.php
@@ -10,6 +10,7 @@ use App\Models\Table;
 use App\Models\User;
 use App\Policies\TablePolicy;
 use App\Providers\AuthServiceProvider;
+use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Gate;
 use Tests\TestCase;
@@ -73,6 +74,17 @@ class TablePolicyTest extends TestCase
         $this->assertFalse($owner->can('view', $foreignTable));
         $this->assertFalse($owner->can('update', $foreignTable));
         $this->assertFalse($owner->can('delete', $foreignTable));
+    }
+
+    public function test_authorize_throws_for_foreign_table_access(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $owner = $this->owner($home);
+        $foreignTable = Table::factory()->for($foreign)->create();
+
+        $this->expectException(AuthorizationException::class);
+
+        Gate::forUser($owner)->authorize('update', $foreignTable);
     }
 
     public function test_guest_is_denied_all_table_actions(): void

--- a/tests/Feature/Policies/TablePolicyTest.php
+++ b/tests/Feature/Policies/TablePolicyTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Policies;
+
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use App\Policies\TablePolicy;
+use App\Providers\AuthServiceProvider;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+class TablePolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function owner(Restaurant $restaurant): User
+    {
+        return User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Owner]);
+    }
+
+    private function staff(Restaurant $restaurant): User
+    {
+        return User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Staff]);
+    }
+
+    public function test_policy_is_registered_in_auth_service_provider(): void
+    {
+        $this->assertSame(
+            TablePolicy::class,
+            AuthServiceProvider::$policies[Table::class] ?? null
+        );
+
+        $this->assertInstanceOf(TablePolicy::class, Gate::getPolicyFor(Table::class));
+    }
+
+    public function test_owner_has_full_crud_on_own_tables(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = $this->owner($restaurant);
+        $table = Table::factory()->for($restaurant)->create();
+
+        $this->assertTrue($owner->can('viewAny', Table::class));
+        $this->assertTrue($owner->can('view', $table));
+        $this->assertTrue($owner->can('create', Table::class));
+        $this->assertTrue($owner->can('update', $table));
+        $this->assertTrue($owner->can('delete', $table));
+    }
+
+    public function test_staff_may_view_but_not_mutate_tables(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $staff = $this->staff($restaurant);
+        $table = Table::factory()->for($restaurant)->create();
+
+        $this->assertTrue($staff->can('viewAny', Table::class));
+        $this->assertTrue($staff->can('view', $table));
+        $this->assertFalse($staff->can('create', Table::class));
+        $this->assertFalse($staff->can('update', $table));
+        $this->assertFalse($staff->can('delete', $table));
+    }
+
+    public function test_user_from_another_restaurant_is_denied_table_access(): void
+    {
+        [$home, $foreign] = Restaurant::factory()->count(2)->create();
+        $foreignTable = Table::factory()->for($foreign)->create();
+        $owner = $this->owner($home);
+
+        $this->assertFalse($owner->can('view', $foreignTable));
+        $this->assertFalse($owner->can('update', $foreignTable));
+        $this->assertFalse($owner->can('delete', $foreignTable));
+    }
+
+    public function test_guest_is_denied_all_table_actions(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $table = Table::factory()->for($restaurant)->create();
+
+        $this->assertFalse(Gate::forUser(null)->allows('viewAny', Table::class));
+        $this->assertFalse(Gate::forUser(null)->allows('view', $table));
+        $this->assertFalse(Gate::forUser(null)->allows('create', Table::class));
+        $this->assertFalse(Gate::forUser(null)->allows('update', $table));
+        $this->assertFalse(Gate::forUser(null)->allows('delete', $table));
+    }
+}


### PR DESCRIPTION
## Summary

`TablePolicy` for table master data (PRD-011, plan Task 10):

- `viewAny`, `view`, `create`, `update`, `delete`.
- **Tenant isolation in the policy**, not the controller: `view`/`update`/`delete` compare `restaurant_id`.
- **Role check:** `create`/`update`/`delete` require the `owner` role; staff get read-only (`viewAny`/`view`).
- Registered in `AuthServiceProvider::$policies` (the project's explicit registration pattern).

## Why

PRD-011 adds table CRUD endpoints (#319). CLAUDE.md mandates tenant scope in policies/global scopes — never `where('restaurant_id', auth()->...)` in controllers — so the gate logic lands here first.

## Notes

- The codebase has two roles (`Owner`, `Staff`); "owner/admin" from the issue maps to `Owner`. Mutations require `Owner`.
- Guests are denied by Gate (policy methods type-hint a non-nullable `User`); covered by a `Gate::forUser(null)` test in addition to the route middleware that will guard the controller in #319.

## Test plan

- [x] `php artisan test tests/Feature/Policies/TablePolicyTest.php` — 5 pass (owner CRUD, staff read-only, foreign-tenant denied, guest denied, registration)
- [x] `php artisan test` — 857 pass, no regressions
- [x] `./vendor/bin/pint --test` on touched paths — clean

Closes #318