### PR TITLE
PRD-011: TableController CRUD + form request + resource (#319)

### DIFF
--- a/app/Http/Controllers/TableController.php
+++ b/app/Http/Controllers/TableController.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\TableRequest;
+use App\Http\Resources\TableResource;
+use App\Models\Table;
+use Illuminate\Http\RedirectResponse;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * CRUD for table master data (PRD-011).
+ *
+ * Tenant isolation is not done here: the Table model carries the global
+ * RestaurantScope, so every query and route-model binding is already
+ * confined to the acting user's restaurant. A foreign table id therefore
+ * resolves to a 404 at route binding — the project's tenant-isolation
+ * contract — before the policy gate would even fire. Role/ability checks
+ * live in TablePolicy and are wired via the `can:` middleware on the routes.
+ */
+final class TableController extends Controller
+{
+    public function index(): Response
+    {
+        $tables = Table::query()
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+
+        return Inertia::render('Tables', [
+            'tables' => TableResource::collection($tables),
+        ]);
+    }
+
+    public function store(TableRequest $request): RedirectResponse
+    {
+        Table::create([
+            ...$request->validated(),
+            // restaurant_id is taken from the authenticated user, never from
+            // the request body (TablePolicy::create only gates role + membership).
+            'restaurant_id' => $request->user()->restaurant_id,
+        ]);
+
+        return redirect()->route('tables.index')->with('success', 'Tisch angelegt.');
+    }
+
+    public function update(TableRequest $request, Table $table): RedirectResponse
+    {
+        $table->update($request->validated());
+
+        return redirect()->route('tables.index')->with('success', 'Tisch aktualisiert.');
+    }
+
+    /**
+     * Soft-deactivate rather than hard-delete: the row is kept so historical
+     * reservation-table assignments stay referenceable; the table simply drops
+     * out of the active grid and can be reactivated via update.
+     */
+    public function destroy(Table $table): RedirectResponse
+    {
+        $table->update(['active' => false]);
+
+        return redirect()->route('tables.index')->with('success', 'Tisch deaktiviert.');
+    }
+}

--- a/app/Http/Requests/TableRequest.php
+++ b/app/Http/Requests/TableRequest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validation for table master data (PRD-011).
+ *
+ * Authorization is enforced by the `can:` middleware on the table routes
+ * (TablePolicy create/update), so this request is validation-only and
+ * returns true — mirroring the public StoreReservationRequest pattern.
+ */
+class TableRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        $restaurantId = $this->user()?->restaurant_id;
+
+        return [
+            'label' => ['required', 'string', 'max:100'],
+            'seats' => ['required', 'integer', 'between:1,20'],
+            'room_tag' => ['nullable', 'string', 'max:50'],
+            'sort_order' => ['nullable', 'integer', 'between:0,9999'],
+            'active' => ['nullable', 'boolean'],
+            'combinable_with' => ['nullable', 'array', 'max:20'],
+            // Combinable ids must reference tables of the acting user's own
+            // restaurant. Rule::exists hits the query builder, which bypasses
+            // the global RestaurantScope, so the tenant constraint is spelled
+            // out here explicitly — this is validation, not a controller
+            // tenant-scope query.
+            'combinable_with.*' => [
+                'integer',
+                Rule::exists('tables', 'id')->where(
+                    fn ($query) => $query->where('restaurant_id', $restaurantId)
+                ),
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'label.required' => 'Bitte geben Sie eine Tischbezeichnung an.',
+            'label.max' => 'Die Tischbezeichnung darf höchstens 100 Zeichen lang sein.',
+
+            'seats.required' => 'Bitte geben Sie die Anzahl der Sitzplätze an.',
+            'seats.integer' => 'Die Anzahl der Sitzplätze muss eine ganze Zahl sein.',
+            'seats.between' => 'Ein Tisch hat zwischen 1 und 20 Sitzplätze.',
+
+            'room_tag.max' => 'Die Bereichsangabe darf höchstens 50 Zeichen lang sein.',
+
+            'combinable_with.array' => 'Die kombinierbaren Tische müssen als Liste übergeben werden.',
+            'combinable_with.*.exists' => 'Ein kombinierbarer Tisch gehört nicht zu diesem Restaurant.',
+        ];
+    }
+}

--- a/app/Http/Requests/TableRequest.php
+++ b/app/Http/Requests/TableRequest.php
@@ -33,8 +33,12 @@ class TableRequest extends FormRequest
             'label' => ['required', 'string', 'max:100'],
             'seats' => ['required', 'integer', 'between:1,20'],
             'room_tag' => ['nullable', 'string', 'max:50'],
-            'sort_order' => ['nullable', 'integer', 'between:0,9999'],
-            'active' => ['nullable', 'boolean'],
+            // active and sort_order are NOT NULL columns with DB defaults, so
+            // they are optional (omit → default) but must not be written as
+            // null. `sometimes` skips an absent field yet rejects an explicit
+            // null as a clean 422 instead of letting it hit the database.
+            'sort_order' => ['sometimes', 'integer', 'between:0,9999'],
+            'active' => ['sometimes', 'boolean'],
             'combinable_with' => ['nullable', 'array', 'max:20'],
             // Combinable ids must reference tables of the acting user's own
             // restaurant. Rule::exists hits the query builder, which bypasses

--- a/app/Http/Resources/TableResource.php
+++ b/app/Http/Resources/TableResource.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Table;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * JSON contract for a table (PRD-011).
+ *
+ * Field names follow the actual schema columns (`label`, `seats`, `active`)
+ * rather than the generic names used in the issue text, keeping the contract
+ * aligned with the model and the Tables.vue master-data / occupancy tabs.
+ *
+ * @property-read Table $resource
+ */
+final class TableResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->resource->id,
+            'label' => $this->resource->label,
+            'seats' => $this->resource->seats,
+            'room_tag' => $this->resource->room_tag,
+            'sort_order' => $this->resource->sort_order,
+            'active' => $this->resource->active,
+            'combinable_with' => $this->resource->combinable_with ?? [],
+            'created_at' => $this->resource->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\ReservationMessagesController;
 use App\Http\Controllers\ReservationReplyController;
 use App\Http\Controllers\ReservationRequestController;
 use App\Http\Controllers\SendModeKillswitchController;
+use App\Http\Controllers\TableController;
+use App\Models\Table;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -61,6 +63,24 @@ Route::post('reservation-replies/{reply}/mark-shadow-compared', [ReservationRepl
 Route::post('restaurants/{restaurant}/send-mode/killswitch', SendModeKillswitchController::class)
     ->middleware(['auth', 'verified', 'can:manageSendMode,restaurant'])
     ->name('restaurants.send-mode.killswitch');
+
+Route::get('tables', [TableController::class, 'index'])
+    ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])
+    ->name('tables.index');
+
+Route::post('tables', [TableController::class, 'store'])
+    ->middleware(['auth', 'verified', 'can:create,'.Table::class])
+    ->name('tables.store');
+
+Route::match(['put', 'patch'], 'tables/{table}', [TableController::class, 'update'])
+    ->whereNumber('table')
+    ->middleware(['auth', 'verified', 'can:update,table'])
+    ->name('tables.update');
+
+Route::delete('tables/{table}', [TableController::class, 'destroy'])
+    ->whereNumber('table')
+    ->middleware(['auth', 'verified', 'can:delete,table'])
+    ->name('tables.destroy');
 
 Route::get('r/{restaurant:slug}/reservations', [PublicReservationController::class, 'create'])
     ->name('public.reservations.create');

--- a/tests/Feature/Tables/TableCrudTest.php
+++ b/tests/Feature/Tables/TableCrudTest.php
@@ -146,6 +146,19 @@ class TableCrudTest extends TestCase
             ->assertSessionHasErrors('label');
     }
 
+    public function test_store_rejects_an_explicit_null_active(): void
+    {
+        $home = Restaurant::factory()->create();
+
+        // active is a NOT NULL column: an explicit null must be a 422, never a
+        // null write that the production DB (MySQL/Postgres) would reject.
+        $this->actingAs($this->owner($home))
+            ->post(route('tables.store'), ['label' => 'Tisch 2', 'seats' => 4, 'active' => null])
+            ->assertSessionHasErrors('active');
+
+        $this->assertDatabaseMissing('tables', ['label' => 'Tisch 2']);
+    }
+
     public function test_owner_can_update_own_table(): void
     {
         $home = Restaurant::factory()->create();
@@ -183,6 +196,26 @@ class TableCrudTest extends TestCase
         $this->assertDatabaseHas('tables', ['id' => $table->id, 'label' => 'Alt']);
     }
 
+    public function test_update_rejects_combinable_with_from_a_foreign_restaurant(): void
+    {
+        $home = Restaurant::factory()->create();
+        $foreign = Restaurant::factory()->create();
+        $ownTable = Table::factory()->for($home)->create();
+        $foreignTable = Table::factory()->for($foreign)->create();
+
+        // The tenant-scoped combinable_with rule must hold on the update path
+        // too, not just on store.
+        $this->actingAs($this->owner($home))
+            ->patch(route('tables.update', $ownTable), [
+                'label' => 'Kombiniert',
+                'seats' => 4,
+                'combinable_with' => [$foreignTable->id],
+            ])
+            ->assertSessionHasErrors('combinable_with.0');
+
+        $this->assertDatabaseMissing('tables', ['id' => $ownTable->id, 'label' => 'Kombiniert']);
+    }
+
     public function test_destroy_soft_deactivates_the_table(): void
     {
         $home = Restaurant::factory()->create();
@@ -212,6 +245,18 @@ class TableCrudTest extends TestCase
         // stay referenceable.
         $this->assertNotNull(Table::find($table->id));
         $this->assertDatabaseHas('tables', ['id' => $table->id, 'active' => false]);
+    }
+
+    public function test_staff_cannot_destroy_a_table(): void
+    {
+        $home = Restaurant::factory()->create();
+        $table = Table::factory()->for($home)->create(['active' => true]);
+
+        $this->actingAs($this->staff($home))
+            ->delete(route('tables.destroy', $table))
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('tables', ['id' => $table->id, 'active' => true]);
     }
 
     public function test_cross_tenant_destroy_returns_404(): void

--- a/tests/Feature/Tables/TableCrudTest.php
+++ b/tests/Feature/Tables/TableCrudTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tables;
+
+use App\Enums\UserRole;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class TableCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function owner(Restaurant $restaurant): User
+    {
+        return User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Owner]);
+    }
+
+    private function staff(Restaurant $restaurant): User
+    {
+        return User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Staff]);
+    }
+
+    public function test_guests_are_redirected_from_the_table_index(): void
+    {
+        $this->get(route('tables.index'))->assertRedirect('/login');
+    }
+
+    public function test_index_lists_only_own_restaurant_tables(): void
+    {
+        $home = Restaurant::factory()->create();
+        $foreign = Restaurant::factory()->create();
+        Table::factory()->for($home)->count(2)->create();
+        Table::factory()->for($foreign)->create();
+
+        $this->actingAs($this->owner($home))
+            ->get(route('tables.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Tables', false)
+                ->has('tables.data', 2)
+            );
+    }
+
+    public function test_index_includes_inactive_tables_so_they_can_be_managed(): void
+    {
+        $home = Restaurant::factory()->create();
+        Table::factory()->for($home)->create();
+        Table::factory()->for($home)->inactive()->create();
+
+        $this->actingAs($this->owner($home))
+            ->get(route('tables.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Tables', false)
+                ->has('tables.data', 2)
+            );
+    }
+
+    public function test_staff_may_view_the_table_index(): void
+    {
+        $home = Restaurant::factory()->create();
+        Table::factory()->for($home)->create();
+
+        $this->actingAs($this->staff($home))
+            ->get(route('tables.index'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Tables', false));
+    }
+
+    public function test_owner_can_create_a_table(): void
+    {
+        $home = Restaurant::factory()->create();
+
+        $response = $this->actingAs($this->owner($home))->post(route('tables.store'), [
+            'label' => 'Tisch 7',
+            'seats' => 4,
+            'room_tag' => 'Innen',
+            'sort_order' => 1,
+            'active' => true,
+            'combinable_with' => null,
+        ]);
+
+        $response->assertRedirect(route('tables.index'));
+        $this->assertDatabaseHas('tables', [
+            'restaurant_id' => $home->id,
+            'label' => 'Tisch 7',
+            'seats' => 4,
+            'room_tag' => 'Innen',
+        ]);
+    }
+
+    public function test_store_ignores_a_client_supplied_restaurant_id(): void
+    {
+        $home = Restaurant::factory()->create();
+        $foreign = Restaurant::factory()->create();
+
+        $this->actingAs($this->owner($home))->post(route('tables.store'), [
+            'restaurant_id' => $foreign->id,
+            'label' => 'Tisch 1',
+            'seats' => 2,
+        ]);
+
+        $this->assertDatabaseHas('tables', ['label' => 'Tisch 1', 'restaurant_id' => $home->id]);
+        $this->assertDatabaseMissing('tables', ['label' => 'Tisch 1', 'restaurant_id' => $foreign->id]);
+    }
+
+    public function test_staff_cannot_create_a_table(): void
+    {
+        $home = Restaurant::factory()->create();
+
+        $this->actingAs($this->staff($home))
+            ->post(route('tables.store'), ['label' => 'Tisch 9', 'seats' => 2])
+            ->assertForbidden();
+
+        $this->assertDatabaseMissing('tables', ['label' => 'Tisch 9']);
+    }
+
+    public function test_store_rejects_seats_outside_one_to_twenty(): void
+    {
+        $home = Restaurant::factory()->create();
+        $owner = $this->owner($home);
+
+        $this->actingAs($owner)
+            ->post(route('tables.store'), ['label' => 'Riesentisch', 'seats' => 25])
+            ->assertSessionHasErrors('seats');
+
+        $this->actingAs($owner)
+            ->post(route('tables.store'), ['label' => 'Phantomtisch', 'seats' => 0])
+            ->assertSessionHasErrors('seats');
+    }
+
+    public function test_store_requires_a_label(): void
+    {
+        $home = Restaurant::factory()->create();
+
+        $this->actingAs($this->owner($home))
+            ->post(route('tables.store'), ['seats' => 4])
+            ->assertSessionHasErrors('label');
+    }
+
+    public function test_owner_can_update_own_table(): void
+    {
+        $home = Restaurant::factory()->create();
+        $table = Table::factory()->for($home)->create(['label' => 'Alt', 'seats' => 2]);
+
+        $this->actingAs($this->owner($home))
+            ->patch(route('tables.update', $table), ['label' => 'Neu', 'seats' => 6])
+            ->assertRedirect(route('tables.index'));
+
+        $this->assertDatabaseHas('tables', ['id' => $table->id, 'label' => 'Neu', 'seats' => 6]);
+    }
+
+    public function test_cross_tenant_update_returns_404_and_leaves_table_untouched(): void
+    {
+        $home = Restaurant::factory()->create();
+        $foreign = Restaurant::factory()->create();
+        $foreignTable = Table::factory()->for($foreign)->create(['label' => 'Fremd']);
+
+        $this->actingAs($this->owner($home))
+            ->patch(route('tables.update', $foreignTable), ['label' => 'Hijack', 'seats' => 4])
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('tables', ['id' => $foreignTable->id, 'label' => 'Fremd']);
+    }
+
+    public function test_staff_cannot_update_a_table(): void
+    {
+        $home = Restaurant::factory()->create();
+        $table = Table::factory()->for($home)->create(['label' => 'Alt']);
+
+        $this->actingAs($this->staff($home))
+            ->patch(route('tables.update', $table), ['label' => 'Neu', 'seats' => 4])
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('tables', ['id' => $table->id, 'label' => 'Alt']);
+    }
+
+    public function test_destroy_soft_deactivates_the_table(): void
+    {
+        $home = Restaurant::factory()->create();
+        $table = Table::factory()->for($home)->create(['active' => true]);
+
+        $this->actingAs($this->owner($home))
+            ->delete(route('tables.destroy', $table))
+            ->assertRedirect(route('tables.index'));
+
+        $this->assertDatabaseHas('tables', ['id' => $table->id, 'active' => false]);
+    }
+
+    public function test_destroy_keeps_table_with_assignments_intact(): void
+    {
+        $home = Restaurant::factory()->create();
+        $table = Table::factory()->for($home)->create(['active' => true]);
+        ReservationTableAssignment::factory()
+            ->for(ReservationRequest::factory()->for($home), 'reservationRequest')
+            ->for($table)
+            ->create();
+
+        $this->actingAs($this->owner($home))
+            ->delete(route('tables.destroy', $table))
+            ->assertRedirect(route('tables.index'));
+
+        // Soft-deactivation never removes the row, so historical assignments
+        // stay referenceable.
+        $this->assertNotNull(Table::find($table->id));
+        $this->assertDatabaseHas('tables', ['id' => $table->id, 'active' => false]);
+    }
+
+    public function test_cross_tenant_destroy_returns_404(): void
+    {
+        $home = Restaurant::factory()->create();
+        $foreign = Restaurant::factory()->create();
+        $foreignTable = Table::factory()->for($foreign)->create(['active' => true]);
+
+        $this->actingAs($this->owner($home))
+            ->delete(route('tables.destroy', $foreignTable))
+            ->assertNotFound();
+
+        $this->assertDatabaseHas('tables', ['id' => $foreignTable->id, 'active' => true]);
+    }
+
+    public function test_combinable_with_referencing_a_foreign_table_is_rejected(): void
+    {
+        $home = Restaurant::factory()->create();
+        $foreign = Restaurant::factory()->create();
+        $foreignTable = Table::factory()->for($foreign)->create();
+
+        $this->actingAs($this->owner($home))
+            ->post(route('tables.store'), [
+                'label' => 'Tisch 3',
+                'seats' => 4,
+                'combinable_with' => [$foreignTable->id],
+            ])
+            ->assertSessionHasErrors('combinable_with.0');
+
+        $this->assertDatabaseMissing('tables', ['label' => 'Tisch 3']);
+    }
+
+    public function test_combinable_with_referencing_an_own_table_is_accepted(): void
+    {
+        $home = Restaurant::factory()->create();
+        $sibling = Table::factory()->for($home)->create();
+
+        $this->actingAs($this->owner($home))
+            ->post(route('tables.store'), [
+                'label' => 'Tisch 4',
+                'seats' => 4,
+                'combinable_with' => [$sibling->id],
+            ])
+            ->assertRedirect(route('tables.index'));
+
+        $this->assertDatabaseHas('tables', ['label' => 'Tisch 4', 'restaurant_id' => $home->id]);
+    }
+}


### PR DESCRIPTION
## Summary

REST-ish CRUD for table master data (PRD-011, Task 11):

- `TableController` — `index`, `store`, `update`, `destroy`.
- `TableRequest` — validates `label` (≤100), `seats` (1..20), `room_tag`, `sort_order`, `active`, and `combinable_with` (each id must belong to the acting user's own restaurant).
- `TableResource` — JSON contract using the real schema columns (`label`, `seats`, `room_tag`, `sort_order`, `active`, `combinable_with`, `created_at`).
- Routes `GET/POST /tables`, `PUT|PATCH/DELETE /tables/{table}`, all behind `auth` + `verified` + `can:` policy middleware.

### Acceptance criteria
- [x] `TableRequest` validates label/seats/room_tag/sort_order/active + `combinable_with` scoped to own restaurant
- [x] `TableResource` exposes the table contract
- [x] Routes for index/store/update/destroy via `auth` + policy
- [x] Tenant scope enforced via policy + global `RestaurantScope` — no `where('restaurant_id', ...)` in the controller
- [x] `ziggy:generate` run (output is gitignored — local types refreshed)
- [x] `php artisan test` green; `pint --test` clean; `prettier --check` clean

## Why

PRD-011 (V3.0) needs table master data so the availability model and the upcoming Tables.vue tabs (#320, #321) have something to manage. This is the backend half.

### Two design decisions worth flagging
1. **Cross-tenant access → 404, not 403.** The `Table` model carries `#[ScopedBy(RestaurantScope)]`, so a foreign table id is filtered out at route-model binding before any policy gate runs. This matches the project's existing tenant-isolation contract (see `ReservationReplyFlowTest`: "404 is the project's tenant-isolation contract"). The issue text said 403; the established convention wins.
2. **`destroy` soft-deactivates (`active=false`)** instead of hard-deleting, so historical `reservation_table_assignments` stay referenceable. The issue left this open ("soft-deactivates or deletes").

The Inertia `Tables` page component is delivered in #320, so the index tests assert the component name with `shouldExist=false`.

## Test plan

- `php artisan test --filter=TableCrudTest` — 17 passing (index tenant-scoping incl. inactive, owner/staff role gating, seats range, label required, soft-deactivate, assignments stay intact, cross-tenant 404 for update + destroy, combinable_with own vs foreign).
- `php artisan test` — 875 passing.
- `./vendor/bin/pint --test` — pass.
- `npm run format:check` — pass.

Closes #319