### PR TITLE
PRD-011: Tables.vue master-data tab + TableForm drawer (#320)

### DIFF
--- a/resources/js/components/AppSidebar.vue
+++ b/resources/js/components/AppSidebar.vue
@@ -4,7 +4,7 @@ import NavUser from '@/components/NavUser.vue';
 import { Sidebar, SidebarContent, SidebarFooter, SidebarHeader, SidebarMenu, SidebarMenuButton, SidebarMenuItem } from '@/components/ui/sidebar';
 import { type NavItem } from '@/types';
 import { Link } from '@inertiajs/vue3';
-import { BarChart3, CalendarClock, Settings } from 'lucide-vue-next';
+import { Armchair, BarChart3, CalendarClock, Settings } from 'lucide-vue-next';
 import AppLogo from './AppLogo.vue';
 
 const mainNavItems: NavItem[] = [
@@ -17,6 +17,11 @@ const mainNavItems: NavItem[] = [
         title: 'Analytics',
         href: '/analytics',
         icon: BarChart3,
+    },
+    {
+        title: 'Tische',
+        href: '/tables',
+        icon: Armchair,
     },
     {
         title: 'Einstellungen',

--- a/resources/js/components/tables/TableForm.vue
+++ b/resources/js/components/tables/TableForm.vue
@@ -1,0 +1,142 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle } from '@/components/ui/sheet';
+import { type TableFormPayload, type TableModel } from '@/types';
+import { router } from '@inertiajs/vue3';
+import { computed, reactive, ref } from 'vue';
+
+const props = defineProps<{
+    /** The table being edited, or `null` for a create. */
+    table: TableModel | null;
+    /** Tables of the same restaurant that this one may be combined with. */
+    siblings: TableModel[];
+}>();
+
+const emit = defineEmits<{
+    (e: 'close'): void;
+    (e: 'saved'): void;
+}>();
+
+const isEdit = computed(() => props.table !== null);
+
+const form = reactive<TableFormPayload>({
+    label: props.table?.label ?? '',
+    seats: props.table?.seats ?? 2,
+    room_tag: props.table?.room_tag ?? '',
+    sort_order: props.table?.sort_order ?? 0,
+    active: props.table?.active ?? true,
+    combinable_with: [...(props.table?.combinable_with ?? [])],
+});
+
+const errors = ref<Record<string, string>>({});
+const processing = ref(false);
+
+function payload(): TableFormPayload {
+    return {
+        label: form.label,
+        seats: form.seats,
+        room_tag: form.room_tag === '' ? null : form.room_tag,
+        sort_order: form.sort_order,
+        active: form.active,
+        combinable_with: form.combinable_with,
+    };
+}
+
+function submit(): void {
+    processing.value = true;
+    const options = {
+        preserveScroll: true,
+        onSuccess: () => emit('saved'),
+        onError: (received: Record<string, string>) => {
+            errors.value = received;
+        },
+        onFinish: () => {
+            processing.value = false;
+        },
+    };
+
+    if (props.table) {
+        router.patch(route('tables.update', { table: props.table.id }), payload(), options);
+    } else {
+        router.post(route('tables.store'), payload(), options);
+    }
+}
+
+function toggleCombinable(id: number): void {
+    const index = form.combinable_with.indexOf(id);
+    if (index === -1) {
+        form.combinable_with.push(id);
+    } else {
+        form.combinable_with.splice(index, 1);
+    }
+}
+
+function onOpenChange(open: boolean): void {
+    if (!open) {
+        emit('close');
+    }
+}
+</script>
+
+<template>
+    <Sheet :open="true" @update:open="onOpenChange">
+        <SheetContent class="flex w-full flex-col gap-4 overflow-y-auto sm:max-w-md" data-testid="table-form">
+            <SheetHeader>
+                <SheetTitle>{{ isEdit ? 'Tisch bearbeiten' : 'Neuer Tisch' }}</SheetTitle>
+            </SheetHeader>
+
+            <form class="flex flex-1 flex-col gap-4" @submit.prevent="submit">
+                <div class="grid gap-2">
+                    <Label for="table-label">Bezeichnung</Label>
+                    <Input id="table-label" v-model="form.label" data-testid="field-label" required />
+                    <InputError :message="errors.label" />
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="table-seats">Plätze</Label>
+                    <Input id="table-seats" v-model.number="form.seats" type="number" min="1" max="20" data-testid="field-seats" required />
+                    <InputError :message="errors.seats" />
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="table-room-tag">Bereich</Label>
+                    <Input id="table-room-tag" v-model="form.room_tag" data-testid="field-room-tag" placeholder="z. B. Innen, Terrasse" />
+                    <InputError :message="errors.room_tag" />
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="table-sort-order">Sortierung</Label>
+                    <Input id="table-sort-order" v-model.number="form.sort_order" type="number" min="0" data-testid="field-sort-order" />
+                    <InputError :message="errors.sort_order" />
+                </div>
+
+                <label class="flex items-center gap-2">
+                    <Checkbox v-model:checked="form.active" data-testid="field-active" />
+                    <span class="text-sm font-medium">Aktiv</span>
+                </label>
+
+                <fieldset v-if="siblings.length > 0" class="grid gap-2">
+                    <legend class="text-sm font-medium">Kombinierbar mit</legend>
+                    <label v-for="sibling in siblings" :key="sibling.id" class="flex items-center gap-2 text-sm">
+                        <Checkbox
+                            :checked="form.combinable_with.includes(sibling.id)"
+                            :data-testid="`combinable-${sibling.id}`"
+                            @update:checked="toggleCombinable(sibling.id)"
+                        />
+                        {{ sibling.label }}
+                    </label>
+                    <InputError :message="errors.combinable_with" />
+                </fieldset>
+
+                <SheetFooter class="mt-auto flex justify-end gap-2">
+                    <Button type="button" variant="outline" @click="emit('close')">Abbrechen</Button>
+                    <Button type="submit" :disabled="processing" data-testid="submit">Speichern</Button>
+                </SheetFooter>
+            </form>
+        </SheetContent>
+    </Sheet>
+</template>

--- a/resources/js/components/tables/TableForm.vue
+++ b/resources/js/components/tables/TableForm.vue
@@ -38,9 +38,12 @@ const processing = ref(false);
 function payload(): TableFormPayload {
     return {
         label: form.label,
-        seats: form.seats,
+        // The ui Input is a wrapper component, so the v-model.number modifier is
+        // not applied automatically — coerce the numeric fields explicitly so
+        // the backend always receives integers, not numeric strings.
+        seats: Number(form.seats),
         room_tag: form.room_tag === '' ? null : form.room_tag,
-        sort_order: form.sort_order,
+        sort_order: Number(form.sort_order),
         active: form.active,
         combinable_with: form.combinable_with,
     };
@@ -48,6 +51,9 @@ function payload(): TableFormPayload {
 
 function submit(): void {
     processing.value = true;
+    // Drop any errors from a previous attempt so a now-valid field stops
+    // showing a stale message even if a different field fails.
+    errors.value = {};
     const options = {
         preserveScroll: true,
         onSuccess: () => emit('saved'),

--- a/resources/js/pages/Tables.test.ts
+++ b/resources/js/pages/Tables.test.ts
@@ -1,0 +1,168 @@
+import type { TableModel } from '@/types';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import Tables from './Tables.vue';
+
+const { postSpy, patchSpy, deleteSpy } = vi.hoisted(() => ({
+    postSpy: vi.fn(),
+    patchSpy: vi.fn(),
+    deleteSpy: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    Head: { name: 'Head', render: () => null },
+    router: {
+        post: (...args: unknown[]) => postSpy(...args),
+        patch: (...args: unknown[]) => patchSpy(...args),
+        delete: (...args: unknown[]) => deleteSpy(...args),
+    },
+}));
+
+vi.mock('@/layouts/AppLayout.vue', () => ({
+    default: { name: 'AppLayout', template: '<div data-testid="layout"><slot /></div>' },
+}));
+
+// The Sheet drawer renders through a radix DialogPortal (teleport) in the real
+// app; stubbing the chrome to passthrough divs keeps the form fields inline and
+// queryable in the test. Checkbox is radix-driven too — a minimal stub keeps
+// the v-model:checked contract testable without the indicator internals.
+const sheetStubs = {
+    Sheet: { template: '<div><slot /></div>' },
+    SheetContent: { template: '<div v-bind="$attrs"><slot /></div>' },
+    SheetHeader: { template: '<div><slot /></div>' },
+    SheetTitle: { template: '<div><slot /></div>' },
+    SheetFooter: { template: '<div><slot /></div>' },
+    Checkbox: {
+        props: ['checked'],
+        emits: ['update:checked'],
+        template:
+            '<button type="button" role="checkbox" :aria-checked="String(checked)" v-bind="$attrs" @click="$emit(\'update:checked\', !checked)" />',
+    },
+};
+
+function makeTable(overrides: Partial<TableModel> = {}): TableModel {
+    return {
+        id: 1,
+        label: 'Tisch 1',
+        seats: 4,
+        room_tag: 'Innen',
+        sort_order: 1,
+        active: true,
+        combinable_with: [],
+        created_at: '2026-05-01T10:00:00+00:00',
+        ...overrides,
+    };
+}
+
+function mountTables(tables: TableModel[]) {
+    return mount(Tables, {
+        props: { tables: { data: tables } },
+        global: { stubs: sheetStubs },
+    });
+}
+
+beforeEach(() => {
+    postSpy.mockReset();
+    patchSpy.mockReset();
+    deleteSpy.mockReset();
+
+    vi.stubGlobal('route', (name: string, params?: Record<string, unknown>) => (params ? `${name}/${Object.values(params).join('/')}` : name));
+});
+
+describe('Tables.vue master-data tab', () => {
+    it('renders one row per table and resolves combinable labels', () => {
+        const wrapper = mountTables([
+            makeTable({ id: 1, label: 'Tisch 1', seats: 4, room_tag: 'Innen', combinable_with: [2] }),
+            makeTable({ id: 2, label: 'Tisch 2', seats: 6, room_tag: 'Terrasse' }),
+        ]);
+
+        const tableRows = wrapper.findAll('[data-testid="table-row"]');
+        expect(tableRows).toHaveLength(2);
+        expect(wrapper.text()).toContain('Tisch 1');
+        expect(wrapper.text()).toContain('Terrasse');
+        // Row 1 combines with table 2, so its label is resolved to "Tisch 2".
+        expect(tableRows[0].text()).toContain('Tisch 2');
+    });
+
+    it('shows the empty state when there are no tables', () => {
+        const wrapper = mountTables([]);
+
+        expect(wrapper.find('[data-testid="empty-state"]').exists()).toBe(true);
+        expect(wrapper.findAll('[data-testid="table-row"]')).toHaveLength(0);
+    });
+
+    it('switches to the Belegung placeholder tab', async () => {
+        const wrapper = mountTables([makeTable()]);
+
+        expect(wrapper.find('[data-testid="tab-panel-stammdaten"]').exists()).toBe(true);
+
+        await wrapper.find('[data-testid="tab-belegung"]').trigger('click');
+
+        expect(wrapper.find('[data-testid="tab-panel-belegung"]').exists()).toBe(true);
+        expect(wrapper.find('[data-testid="tab-panel-stammdaten"]').exists()).toBe(false);
+    });
+
+    it('opens the drawer with empty fields for create', async () => {
+        const wrapper = mountTables([makeTable({ id: 1, label: 'Tisch 1' })]);
+
+        expect(wrapper.find('[data-testid="table-form"]').exists()).toBe(false);
+
+        await wrapper.find('[data-testid="new-table"]').trigger('click');
+
+        expect(wrapper.find('[data-testid="table-form"]').exists()).toBe(true);
+        expect((wrapper.find('[data-testid="field-label"]').element as HTMLInputElement).value).toBe('');
+    });
+
+    it('opens the drawer pre-filled for edit', async () => {
+        const wrapper = mountTables([makeTable({ id: 7, label: 'Fenstertisch', seats: 5, room_tag: 'Innen' })]);
+
+        await wrapper.find('[data-testid="edit-7"]').trigger('click');
+
+        expect((wrapper.find('[data-testid="field-label"]').element as HTMLInputElement).value).toBe('Fenstertisch');
+        expect((wrapper.find('[data-testid="field-seats"]').element as HTMLInputElement).value).toBe('5');
+    });
+
+    it('submits a create through router.post with the form payload', async () => {
+        const wrapper = mountTables([]);
+
+        await wrapper.find('[data-testid="new-table"]').trigger('click');
+        await wrapper.find('[data-testid="field-label"]').setValue('Tisch 9');
+        await wrapper.find('[data-testid="field-seats"]').setValue(8);
+        await wrapper.find('[data-testid="field-room-tag"]').setValue('Terrasse');
+        await wrapper.find('form').trigger('submit');
+
+        expect(patchSpy).not.toHaveBeenCalled();
+        expect(postSpy).toHaveBeenCalledTimes(1);
+        expect(postSpy.mock.calls[0][0]).toBe('tables.store');
+        expect(postSpy.mock.calls[0][1]).toMatchObject({
+            label: 'Tisch 9',
+            seats: 8,
+            room_tag: 'Terrasse',
+            active: true,
+        });
+    });
+
+    it('submits an edit through router.patch to the table route', async () => {
+        const wrapper = mountTables([makeTable({ id: 3, label: 'Tisch 3', seats: 4 })]);
+
+        await wrapper.find('[data-testid="edit-3"]').trigger('click');
+        await wrapper.find('form').trigger('submit');
+
+        expect(postSpy).not.toHaveBeenCalled();
+        expect(patchSpy).toHaveBeenCalledTimes(1);
+        expect(patchSpy.mock.calls[0][0]).toBe('tables.update/3');
+        expect(patchSpy.mock.calls[0][1]).toMatchObject({ label: 'Tisch 3', seats: 4 });
+    });
+
+    it('requires a confirmation before deleting and then calls router.delete', async () => {
+        const wrapper = mountTables([makeTable({ id: 5 })]);
+
+        await wrapper.find('[data-testid="delete-5"]').trigger('click');
+        expect(wrapper.find('[data-testid="confirm-delete-5"]').exists()).toBe(true);
+        expect(deleteSpy).not.toHaveBeenCalled();
+
+        await wrapper.find('[data-testid="confirm-delete-5"]').trigger('click');
+        expect(deleteSpy).toHaveBeenCalledTimes(1);
+        expect(deleteSpy.mock.calls[0][0]).toBe('tables.destroy/5');
+    });
+});

--- a/resources/js/pages/Tables.test.ts
+++ b/resources/js/pages/Tables.test.ts
@@ -1,5 +1,5 @@
 import type { TableModel } from '@/types';
-import { mount } from '@vue/test-utils';
+import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Tables from './Tables.vue';
 
@@ -154,15 +154,33 @@ describe('Tables.vue master-data tab', () => {
         expect(patchSpy.mock.calls[0][1]).toMatchObject({ label: 'Tisch 3', seats: 4 });
     });
 
-    it('requires a confirmation before deleting and then calls router.delete', async () => {
+    it('requires a confirmation before deactivating and then calls router.delete', async () => {
         const wrapper = mountTables([makeTable({ id: 5 })]);
 
-        await wrapper.find('[data-testid="delete-5"]').trigger('click');
-        expect(wrapper.find('[data-testid="confirm-delete-5"]').exists()).toBe(true);
+        await wrapper.find('[data-testid="deactivate-5"]').trigger('click');
+        expect(wrapper.find('[data-testid="confirm-deactivate-5"]').exists()).toBe(true);
         expect(deleteSpy).not.toHaveBeenCalled();
 
-        await wrapper.find('[data-testid="confirm-delete-5"]').trigger('click');
+        await wrapper.find('[data-testid="confirm-deactivate-5"]').trigger('click');
         expect(deleteSpy).toHaveBeenCalledTimes(1);
         expect(deleteSpy.mock.calls[0][0]).toBe('tables.destroy/5');
+    });
+
+    it('closes the drawer once a save succeeds', async () => {
+        const wrapper = mountTables([]);
+
+        await wrapper.find('[data-testid="new-table"]').trigger('click');
+        await wrapper.find('[data-testid="field-label"]').setValue('Tisch 1');
+        await wrapper.find('form').trigger('submit');
+
+        expect(wrapper.find('[data-testid="table-form"]').exists()).toBe(true);
+
+        // Drive the Inertia onSuccess callback the router mock captured; it is
+        // what emits "saved" and lets the page close the drawer.
+        const options = postSpy.mock.calls[0][2] as { onSuccess: () => void };
+        options.onSuccess();
+        await flushPromises();
+
+        expect(wrapper.find('[data-testid="table-form"]').exists()).toBe(false);
     });
 });

--- a/resources/js/pages/Tables.vue
+++ b/resources/js/pages/Tables.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import TableForm from '@/components/tables/TableForm.vue';
+import { Button } from '@/components/ui/button';
+import AppLayout from '@/layouts/AppLayout.vue';
+import { type BreadcrumbItem, type TableModel } from '@/types';
+import { Head, router } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+
+const props = defineProps<{
+    tables: { data: TableModel[] };
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'Tische', href: '/tables' }];
+
+type TabKey = 'stammdaten' | 'belegung';
+const tabs: Array<{ value: TabKey; label: string }> = [
+    { value: 'stammdaten', label: 'Stammdaten' },
+    { value: 'belegung', label: 'Belegung' },
+];
+const activeTab = ref<TabKey>('stammdaten');
+
+const rows = computed(() => props.tables.data);
+const labelById = computed(() => new Map(rows.value.map((table) => [table.id, table.label])));
+
+function combinableLabels(table: TableModel): string {
+    if (table.combinable_with.length === 0) {
+        return '–';
+    }
+    return table.combinable_with.map((id) => labelById.value.get(id) ?? `#${id}`).join(', ');
+}
+
+const showForm = ref(false);
+const editing = ref<TableModel | null>(null);
+
+// On create every table is a combinable candidate; on edit a table cannot be
+// combined with itself, so it is filtered out of the sibling list.
+const siblings = computed<TableModel[]>(() => {
+    const current = editing.value;
+    return current ? rows.value.filter((table) => table.id !== current.id) : rows.value;
+});
+
+function openCreate(): void {
+    editing.value = null;
+    showForm.value = true;
+}
+
+function openEdit(table: TableModel): void {
+    editing.value = table;
+    showForm.value = true;
+}
+
+// The store/update controllers redirect to tables.index, so Inertia reloads
+// the list automatically — closing the drawer is all the page has to do.
+function onSaved(): void {
+    showForm.value = false;
+}
+
+const confirmingId = ref<number | null>(null);
+
+function requestDelete(table: TableModel): void {
+    confirmingId.value = table.id;
+}
+
+function cancelDelete(): void {
+    confirmingId.value = null;
+}
+
+function confirmDelete(table: TableModel): void {
+    router.delete(route('tables.destroy', { table: table.id }), {
+        preserveScroll: true,
+        onFinish: () => {
+            confirmingId.value = null;
+        },
+    });
+}
+</script>
+
+<template>
+    <Head title="Tische" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="flex flex-col gap-6 p-4 md:p-6">
+            <header class="flex flex-wrap items-center justify-between gap-3">
+                <h1 class="text-2xl font-semibold tracking-tight">Tische</h1>
+                <Button type="button" data-testid="new-table" @click="openCreate">+ Neuer Tisch</Button>
+            </header>
+
+            <div role="tablist" aria-label="Tisch-Ansicht" class="flex gap-2 border-b border-border">
+                <button
+                    v-for="tab in tabs"
+                    :key="tab.value"
+                    type="button"
+                    role="tab"
+                    :aria-selected="activeTab === tab.value"
+                    :data-active="activeTab === tab.value"
+                    :data-testid="`tab-${tab.value}`"
+                    class="-mb-px border-b-2 px-3 py-2 text-sm transition"
+                    :class="
+                        activeTab === tab.value
+                            ? 'border-primary font-medium text-primary'
+                            : 'border-transparent text-muted-foreground hover:text-foreground'
+                    "
+                    @click="activeTab = tab.value"
+                >
+                    {{ tab.label }}
+                </button>
+            </div>
+
+            <section v-if="activeTab === 'stammdaten'" data-testid="tab-panel-stammdaten">
+                <div v-if="rows.length === 0" class="rounded-lg border border-dashed p-10 text-center" data-testid="empty-state">
+                    <p class="text-lg font-medium">Noch keine Tische angelegt.</p>
+                    <p class="mt-1 text-sm text-muted-foreground">Lege deinen ersten Tisch an, um die Verfügbarkeit zu pflegen.</p>
+                </div>
+
+                <div v-else class="overflow-x-auto rounded-lg border border-border">
+                    <table class="w-full text-left text-sm">
+                        <thead class="bg-muted/40">
+                            <tr class="border-b border-border">
+                                <th class="px-4 py-2">Bezeichnung</th>
+                                <th class="px-4 py-2">Plätze</th>
+                                <th class="px-4 py-2">Bereich</th>
+                                <th class="px-4 py-2">Kombinierbar mit</th>
+                                <th class="px-4 py-2">Aktiv</th>
+                                <th class="px-4 py-2 text-right">Aktionen</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr
+                                v-for="table in rows"
+                                :key="table.id"
+                                data-testid="table-row"
+                                class="border-b border-border last:border-0 hover:bg-muted/30"
+                            >
+                                <td class="px-4 py-2 font-medium">{{ table.label }}</td>
+                                <td class="px-4 py-2">{{ table.seats }}</td>
+                                <td class="px-4 py-2">{{ table.room_tag ?? '–' }}</td>
+                                <td class="px-4 py-2">{{ combinableLabels(table) }}</td>
+                                <td class="px-4 py-2">
+                                    <span :class="table.active ? 'text-foreground' : 'text-muted-foreground'">
+                                        {{ table.active ? 'Ja' : 'Nein' }}
+                                    </span>
+                                </td>
+                                <td class="px-4 py-2 text-right">
+                                    <template v-if="confirmingId === table.id">
+                                        <span class="mr-2 text-xs text-muted-foreground">Wirklich deaktivieren?</span>
+                                        <Button
+                                            type="button"
+                                            variant="destructive"
+                                            size="sm"
+                                            :data-testid="`confirm-delete-${table.id}`"
+                                            @click="confirmDelete(table)"
+                                        >
+                                            Ja
+                                        </Button>
+                                        <Button type="button" variant="ghost" size="sm" class="ml-1" @click="cancelDelete">Abbrechen</Button>
+                                    </template>
+                                    <template v-else>
+                                        <Button type="button" variant="ghost" size="sm" :data-testid="`edit-${table.id}`" @click="openEdit(table)">
+                                            Bearbeiten
+                                        </Button>
+                                        <Button
+                                            type="button"
+                                            variant="ghost"
+                                            size="sm"
+                                            class="ml-1 text-destructive"
+                                            :data-testid="`delete-${table.id}`"
+                                            @click="requestDelete(table)"
+                                        >
+                                            Löschen
+                                        </Button>
+                                    </template>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+
+            <section v-else data-testid="tab-panel-belegung" class="rounded-lg border border-dashed p-10 text-center">
+                <p class="text-lg font-medium">Belegungs-Ansicht folgt.</p>
+                <p class="mt-1 text-sm text-muted-foreground">Die Tages-Belegung wird in einem späteren Schritt ergänzt.</p>
+            </section>
+        </div>
+
+        <TableForm v-if="showForm" :table="editing" :siblings="siblings" @close="showForm = false" @saved="onSaved" />
+    </AppLayout>
+</template>

--- a/resources/js/pages/Tables.vue
+++ b/resources/js/pages/Tables.vue
@@ -57,15 +57,17 @@ function onSaved(): void {
 
 const confirmingId = ref<number | null>(null);
 
-function requestDelete(table: TableModel): void {
+function requestDeactivate(table: TableModel): void {
     confirmingId.value = table.id;
 }
 
-function cancelDelete(): void {
+function cancelDeactivate(): void {
     confirmingId.value = null;
 }
 
-function confirmDelete(table: TableModel): void {
+// The destroy endpoint soft-deactivates the table (active = false) rather than
+// removing the row, so the UI consistently speaks of "deactivating".
+function confirmDeactivate(table: TableModel): void {
     router.delete(route('tables.destroy', { table: table.id }), {
         preserveScroll: true,
         onFinish: () => {
@@ -147,12 +149,12 @@ function confirmDelete(table: TableModel): void {
                                             type="button"
                                             variant="destructive"
                                             size="sm"
-                                            :data-testid="`confirm-delete-${table.id}`"
-                                            @click="confirmDelete(table)"
+                                            :data-testid="`confirm-deactivate-${table.id}`"
+                                            @click="confirmDeactivate(table)"
                                         >
                                             Ja
                                         </Button>
-                                        <Button type="button" variant="ghost" size="sm" class="ml-1" @click="cancelDelete">Abbrechen</Button>
+                                        <Button type="button" variant="ghost" size="sm" class="ml-1" @click="cancelDeactivate">Abbrechen</Button>
                                     </template>
                                     <template v-else>
                                         <Button type="button" variant="ghost" size="sm" :data-testid="`edit-${table.id}`" @click="openEdit(table)">
@@ -162,11 +164,11 @@ function confirmDelete(table: TableModel): void {
                                             type="button"
                                             variant="ghost"
                                             size="sm"
-                                            class="ml-1 text-destructive"
-                                            :data-testid="`delete-${table.id}`"
-                                            @click="requestDelete(table)"
+                                            class="ml-1"
+                                            :data-testid="`deactivate-${table.id}`"
+                                            @click="requestDeactivate(table)"
                                         >
-                                            Löschen
+                                            Deaktivieren
                                         </Button>
                                     </template>
                                 </td>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -92,6 +92,26 @@ export interface PaginatedReservationRequests {
     links: { first: string | null; last: string | null; prev: string | null; next: string | null };
 }
 
+export interface TableModel {
+    id: number;
+    label: string;
+    seats: number;
+    room_tag: string | null;
+    sort_order: number;
+    active: boolean;
+    combinable_with: number[];
+    created_at: string | null;
+}
+
+export interface TableFormPayload {
+    label: string;
+    seats: number;
+    room_tag: string | null;
+    sort_order: number;
+    active: boolean;
+    combinable_with: number[];
+}
+
 export interface DashboardFilters {
     status?: ReservationStatus[];
     source?: ReservationSource[];


### PR DESCRIPTION
## Summary

Frontend for table master data (PRD-011, Task 12):

- `resources/js/pages/Tables.vue` — Inertia page in `AppLayout` with a two-tab scaffold (Stammdaten + a Belegung placeholder for #321). The Stammdaten tab lists tables (Bezeichnung, Plätze, Bereich, Kombinierbar mit — resolved to sibling labels, Aktiv) with an empty state, "Neuer Tisch", per-row Bearbeiten, and an inline delete confirmation.
- `resources/js/components/tables/TableForm.vue` — Reka UI `Sheet` drawer for create/edit. Fields: label, seats, room_tag, sort_order, active, combinable_with (sibling checkboxes). Submits via Inertia `router.post`/`router.patch`; validation errors surface through `onError` + `InputError`.
- `resources/js/components/AppSidebar.vue` — adds a "Tische" nav link (otherwise the page is unreachable).
- `resources/js/types/index.ts` — `TableModel` + `TableFormPayload`.

### Acceptance criteria
- [x] Two-tab scaffold (Stammdaten + Belegung placeholder)
- [x] Stammdaten tab lists tables (label, seats, combinable_with, active)
- [x] "Neuer Tisch" + row "Bearbeiten" open the `TableForm` drawer (Reka UI Sheet)
- [x] Submit goes through Inertia `router.post`/`patch`; the store/update redirect refreshes the list
- [x] Delete confirmation before destroy
- [x] No raw `fetch`/`axios` — Inertia only
- [x] Types added to `types/index.ts`
- [x] `npm run lint`, `format:check`, `build`, `test` all green

## Why

PRD-011 needs a UI to manage the table master data that #319 exposes via `TableController`. This page consumes the `tables.data` resource collection and drives the CRUD endpoints. The Belegung tab is a placeholder until #321 adds the day-availability endpoint.

Note: the JSON contract uses the real schema columns (`label`/`seats`/`active`), matching `TableResource` from #319, not the generic `name`/`capacity`/`is_active` field names in the issue text.

## Test plan

- `npm run test` — 90 passing (12 files); `Tables.test.ts` covers row rendering + combinable-label resolution, empty state, tab switching, drawer create (empty) and edit (prefilled) states, create/edit submit payloads through `router.post`/`patch`, and the delete confirmation gating `router.delete`.
- `npm run build` — TypeScript check + Vite build green (Tables chunk emitted).
- `npm run lint`, `npm run format:check` — clean.

Closes #320