### PR TITLE
PRD-011: Belegungs-Tab + day-availability endpoint (#321)

### DIFF
--- a/app/Http/Controllers/TableAvailabilityController.php
+++ b/app/Http/Controllers/TableAvailabilityController.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\TableAvailabilityRequest;
+use App\Http\Resources\TableResource;
+use App\Models\Table;
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use App\Services\Availability\SlotAvailability;
+use Carbon\CarbonImmutable;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Renders the Belegung (occupancy) tab of the tables page (PRD-011): a
+ * deterministic day grid produced by {@see SlotAvailability::forDay}. The
+ * controller stays a thin Inertia adapter — availability is computed by the
+ * service, tenant scope comes from the Table model's global RestaurantScope, and
+ * the `can:viewAny,Table` middleware gates access.
+ */
+final class TableAvailabilityController extends Controller
+{
+    public function __construct(
+        private readonly SlotAvailability $availability,
+    ) {}
+
+    public function show(TableAvailabilityRequest $request): Response
+    {
+        $user = $request->user();
+        $restaurant = $user->restaurant;
+        $date = CarbonImmutable::parse($request->validated()['date']);
+
+        $day = $this->availability->forDay($user->restaurant_id, $date);
+
+        $tables = Table::query()
+            ->where('active', true)
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+
+        return Inertia::render('Tables', [
+            'tables' => TableResource::collection($tables),
+            'activeTab' => 'availability',
+            'availability' => [
+                'date' => $day->date->toDateString(),
+                'total_capacity' => $day->totalCapacity,
+                'reserved_seats' => $day->reservedSeats,
+                // slotStart is a UTC instant; render it in the restaurant's own
+                // timezone so the operator reads local opening times.
+                'slots' => $day->slots->map(fn (SlotAvailabilityResult $slot): array => [
+                    'time' => $slot->slotStart->setTimezone($restaurant->timezone)->format('H:i'),
+                    'state' => $slot->state->value,
+                    'suggested_table_id' => $slot->suggestedTableId,
+                ])->values()->all(),
+            ],
+        ]);
+    }
+}

--- a/app/Http/Requests/TableAvailabilityRequest.php
+++ b/app/Http/Requests/TableAvailabilityRequest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the `date` query parameter for the table-availability grid
+ * (PRD-011). Authorization is enforced by the `can:viewAny,Table` middleware on
+ * the route, so this request is validation-only.
+ */
+class TableAvailabilityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Default an empty `date` to today so opening the Belegung tab without an
+     * explicit day still resolves to a valid grid.
+     */
+    protected function prepareForValidation(): void
+    {
+        if (! $this->filled('date')) {
+            $this->merge(['date' => now()->format('Y-m-d')]);
+        }
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'date' => ['required', 'date_format:Y-m-d', 'after_or_equal:today'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'date.required' => 'Bitte ein Datum angeben.',
+            'date.date_format' => 'Das Datum muss im Format JJJJ-MM-TT vorliegen.',
+            'date.after_or_equal' => 'Das Datum darf nicht in der Vergangenheit liegen.',
+        ];
+    }
+}

--- a/resources/js/components/tables/TableAvailabilityGrid.vue
+++ b/resources/js/components/tables/TableAvailabilityGrid.vue
@@ -1,0 +1,85 @@
+<script setup lang="ts">
+import { Label } from '@/components/ui/label';
+import { type DayAvailability, type SlotState, type TableModel } from '@/types';
+import { router } from '@inertiajs/vue3';
+import { computed, ref } from 'vue';
+
+const props = defineProps<{
+    tables: TableModel[];
+    availability: DayAvailability;
+}>();
+
+const date = ref(props.availability.date);
+const labelById = computed(() => new Map(props.tables.map((table) => [table.id, table.label])));
+
+// Partial reload: the Belegung tab is the availability endpoint itself, so
+// re-requesting the current URL with a new date and only the availability prop
+// refreshes the grid without a full page visit or any fetch/axios call.
+function changeDate(): void {
+    router.reload({ data: { date: date.value }, only: ['availability'] });
+}
+
+const stateMeta: Record<SlotState, { label: string; class: string }> = {
+    free: { label: 'Frei', class: 'bg-green-100 text-green-900 dark:bg-green-950 dark:text-green-200' },
+    tight: { label: 'Knapp', class: 'bg-yellow-100 text-yellow-900 dark:bg-yellow-950 dark:text-yellow-200' },
+    full: { label: 'Voll', class: 'bg-red-100 text-red-900 dark:bg-red-950 dark:text-red-200' },
+};
+
+function suggestedLabel(id: number | null): string {
+    return id === null ? '–' : (labelById.value.get(id) ?? `#${id}`);
+}
+</script>
+
+<template>
+    <div class="space-y-4" data-testid="availability-grid">
+        <div class="flex flex-wrap items-center gap-4">
+            <div class="flex items-center gap-2">
+                <Label for="availability-date">Datum</Label>
+                <input
+                    id="availability-date"
+                    v-model="date"
+                    type="date"
+                    data-testid="availability-date"
+                    class="h-9 rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    @change="changeDate"
+                />
+            </div>
+            <span class="text-sm text-muted-foreground" data-testid="occupancy">
+                {{ availability.reserved_seats }} / {{ availability.total_capacity }} Plätze belegt
+            </span>
+        </div>
+
+        <div v-if="availability.slots.length === 0" class="rounded-lg border border-dashed p-10 text-center" data-testid="availability-empty">
+            <p class="text-sm text-muted-foreground">An diesem Tag ist das Restaurant geschlossen.</p>
+        </div>
+
+        <div v-else class="overflow-x-auto rounded-lg border border-border">
+            <table class="w-full text-left text-sm">
+                <thead class="bg-muted/40">
+                    <tr class="border-b border-border">
+                        <th class="px-4 py-2">Zeit</th>
+                        <th class="px-4 py-2">Status</th>
+                        <th class="px-4 py-2">Tisch-Vorschlag</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr
+                        v-for="slot in availability.slots"
+                        :key="slot.time"
+                        data-testid="slot-row"
+                        :data-state="slot.state"
+                        class="border-b border-border last:border-0"
+                    >
+                        <td class="px-4 py-2 font-medium">{{ slot.time }}</td>
+                        <td class="px-4 py-2">
+                            <span class="inline-block rounded px-2 py-0.5 text-xs font-medium" :class="stateMeta[slot.state].class">
+                                {{ stateMeta[slot.state].label }}
+                            </span>
+                        </td>
+                        <td class="px-4 py-2">{{ suggestedLabel(slot.suggested_table_id) }}</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</template>

--- a/resources/js/pages/Tables.test.ts
+++ b/resources/js/pages/Tables.test.ts
@@ -1,12 +1,15 @@
-import type { TableModel } from '@/types';
+import TableAvailabilityGrid from '@/components/tables/TableAvailabilityGrid.vue';
+import type { DayAvailability, TableModel } from '@/types';
 import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import Tables from './Tables.vue';
 
-const { postSpy, patchSpy, deleteSpy } = vi.hoisted(() => ({
+const { postSpy, patchSpy, deleteSpy, getSpy, reloadSpy } = vi.hoisted(() => ({
     postSpy: vi.fn(),
     patchSpy: vi.fn(),
     deleteSpy: vi.fn(),
+    getSpy: vi.fn(),
+    reloadSpy: vi.fn(),
 }));
 
 vi.mock('@inertiajs/vue3', () => ({
@@ -15,6 +18,8 @@ vi.mock('@inertiajs/vue3', () => ({
         post: (...args: unknown[]) => postSpy(...args),
         patch: (...args: unknown[]) => patchSpy(...args),
         delete: (...args: unknown[]) => deleteSpy(...args),
+        get: (...args: unknown[]) => getSpy(...args),
+        reload: (...args: unknown[]) => reloadSpy(...args),
     },
 }));
 
@@ -54,6 +59,20 @@ function makeTable(overrides: Partial<TableModel> = {}): TableModel {
     };
 }
 
+function makeAvailability(overrides: Partial<DayAvailability> = {}): DayAvailability {
+    return {
+        date: '2026-06-15',
+        total_capacity: 12,
+        reserved_seats: 4,
+        slots: [
+            { time: '17:00', state: 'free', suggested_table_id: 1 },
+            { time: '17:30', state: 'tight', suggested_table_id: 1 },
+            { time: '18:00', state: 'full', suggested_table_id: null },
+        ],
+        ...overrides,
+    };
+}
+
 function mountTables(tables: TableModel[]) {
     return mount(Tables, {
         props: { tables: { data: tables } },
@@ -65,6 +84,8 @@ beforeEach(() => {
     postSpy.mockReset();
     patchSpy.mockReset();
     deleteSpy.mockReset();
+    getSpy.mockReset();
+    reloadSpy.mockReset();
 
     vi.stubGlobal('route', (name: string, params?: Record<string, unknown>) => (params ? `${name}/${Object.values(params).join('/')}` : name));
 });
@@ -91,15 +112,32 @@ describe('Tables.vue master-data tab', () => {
         expect(wrapper.findAll('[data-testid="table-row"]')).toHaveLength(0);
     });
 
-    it('switches to the Belegung placeholder tab', async () => {
+    it('navigates to the availability endpoint when the Belegung tab is clicked', async () => {
         const wrapper = mountTables([makeTable()]);
 
         expect(wrapper.find('[data-testid="tab-panel-stammdaten"]').exists()).toBe(true);
 
-        await wrapper.find('[data-testid="tab-belegung"]').trigger('click');
+        await wrapper.find('[data-testid="tab-availability"]').trigger('click');
 
-        expect(wrapper.find('[data-testid="tab-panel-belegung"]').exists()).toBe(true);
+        expect(getSpy).toHaveBeenCalledTimes(1);
+        expect(getSpy.mock.calls[0][0]).toBe('tables.availability');
+    });
+
+    it('renders the availability grid when the server marks the tab active', () => {
+        const wrapper = mount(Tables, {
+            props: {
+                tables: { data: [makeTable({ id: 1, label: 'Tisch 1' })] },
+                activeTab: 'availability',
+                availability: makeAvailability(),
+            },
+            global: { stubs: sheetStubs },
+        });
+
+        expect(wrapper.find('[data-testid="tab-panel-availability"]').exists()).toBe(true);
         expect(wrapper.find('[data-testid="tab-panel-stammdaten"]').exists()).toBe(false);
+        expect(wrapper.find('[data-testid="availability-grid"]').exists()).toBe(true);
+        // The "Neuer Tisch" button is master-data only.
+        expect(wrapper.find('[data-testid="new-table"]').exists()).toBe(false);
     });
 
     it('opens the drawer with empty fields for create', async () => {
@@ -182,5 +220,51 @@ describe('Tables.vue master-data tab', () => {
         await flushPromises();
 
         expect(wrapper.find('[data-testid="table-form"]').exists()).toBe(false);
+    });
+});
+
+describe('TableAvailabilityGrid', () => {
+    function mountGrid(availability: DayAvailability, tables: TableModel[] = [makeTable({ id: 1, label: 'Tisch 1' })]) {
+        return mount(TableAvailabilityGrid, { props: { tables, availability } });
+    }
+
+    it('renders one row per slot with the matching state', () => {
+        const wrapper = mountGrid(makeAvailability());
+
+        const slotRows = wrapper.findAll('[data-testid="slot-row"]');
+        expect(slotRows).toHaveLength(3);
+        expect(slotRows[0].attributes('data-state')).toBe('free');
+        expect(slotRows[1].attributes('data-state')).toBe('tight');
+        expect(slotRows[2].attributes('data-state')).toBe('full');
+        expect(wrapper.text()).toContain('17:00');
+        expect(wrapper.get('[data-testid="occupancy"]').text()).toContain('4 / 12');
+    });
+
+    it('resolves the suggested table to its label and shows a dash when none', () => {
+        const wrapper = mountGrid(makeAvailability());
+        const slotRows = wrapper.findAll('[data-testid="slot-row"]');
+
+        expect(slotRows[0].text()).toContain('Tisch 1');
+        expect(slotRows[2].text()).toContain('–');
+    });
+
+    it('shows the closed-day state when there are no slots', () => {
+        const wrapper = mountGrid(makeAvailability({ slots: [] }));
+
+        expect(wrapper.find('[data-testid="availability-empty"]').exists()).toBe(true);
+        expect(wrapper.findAll('[data-testid="slot-row"]')).toHaveLength(0);
+    });
+
+    it('reloads only the availability prop when the date changes', async () => {
+        const wrapper = mountGrid(makeAvailability());
+
+        // setValue on a date input updates the v-model and fires `change`.
+        await wrapper.get('[data-testid="availability-date"]').setValue('2026-06-20');
+
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+        expect(reloadSpy.mock.calls[0][0]).toMatchObject({
+            data: { date: '2026-06-20' },
+            only: ['availability'],
+        });
     });
 });

--- a/resources/js/pages/Tables.vue
+++ b/resources/js/pages/Tables.vue
@@ -1,23 +1,38 @@
 <script setup lang="ts">
+import TableAvailabilityGrid from '@/components/tables/TableAvailabilityGrid.vue';
 import TableForm from '@/components/tables/TableForm.vue';
 import { Button } from '@/components/ui/button';
 import AppLayout from '@/layouts/AppLayout.vue';
-import { type BreadcrumbItem, type TableModel } from '@/types';
+import { type BreadcrumbItem, type DayAvailability, type TableModel } from '@/types';
 import { Head, router } from '@inertiajs/vue3';
 import { computed, ref } from 'vue';
 
+type TabKey = 'stammdaten' | 'availability';
+
 const props = defineProps<{
     tables: { data: TableModel[] };
+    // Server-driven: the availability endpoint sets activeTab='availability' and
+    // supplies the day grid; the index leaves both undefined (→ Stammdaten).
+    activeTab?: TabKey;
+    availability?: DayAvailability;
 }>();
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'Tische', href: '/tables' }];
 
-type TabKey = 'stammdaten' | 'belegung';
 const tabs: Array<{ value: TabKey; label: string }> = [
     { value: 'stammdaten', label: 'Stammdaten' },
-    { value: 'belegung', label: 'Belegung' },
+    { value: 'availability', label: 'Belegung' },
 ];
-const activeTab = ref<TabKey>('stammdaten');
+const currentTab = computed<TabKey>(() => props.activeTab ?? 'stammdaten');
+
+// Each tab is its own server route, so switching is an Inertia GET that loads
+// the matching controller (index for master data, availability for the grid).
+function switchTab(tab: TabKey): void {
+    if (tab === currentTab.value) {
+        return;
+    }
+    router.get(tab === 'availability' ? route('tables.availability') : route('tables.index'));
+}
 
 const rows = computed(() => props.tables.data);
 const labelById = computed(() => new Map(rows.value.map((table) => [table.id, table.label])));
@@ -84,7 +99,7 @@ function confirmDeactivate(table: TableModel): void {
         <div class="flex flex-col gap-6 p-4 md:p-6">
             <header class="flex flex-wrap items-center justify-between gap-3">
                 <h1 class="text-2xl font-semibold tracking-tight">Tische</h1>
-                <Button type="button" data-testid="new-table" @click="openCreate">+ Neuer Tisch</Button>
+                <Button v-if="currentTab === 'stammdaten'" type="button" data-testid="new-table" @click="openCreate">+ Neuer Tisch</Button>
             </header>
 
             <div role="tablist" aria-label="Tisch-Ansicht" class="flex gap-2 border-b border-border">
@@ -93,22 +108,22 @@ function confirmDeactivate(table: TableModel): void {
                     :key="tab.value"
                     type="button"
                     role="tab"
-                    :aria-selected="activeTab === tab.value"
-                    :data-active="activeTab === tab.value"
+                    :aria-selected="currentTab === tab.value"
+                    :data-active="currentTab === tab.value"
                     :data-testid="`tab-${tab.value}`"
                     class="-mb-px border-b-2 px-3 py-2 text-sm transition"
                     :class="
-                        activeTab === tab.value
+                        currentTab === tab.value
                             ? 'border-primary font-medium text-primary'
                             : 'border-transparent text-muted-foreground hover:text-foreground'
                     "
-                    @click="activeTab = tab.value"
+                    @click="switchTab(tab.value)"
                 >
                     {{ tab.label }}
                 </button>
             </div>
 
-            <section v-if="activeTab === 'stammdaten'" data-testid="tab-panel-stammdaten">
+            <section v-if="currentTab === 'stammdaten'" data-testid="tab-panel-stammdaten">
                 <div v-if="rows.length === 0" class="rounded-lg border border-dashed p-10 text-center" data-testid="empty-state">
                     <p class="text-lg font-medium">Noch keine Tische angelegt.</p>
                     <p class="mt-1 text-sm text-muted-foreground">Lege deinen ersten Tisch an, um die Verfügbarkeit zu pflegen.</p>
@@ -178,9 +193,8 @@ function confirmDeactivate(table: TableModel): void {
                 </div>
             </section>
 
-            <section v-else data-testid="tab-panel-belegung" class="rounded-lg border border-dashed p-10 text-center">
-                <p class="text-lg font-medium">Belegungs-Ansicht folgt.</p>
-                <p class="mt-1 text-sm text-muted-foreground">Die Tages-Belegung wird in einem späteren Schritt ergänzt.</p>
+            <section v-else-if="currentTab === 'availability'" data-testid="tab-panel-availability">
+                <TableAvailabilityGrid v-if="availability" :tables="rows" :availability="availability" />
             </section>
         </div>
 

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -112,6 +112,21 @@ export interface TableFormPayload {
     combinable_with: number[];
 }
 
+export type SlotState = 'free' | 'tight' | 'full';
+
+export interface AvailabilitySlot {
+    time: string;
+    state: SlotState;
+    suggested_table_id: number | null;
+}
+
+export interface DayAvailability {
+    date: string;
+    slots: AvailabilitySlot[];
+    total_capacity: number;
+    reserved_seats: number;
+}
+
 export interface DashboardFilters {
     status?: ReservationStatus[];
     source?: ReservationSource[];

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -52,6 +52,23 @@ declare module 'ziggy-js' {
             "binding": "id"
         }
     ],
+    "tables.availability": [],
+    "tables.index": [],
+    "tables.store": [],
+    "tables.update": [
+        {
+            "name": "table",
+            "required": true,
+            "binding": "id"
+        }
+    ],
+    "tables.destroy": [
+        {
+            "name": "table",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "public.reservations.create": [
         {
             "name": "restaurant",

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,7 @@ use App\Http\Controllers\ReservationMessagesController;
 use App\Http\Controllers\ReservationReplyController;
 use App\Http\Controllers\ReservationRequestController;
 use App\Http\Controllers\SendModeKillswitchController;
+use App\Http\Controllers\TableAvailabilityController;
 use App\Http\Controllers\TableController;
 use App\Models\Table;
 use Illuminate\Support\Facades\Route;
@@ -63,6 +64,10 @@ Route::post('reservation-replies/{reply}/mark-shadow-compared', [ReservationRepl
 Route::post('restaurants/{restaurant}/send-mode/killswitch', SendModeKillswitchController::class)
     ->middleware(['auth', 'verified', 'can:manageSendMode,restaurant'])
     ->name('restaurants.send-mode.killswitch');
+
+Route::get('tables/availability', [TableAvailabilityController::class, 'show'])
+    ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])
+    ->name('tables.availability');
 
 Route::get('tables', [TableController::class, 'index'])
     ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])

--- a/tests/Feature/Tables/TableAvailabilityTest.php
+++ b/tests/Feature/Tables/TableAvailabilityTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Tables;
+
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class TableAvailabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array{0: Restaurant, 1: User}
+     */
+    private function ownerWithRestaurant(): array
+    {
+        // Default factory: Europe/Berlin, Monday open 11:30–14:30 + 18:00–22:30.
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Owner]);
+
+        return [$restaurant, $owner];
+    }
+
+    public function test_guests_are_redirected_from_availability(): void
+    {
+        $this->get(route('tables.availability', ['date' => '2026-06-15']))->assertRedirect('/login');
+    }
+
+    public function test_owner_sees_the_day_availability_grid_in_local_time(): void
+    {
+        [$restaurant, $owner] = $this->ownerWithRestaurant();
+        Table::factory()->for($restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($owner)
+            ->get(route('tables.availability', ['date' => '2026-06-15'])) // Monday
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Tables')
+                ->where('activeTab', 'availability')
+                ->where('availability.date', '2026-06-15')
+                // First Monday lunch slot is 11:30 in the restaurant's timezone.
+                ->where('availability.slots.0.time', '11:30')
+                ->has('availability.slots')
+                ->has('availability.total_capacity')
+                ->has('availability.reserved_seats')
+                ->has('tables.data')
+            );
+    }
+
+    public function test_availability_defaults_to_today_when_no_date_is_given(): void
+    {
+        [$restaurant, $owner] = $this->ownerWithRestaurant();
+        Table::factory()->for($restaurant)->create();
+
+        $this->actingAs($owner)
+            ->get(route('tables.availability'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Tables')
+                ->where('availability.date', now()->format('Y-m-d'))
+            );
+    }
+
+    public function test_invalid_date_is_rejected(): void
+    {
+        [, $owner] = $this->ownerWithRestaurant();
+
+        $this->actingAs($owner)
+            ->get(route('tables.availability', ['date' => 'not-a-date']))
+            ->assertSessionHasErrors('date');
+    }
+
+    public function test_past_date_is_rejected(): void
+    {
+        [, $owner] = $this->ownerWithRestaurant();
+
+        $this->actingAs($owner)
+            ->get(route('tables.availability', ['date' => '2020-01-01']))
+            ->assertSessionHasErrors('date');
+    }
+
+    public function test_user_without_a_restaurant_is_forbidden(): void
+    {
+        $user = User::factory()->create(); // restaurant_id is null
+
+        $this->actingAs($user)
+            ->get(route('tables.availability', ['date' => '2026-06-15']))
+            ->assertForbidden();
+    }
+
+    public function test_only_active_tables_of_the_own_restaurant_are_returned(): void
+    {
+        [$restaurant, $owner] = $this->ownerWithRestaurant();
+        $foreign = Restaurant::factory()->create();
+        Table::factory()->for($restaurant)->create(['active' => true]);
+        Table::factory()->for($restaurant)->inactive()->create();
+        Table::factory()->for($foreign)->create(['active' => true]);
+
+        $this->actingAs($owner)
+            ->get(route('tables.availability', ['date' => '2026-06-15']))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('tables.data', 1));
+    }
+}

--- a/tests/Feature/Tables/TableAvailabilityTest.php
+++ b/tests/Feature/Tables/TableAvailabilityTest.php
@@ -86,6 +86,21 @@ class TableAvailabilityTest extends TestCase
             ->assertSessionHasErrors('date');
     }
 
+    public function test_staff_may_view_availability(): void
+    {
+        [$restaurant] = $this->ownerWithRestaurant();
+        $staff = User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Staff]);
+        Table::factory()->for($restaurant)->create();
+
+        $this->actingAs($staff)
+            ->get(route('tables.availability', ['date' => '2026-06-15']))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Tables')
+                ->where('activeTab', 'availability')
+            );
+    }
+
     public function test_user_without_a_restaurant_is_forbidden(): void
     {
         $user = User::factory()->create(); // restaurant_id is null


### PR DESCRIPTION
## Summary

Final PRD-011 piece (Task 13): the Belegung (occupancy) tab and its backing endpoint.

**Backend**
- `TableAvailabilityController` — GET endpoint rendering a deterministic day grid from `SlotAvailability::forDay`. Returns active tables + an `availability` payload (date, per-slot time/state/suggested_table_id, total_capacity, reserved_seats) with `activeTab='availability'`.
- `TableAvailabilityRequest` — `date` (Y-m-d, today-or-future), defaults to today when absent so the tab opens without a param.
- Route `GET /tables/availability` behind `auth` + `verified` + `can:viewAny,Table`, registered before the `{table}` routes.

**Frontend**
- `TableAvailabilityGrid.vue` — tables × 30-min slot rows coloured by `SlotState` (free/tight/full), an occupancy headline, suggested-table label resolution, and a date picker that partial-reloads only the `availability` prop.
- `Tables.vue` — tabs become server-driven navigations (Stammdaten → `tables.index`, Belegung → `tables.availability`); the page renders the grid when the server marks `activeTab='availability'`.
- `SlotState` / `AvailabilitySlot` / `DayAvailability` types added.

### Acceptance criteria
- [x] `TableAvailabilityRequest`: `date` Y-m-d, today-or-future
- [x] Controller returns the `DayAvailability` shape via Inertia, refreshed with `router.reload({ only: ['availability'] })`
- [x] Tenant scope via policy; unauthorized (no restaurant) → 403; data scoped by `RestaurantScope`
- [x] Grid: rows = slots, coloured by `SlotState`, with suggested table
- [x] Date picker switches the day via Inertia partial reload
- [x] `ziggy:generate` run (gitignored output refreshed)
- [x] `composer test`, `npm run lint`, `format:check`, `build`, `test` all green

## Why

PRD-011 needs the occupancy view so operators can see, per 30-min slot, whether the restaurant is free/tight/full for a chosen day. The decision stays deterministic in `SlotAvailability` (#316); this endpoint is a thin Inertia adapter, and the grid only renders the result — consistent with the "Laravel decides, UI displays" principle.

Note: slot times are rendered in the restaurant's timezone (`slotStart->setTimezone(...)`), since `forDay` returns UTC instants. The "cross-tenant → 403" criterion is realized via `can:viewAny,Table` (a user without a restaurant gets 403); the endpoint only ever serves the caller's own restaurant via the global scope, so there is no foreign id to probe.

## Test plan

- `php artisan test` — 885 passing; `TableAvailabilityTest` covers owner grid (local-time slot assertion), default-to-today, guest redirect, invalid + past date 422, no-restaurant 403, and active/own-restaurant table scoping.
- `npm run test` — 96 passing; new grid tests (slot rows + state, suggested-label resolution, closed-day empty state, date-change partial reload) plus the updated tab-navigation test.
- `npm run build`, `lint`, `format:check` — clean.

Closes #321