### PR TITLE
PRD-012 #341: phone/walk_in source + note + created_by_user_id schema

### DIFF
--- a/app/Enums/ReservationSource.php
+++ b/app/Enums/ReservationSource.php
@@ -6,4 +6,6 @@ enum ReservationSource: string
 {
     case WebForm = 'web_form';
     case Email = 'email';
+    case Phone = 'phone';
+    case WalkIn = 'walk_in';
 }

--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -37,9 +37,11 @@ class ReservationRequest extends Model
         'party_size',
         'desired_at',
         'message',
+        'note',
         'raw_payload',
         'needs_manual_review',
         'email_message_id',
+        'created_by_user_id',
     ];
 
     /**

--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -58,6 +58,7 @@ class ReservationRequest extends Model
             'desired_at' => 'datetime',
             'raw_payload' => 'encrypted:array',
             'needs_manual_review' => 'boolean',
+            'created_by_user_id' => 'integer',
         ];
     }
 
@@ -67,6 +68,17 @@ class ReservationRequest extends Model
     public function restaurant(): BelongsTo
     {
         return $this->belongsTo(Restaurant::class);
+    }
+
+    /**
+     * The user who captured this request manually (phone/walk-in); null for
+     * web-form and email sources.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
     }
 
     /**

--- a/database/migrations/2026_05_22_000001_add_created_by_user_id_to_reservation_requests_table.php
+++ b/database/migrations/2026_05_22_000001_add_created_by_user_id_to_reservation_requests_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->foreignId('created_by_user_id')
+                ->nullable()
+                ->after('needs_manual_review')
+                ->constrained('users')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('created_by_user_id');
+        });
+    }
+};

--- a/database/migrations/2026_05_22_000002_add_note_to_reservation_requests_table.php
+++ b/database/migrations/2026_05_22_000002_add_note_to_reservation_requests_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->text('note')->nullable()->after('message');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->dropColumn('note');
+        });
+    }
+};

--- a/tests/Feature/Models/ReservationRequestTest.php
+++ b/tests/Feature/Models/ReservationRequestTest.php
@@ -7,6 +7,7 @@ use App\Enums\ReservationStatus;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
+use App\Models\User;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -227,5 +228,56 @@ class ReservationRequestTest extends TestCase
 
         $this->assertSame($newest->id, $request->latestReply->id);
         $this->assertSame('Latest revision', $request->latestReply->body);
+    }
+
+    public function test_phone_and_walk_in_sources_round_trip_through_the_cast(): void
+    {
+        $phone = ReservationRequest::factory()->create(['source' => ReservationSource::Phone]);
+        $walkIn = ReservationRequest::factory()->create(['source' => ReservationSource::WalkIn]);
+
+        $this->assertSame('phone', DB::table('reservation_requests')->where('id', $phone->id)->value('source'));
+        $this->assertSame('walk_in', DB::table('reservation_requests')->where('id', $walkIn->id)->value('source'));
+        $this->assertSame(ReservationSource::Phone, $phone->fresh()->source);
+        $this->assertSame(ReservationSource::WalkIn, $walkIn->fresh()->source);
+    }
+
+    public function test_note_is_nullable_and_fillable(): void
+    {
+        $withNote = ReservationRequest::factory()->create(['note' => 'Geburtstag, Fensterplatz']);
+        $withoutNote = ReservationRequest::factory()->create(['note' => null]);
+
+        $this->assertSame('Geburtstag, Fensterplatz', $withNote->fresh()->note);
+        $this->assertNull($withoutNote->fresh()->note);
+    }
+
+    public function test_created_by_user_id_is_nullable_fillable_and_cast_to_int(): void
+    {
+        $user = User::factory()->create();
+
+        $captured = ReservationRequest::factory()->create(['created_by_user_id' => $user->id]);
+        $external = ReservationRequest::factory()->create(['created_by_user_id' => null]);
+
+        $this->assertSame($user->id, $captured->fresh()->created_by_user_id);
+        $this->assertIsInt($captured->fresh()->created_by_user_id);
+        $this->assertNull($external->fresh()->created_by_user_id);
+    }
+
+    public function test_created_by_user_id_is_nulled_when_the_capturing_user_is_deleted(): void
+    {
+        $user = User::factory()->create();
+        $request = ReservationRequest::factory()->create(['created_by_user_id' => $user->id]);
+
+        $user->delete();
+
+        $this->assertTrue($request->fresh()->exists, 'the reservation must survive deleting its creator');
+        $this->assertNull($request->fresh()->created_by_user_id);
+    }
+
+    public function test_created_by_relation_returns_the_capturing_user(): void
+    {
+        $user = User::factory()->create();
+        $request = ReservationRequest::factory()->create(['created_by_user_id' => $user->id]);
+
+        $this->assertSame($user->id, $request->createdBy->id);
     }
 }


### PR DESCRIPTION
## Summary

Schema/enum foundation for PRD-012 (manual phone/walk-in reservation entry):

- `ReservationSource` gains `Phone = 'phone'` and `WalkIn = 'walk_in'`
- `reservation_requests.created_by_user_id` — fk `users`, nullable, `nullOnDelete` (who entered the record)
- `reservation_requests.note` — text, nullable (owner annotation, e.g. "Geburtstag"; deliberately distinct from the inbound `message`)
- Both columns added to `$fillable` so the upcoming controller (#343) can mass-assign them

## Why

PRD-012 stores phone/walk-in reservations directly as `confirmed`, tagged with their source and the staff member who entered them, plus an optional internal note. This issue lays only the data layer; controllers/UI follow in #342–#346.

## Side effect (flagged for follow-up)

`AnalyticsAggregator::bySource` iterates `ReservationSource::cases()`, so analytics now emits zero-count `phone`/`walk_in` buckets. Backend tests tolerate this; the frontend ignores the extra keys. Updating the TS `ReservationSource` type, the Dashboard source filter, and the Analytics display to surface phone/walk-in belongs to the PRD-012 frontend issues (#344/#345), not here.

## Test plan

- [x] `migrate` → `migrate:rollback --step=2` → `migrate` clean on a throwaway SQLite (up/down/up)
- [x] `php artisan test` — 886 passed (2811 assertions)
- [x] `./vendor/bin/pint --test` clean on changed files
- [x] No routes/frontend touched → ziggy-drift and JS checks unaffected

Closes #341