### PR TITLE
PRD-012 #343: quick-reservation store with locking + auto table assignment

### DIFF
--- a/app/Http/Controllers/QuickReservationController.php
+++ b/app/Http/Controllers/QuickReservationController.php
@@ -14,9 +14,9 @@ use App\Models\Restaurant;
 use App\Models\Table;
 use App\Services\Availability\DTOs\SlotAvailabilityResult;
 use App\Services\Availability\SlotAvailability;
+use App\Support\Timezone;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
@@ -94,24 +94,26 @@ final class QuickReservationController extends Controller
         $restaurant = $user->restaurant;
         $validated = $request->validated();
 
-        $datetime = CarbonImmutable::parse("{$validated['date']} {$validated['time']}", $restaurant->timezone)->utc();
+        // Shared helper (used by the public reservation path too) parses the
+        // operator's local input and returns the UTC instant reservations store.
+        $datetime = Timezone::localToUtc(
+            "{$validated['date']} {$validated['time']}",
+            $restaurant->timezone,
+        )->toImmutable();
 
         DB::transaction(function () use ($user, $validated, $datetime): void {
-            // Serialize concurrent bookings for this slot: lock the restaurant's
-            // active tables, then evaluate availability *inside* the lock so a
-            // second request waits and sees the first's committed assignment
-            // before it picks a table. (lockForUpdate is a no-op on SQLite but
-            // protects the production MySQL/Postgres path.)
+            // Serialize concurrent bookings for this slot: a SELECT ... FOR UPDATE
+            // on the restaurant's active tables makes a second request block until
+            // this one commits, after which its in-lock availability re-check sees
+            // the assignment just written. (lockForUpdate is a no-op on SQLite but
+            // protects the production MySQL/Postgres path.) Tenant scope is the
+            // Table model's global RestaurantScope.
             Table::query()
                 ->where('active', true)
                 ->lockForUpdate()
                 ->get();
 
-            $freeTableIds = $this->availability
-                ->freeTablesAt($user->restaurant_id, $datetime)
-                ->pluck('id');
-
-            $tableIds = $this->resolveTableIds($user->restaurant_id, $datetime, $validated, $freeTableIds);
+            $tableIds = $this->resolveTableIds($user->restaurant_id, $datetime, $validated);
 
             $reservation = ReservationRequest::create([
                 'restaurant_id' => $user->restaurant_id,
@@ -140,25 +142,29 @@ final class QuickReservationController extends Controller
     }
 
     /**
-     * Resolve the table(s) to assign. A manual `table_id` is honoured as long as
-     * it is actually free in the slot (the operator may deliberately seat a
-     * regular at a specific table); otherwise the smallest fitting single table
-     * or two-table combination is auto-assigned. A two-table combination yields
-     * an assignment per table so both are marked occupied (the M:N schema, PRD-011)
-     * — assigning only the primary would leave the second table double-bookable.
-     * Throws when the chosen table is busy or no table fits, surfacing a clear
-     * message instead of a silent failure.
+     * Resolve the table(s) to assign. A manual `table_id` is honoured — yielding
+     * exactly that one table — as long as it is actually free in the slot (the
+     * operator may deliberately seat a regular at a specific table). Otherwise
+     * the smallest fitting single table or two-table combination is auto-assigned;
+     * a combination returns one id per table so both are marked occupied (the M:N
+     * schema, PRD-011) — assigning only the primary would leave the second table
+     * double-bookable. Throws when the chosen table is busy or no table fits,
+     * surfacing a clear message instead of a silent failure.
      *
      * @param  array<string, mixed>  $validated
-     * @param  Collection<int, int>  $freeTableIds
      * @return list<int>
      */
-    private function resolveTableIds(int $restaurantId, CarbonImmutable $datetime, array $validated, Collection $freeTableIds): array
+    private function resolveTableIds(int $restaurantId, CarbonImmutable $datetime, array $validated): array
     {
         if (isset($validated['table_id'])) {
             $tableId = (int) $validated['table_id'];
 
-            if (! $freeTableIds->contains($tableId)) {
+            $isFree = $this->availability
+                ->freeTablesAt($restaurantId, $datetime)
+                ->pluck('id')
+                ->contains($tableId);
+
+            if (! $isFree) {
                 throw ValidationException::withMessages([
                     'table_id' => 'Dieser Tisch ist im gewählten Zeitfenster bereits belegt.',
                 ]);

--- a/app/Http/Controllers/QuickReservationController.php
+++ b/app/Http/Controllers/QuickReservationController.php
@@ -4,29 +4,40 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\ReservationStatus;
 use App\Http\Requests\QuickReservationCreateRequest;
+use App\Http\Requests\QuickReservationStoreRequest;
 use App\Http\Resources\TableResource;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
 use App\Models\Restaurant;
 use App\Models\Table;
 use App\Services\Availability\DTOs\SlotAvailabilityResult;
 use App\Services\Availability\SlotAvailability;
 use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
 /**
- * Quick phone/walk-in reservation entry (PRD-012). This controller serves the
- * read path: it renders the keyboard-first form and, on every date/time/party
- * change, recomputes a deterministic availability verdict via
- * {@see SlotAvailability::forSlot}. The store path lives in #343.
+ * Quick phone/walk-in reservation entry (PRD-012).
+ *
+ * `create` is the read path: it renders the keyboard-first form and, on every
+ * date/time/party change, recomputes a deterministic availability verdict via
+ * {@see SlotAvailability::forSlot}. `store` persists the reservation directly as
+ * `confirmed` (the owner has already confirmed verbally) with an auto-assigned
+ * table — no AI reply, no mail.
  *
  * The operator works in the restaurant's local time, so smart defaults and the
- * `defaults` prop are local, while `forSlot` receives the UTC instant it expects
- * (matching how reservations store `desired_at`). The controller stays a thin
- * Inertia adapter — availability is the service's job, authorization is the
- * route's `can:viewAny,Table` gate (TablePolicy, which also rejects a user
- * without a restaurant, like the tables.availability endpoint), and tenant scope
- * comes from the Table model's global RestaurantScope.
+ * `defaults` prop are local, while the availability service receives the UTC
+ * instant it expects (matching how reservations store `desired_at`). The
+ * controller stays a thin Inertia adapter — availability is the service's job,
+ * authorization is the route's `can:viewAny,Table` gate (TablePolicy, which also
+ * rejects a user without a restaurant, like the tables.availability endpoint),
+ * and tenant scope comes from the Table model's global RestaurantScope.
  */
 final class QuickReservationController extends Controller
 {
@@ -75,6 +86,97 @@ final class QuickReservationController extends Controller
             ],
             'availability' => $this->presentAvailability($availability, $restaurant),
         ]);
+    }
+
+    public function store(QuickReservationStoreRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        $restaurant = $user->restaurant;
+        $validated = $request->validated();
+
+        $datetime = CarbonImmutable::parse("{$validated['date']} {$validated['time']}", $restaurant->timezone)->utc();
+
+        DB::transaction(function () use ($user, $validated, $datetime): void {
+            // Serialize concurrent bookings for this slot: lock the restaurant's
+            // active tables, then evaluate availability *inside* the lock so a
+            // second request waits and sees the first's committed assignment
+            // before it picks a table. (lockForUpdate is a no-op on SQLite but
+            // protects the production MySQL/Postgres path.)
+            Table::query()
+                ->where('active', true)
+                ->lockForUpdate()
+                ->get();
+
+            $freeTableIds = $this->availability
+                ->freeTablesAt($user->restaurant_id, $datetime)
+                ->pluck('id');
+
+            $tableIds = $this->resolveTableIds($user->restaurant_id, $datetime, $validated, $freeTableIds);
+
+            $reservation = ReservationRequest::create([
+                'restaurant_id' => $user->restaurant_id,
+                'source' => $validated['source'],
+                'status' => ReservationStatus::Confirmed,
+                'guest_name' => $validated['guest_name'],
+                'guest_phone' => $validated['guest_phone'] ?? null,
+                'guest_email' => $validated['guest_email'] ?? null,
+                'party_size' => $validated['party_size'],
+                'desired_at' => $datetime,
+                'note' => $validated['note'] ?? null,
+                'created_by_user_id' => $user->id,
+            ]);
+
+            foreach ($tableIds as $tableId) {
+                ReservationTableAssignment::create([
+                    'reservation_request_id' => $reservation->id,
+                    'table_id' => $tableId,
+                    'assigned_at' => now(),
+                    'assigned_by_user_id' => $user->id,
+                ]);
+            }
+        });
+
+        return redirect()->route('dashboard')->with('success', 'Reservierung gespeichert.');
+    }
+
+    /**
+     * Resolve the table(s) to assign. A manual `table_id` is honoured as long as
+     * it is actually free in the slot (the operator may deliberately seat a
+     * regular at a specific table); otherwise the smallest fitting single table
+     * or two-table combination is auto-assigned. A two-table combination yields
+     * an assignment per table so both are marked occupied (the M:N schema, PRD-011)
+     * — assigning only the primary would leave the second table double-bookable.
+     * Throws when the chosen table is busy or no table fits, surfacing a clear
+     * message instead of a silent failure.
+     *
+     * @param  array<string, mixed>  $validated
+     * @param  Collection<int, int>  $freeTableIds
+     * @return list<int>
+     */
+    private function resolveTableIds(int $restaurantId, CarbonImmutable $datetime, array $validated, Collection $freeTableIds): array
+    {
+        if (isset($validated['table_id'])) {
+            $tableId = (int) $validated['table_id'];
+
+            if (! $freeTableIds->contains($tableId)) {
+                throw ValidationException::withMessages([
+                    'table_id' => 'Dieser Tisch ist im gewählten Zeitfenster bereits belegt.',
+                ]);
+            }
+
+            return [$tableId];
+        }
+
+        $combination = $this->availability
+            ->suggestTableCombination($restaurantId, $datetime, (int) $validated['party_size']);
+
+        if ($combination === null) {
+            throw ValidationException::withMessages([
+                'table_id' => 'Kein passender Tisch verfügbar. Bitte anderen Slot wählen.',
+            ]);
+        }
+
+        return $combination->tableIds;
     }
 
     /**

--- a/app/Http/Requests/QuickReservationStoreRequest.php
+++ b/app/Http/Requests/QuickReservationStoreRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\ReservationRequest;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a manual phone/walk-in reservation submission (PRD-012).
+ * Authorization is the route's `can:viewAny,Table` gate (same operator
+ * capability as the create form). `table_id` is constrained to an active table
+ * of the acting user's own restaurant, so a client-supplied id can never point
+ * at a foreign or inactive table.
+ */
+class QuickReservationStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'source' => ['required', 'in:phone,walk_in'],
+            'date' => ['required', 'date_format:Y-m-d', 'after_or_equal:today'],
+            'time' => ['required', 'date_format:H:i'],
+            'party_size' => ['required', 'integer', 'min:1', 'max:'.ReservationRequest::MAX_PARTY_SIZE],
+            'guest_name' => ['required', 'string', 'max:200'],
+            'guest_phone' => ['nullable', 'string', 'max:50', 'regex:/^[+0-9 ()\/-]+$/'],
+            'guest_email' => ['nullable', 'email'],
+            'note' => ['nullable', 'string', 'max:500'],
+            'table_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('tables', 'id')
+                    ->where('restaurant_id', $this->user()->restaurant_id)
+                    ->where('active', true),
+            ],
+        ];
+    }
+}

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -12,6 +12,7 @@ declare module 'ziggy-js' {
         }
     ],
     "reservations.quick.create": [],
+    "reservations.quick.store": [],
     "reservations.show": [
         {
             "name": "reservation",

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,10 @@ Route::get('reservations/quick', [QuickReservationController::class, 'create'])
     ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])
     ->name('reservations.quick.create');
 
+Route::post('reservations/quick', [QuickReservationController::class, 'store'])
+    ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])
+    ->name('reservations.quick.store');
+
 Route::get('reservations/{reservation}', [ReservationRequestController::class, 'show'])
     ->whereNumber('reservation')
     ->middleware(['auth', 'verified'])

--- a/tests/Feature/Reservations/QuickReservationStoreTest.php
+++ b/tests/Feature/Reservations/QuickReservationStoreTest.php
@@ -120,6 +120,18 @@ class QuickReservationStoreTest extends TestCase
         $this->assertSame(ReservationSource::WalkIn, ReservationRequest::sole()->source);
     }
 
+    public function test_staff_may_store_a_quick_reservation(): void
+    {
+        $staff = User::factory()->forRestaurant($this->restaurant)->create(['role' => UserRole::Staff]);
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($staff)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame($staff->id, ReservationRequest::sole()->created_by_user_id);
+    }
+
     public function test_it_auto_assigns_the_smallest_fitting_table(): void
     {
         Table::factory()->for($this->restaurant)->create(['seats' => 8, 'sort_order' => 1]);

--- a/tests/Feature/Reservations/QuickReservationStoreTest.php
+++ b/tests/Feature/Reservations/QuickReservationStoreTest.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Reservations;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Enums\UserRole;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class QuickReservationStoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    private User $owner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // UTC + a wide dinner window keeps local time == stored desired_at, so
+        // the booking logic under test is not confounded by timezone maths
+        // (the timezone path is covered by the create endpoint test).
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+        $this->owner = User::factory()->forRestaurant($this->restaurant)->create(['role' => UserRole::Owner]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'source' => 'phone',
+            'date' => '2026-06-15', // Monday
+            'time' => '19:00',
+            'party_size' => 2,
+            'guest_name' => 'Müller',
+        ], $overrides);
+    }
+
+    private function occupy(Table $table, string $desiredAtUtc): void
+    {
+        $reservation = ReservationRequest::factory()->for($this->restaurant)->create([
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => 2,
+            'status' => ReservationStatus::Confirmed,
+        ]);
+
+        ReservationTableAssignment::factory()
+            ->for($reservation, 'reservationRequest')
+            ->for($table)
+            ->create();
+    }
+
+    public function test_guests_are_redirected(): void
+    {
+        $this->post(route('reservations.quick.store'), $this->payload())->assertRedirect('/login');
+    }
+
+    public function test_owner_can_create_a_phone_reservation(): void
+    {
+        Mail::fake();
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload([
+                'guest_phone' => '+49 157 1234',
+                'guest_email' => 'gast@example.com',
+                'note' => 'Geburtstag',
+            ]))
+            ->assertRedirect(route('dashboard'))
+            ->assertSessionHas('success');
+
+        $reservation = ReservationRequest::sole();
+        $this->assertSame(ReservationStatus::Confirmed, $reservation->status);
+        $this->assertSame(ReservationSource::Phone, $reservation->source);
+        $this->assertSame('Müller', $reservation->guest_name);
+        $this->assertSame('Geburtstag', $reservation->note);
+        $this->assertSame($this->owner->id, $reservation->created_by_user_id);
+        $this->assertSame('2026-06-15 19:00:00', $reservation->desired_at->utc()->format('Y-m-d H:i:s'));
+
+        $assignment = ReservationTableAssignment::sole();
+        $this->assertSame($table->id, $assignment->table_id);
+        $this->assertSame($this->owner->id, $assignment->assigned_by_user_id);
+
+        $this->assertSame(0, ReservationReply::count());
+        Mail::assertNothingSent();
+    }
+
+    public function test_owner_can_create_a_walk_in_reservation(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['source' => 'walk_in']))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame(ReservationSource::WalkIn, ReservationRequest::sole()->source);
+    }
+
+    public function test_it_auto_assigns_the_smallest_fitting_table(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8, 'sort_order' => 1]);
+        $small = Table::factory()->for($this->restaurant)->create(['seats' => 4, 'sort_order' => 2]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 4]))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame($small->id, ReservationTableAssignment::sole()->table_id);
+    }
+
+    public function test_it_assigns_every_table_of_a_combination(): void
+    {
+        $a = Table::factory()->for($this->restaurant)->create(['seats' => 2, 'sort_order' => 1]);
+        $b = Table::factory()->for($this->restaurant)->create(['seats' => 2, 'sort_order' => 2]);
+        $a->update(['combinable_with' => [$b->id]]);
+        $b->update(['combinable_with' => [$a->id]]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 4]))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame(2, ReservationTableAssignment::count());
+        $this->assertEqualsCanonicalizing(
+            [$a->id, $b->id],
+            ReservationTableAssignment::pluck('table_id')->all(),
+        );
+    }
+
+    public function test_it_accepts_a_manual_table_override(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4, 'sort_order' => 1]);
+        $preferred = Table::factory()->for($this->restaurant)->create(['seats' => 8, 'sort_order' => 2]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['table_id' => $preferred->id]))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame($preferred->id, ReservationTableAssignment::sole()->table_id);
+    }
+
+    public function test_it_rejects_a_manual_table_that_is_busy_in_the_slot(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00');
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['table_id' => $table->id]))
+            ->assertSessionHasErrors('table_id');
+
+        $this->assertSame(1, ReservationRequest::count()); // only the pre-existing occupier
+    }
+
+    public function test_it_rejects_when_no_table_fits_the_party(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 2]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 6]))
+            ->assertSessionHasErrors('table_id');
+
+        $this->assertSame(0, ReservationRequest::count());
+        $this->assertSame(0, ReservationTableAssignment::count());
+    }
+
+    public function test_a_second_booking_for_the_only_table_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertRedirect(route('dashboard'));
+
+        // Same slot, only table now occupied: the in-transaction re-check rejects.
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertSessionHasErrors('table_id');
+
+        $this->assertSame(1, ReservationRequest::count());
+        $this->assertSame(1, ReservationTableAssignment::count());
+    }
+
+    public function test_a_foreign_restaurant_table_id_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $foreign = Restaurant::factory()->create();
+        $foreignTable = Table::factory()->for($foreign)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['table_id' => $foreignTable->id]))
+            ->assertSessionHasErrors('table_id');
+    }
+
+    public function test_past_date_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create();
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['date' => '2020-01-01']))
+            ->assertSessionHasErrors('date');
+    }
+
+    public function test_party_size_above_the_cap_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create();
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 21]))
+            ->assertSessionHasErrors('party_size');
+    }
+
+    public function test_source_must_be_phone_or_walk_in(): void
+    {
+        Table::factory()->for($this->restaurant)->create();
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['source' => 'web_form']))
+            ->assertSessionHasErrors('source');
+    }
+
+    public function test_user_without_a_restaurant_is_forbidden(): void
+    {
+        $user = User::factory()->create(); // restaurant_id is null
+
+        $this->actingAs($user)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary

PRD-012 store path (`#343`), building on #341/#342:

- `POST /reservations/quick` → `reservations.quick.store` (auth + verified + `can:viewAny,Table`, symmetric with the create form)
- `QuickReservationController@store` + `QuickReservationStoreRequest`
- Persists `status = confirmed`, `source = phone|walk_in`, `created_by_user_id = auth id`, optional `note` — **no AI pipeline, no mail**
- Auto-assigns the smallest fitting single table or two-table combination; honours a manual `table_id` when it is free
- `DB::transaction` + `lockForUpdate` on the restaurant's active tables, with availability re-evaluated **inside** the lock

## Why

This is the write half of the quick form: the owner has already confirmed verbally on the phone, so the tool records the booking and assigns a table deterministically (PRD-011), without any customer-facing message.

## Notes / decisions

- **Combination assignment refinement:** PRD-012's snippet assigns only `primaryTableId`. For a two-table combination that would leave the second table double-bookable, so this assigns **one row per table in the combination** (the M:N schema from PRD-011 supports it). Single-table and manual paths assign one row.
- **Manual override** is validated only for being *free* (not capacity) — the operator may deliberately seat a regular at a larger table (PRD-012).
- **Concurrency:** `lockForUpdate` is a no-op on SQLite but protects the production MySQL/Postgres path; the in-transaction re-check is what the `a_second_booking_for_the_only_table_is_rejected` test exercises (sequential, deterministic).
- **table_id** is constrained by `Rule::exists` to an active table of the acting user's own restaurant.

## Test plan

- [x] `php artisan test` — 912 passed (14 new in `QuickReservationStoreTest`)
- [x] `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check` clean
- [x] ziggy.d.ts regenerated + committed (new POST route)
- [x] Covers: phone + walk_in happy paths, smallest-table auto-assign, combination (both tables), manual override, busy-table rejection, no-fit rejection, second-booking rejection, foreign-table rejection, past-date / party-cap / source validation, no-restaurant forbidden, no reply + no mail

Closes #343