### PR TITLE
PRD-012 #345: dashboard quick-action button for phone reservations

### DIFF
--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -28,7 +28,7 @@ import {
     type ThreadMessage,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
-import { ChevronDown, Info } from 'lucide-vue-next';
+import { ChevronDown, Info, Phone } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 
 const POLL_MS = 30_000;
@@ -514,18 +514,31 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                     <p class="text-sm text-muted-foreground">Reservierungs-Dashboard</p>
                 </div>
 
-                <div class="flex flex-wrap items-center gap-3 text-sm" data-testid="dashboard-stats">
-                    <span
-                        class="rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-200"
+                <div class="flex flex-wrap items-center gap-3">
+                    <!-- The primary action for the owner-on-the-phone: log a phone/walk-in
+                         reservation. Kept a prominent button, not buried in a dropdown. -->
+                    <Link
+                        :href="route('reservations.quick.create')"
+                        class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+                        data-testid="quick-reservation-link"
                     >
-                        Neu: <strong>{{ props.stats.new }}</strong>
-                    </span>
-                    <span
-                        class="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-indigo-900 dark:border-indigo-900/40 dark:bg-indigo-950/40 dark:text-indigo-200"
-                    >
-                        In Bearbeitung: <strong>{{ props.stats.in_review }}</strong>
-                    </span>
-                    <DashboardExportDropdown :filters="props.filters" />
+                        <Phone class="size-4" />
+                        Telefon-Reservierung
+                    </Link>
+
+                    <div class="flex flex-wrap items-center gap-3 text-sm" data-testid="dashboard-stats">
+                        <span
+                            class="rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-200"
+                        >
+                            Neu: <strong>{{ props.stats.new }}</strong>
+                        </span>
+                        <span
+                            class="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-indigo-900 dark:border-indigo-900/40 dark:bg-indigo-950/40 dark:text-indigo-200"
+                        >
+                            In Bearbeitung: <strong>{{ props.stats.in_review }}</strong>
+                        </span>
+                        <DashboardExportDropdown :filters="props.filters" />
+                    </div>
                 </div>
             </header>
 


### PR DESCRIPTION
## Summary

PRD-012 #345: a prominent primary `<Link>` ("Telefon-Reservierung", phone icon) added to the dashboard header, linking to `reservations.quick.create` (the form from #344). Placed beside the stats/export group, kept a button rather than buried in a dropdown.

## Why

The quick phone/walk-in entry form is the most important action for the target user (owner on the phone), so it gets a first-class, always-visible entry point on the dashboard.

## Testing note

Verified via `npm run build` (vue-tsc), `npm run lint`, `npm run format:check` — all clean; the route name resolves through Ziggy types (covered by the ziggy-drift CI job). I deliberately did **not** add a dedicated `Dashboard.test.ts` mount test: the change is a single static `<Link>`, and Dashboard.vue pulls in five composables plus several child components, so a full mount harness for one link would be high-maintenance and brittle out of proportion to the change (the codebase has no Dashboard Vitest for the same reason). The link's correctness (route wiring, compilation) is covered by the build + ziggy-drift.

## Test plan

- [x] `npm run build` clean (Dashboard recompiles, no type errors)
- [x] `npm run lint`, `npm run format:check` clean
- [x] Link uses `route('reservations.quick.create')` (resolved via Ziggy types)

Closes #345