### PR TITLE
PRD-013 #347: ReservationStatus::Waitlisted + status machine transitions

### DIFF
--- a/app/Enums/ReservationStatus.php
+++ b/app/Enums/ReservationStatus.php
@@ -10,6 +10,7 @@ enum ReservationStatus: string
     case Confirmed = 'confirmed';
     case Declined = 'declined';
     case Cancelled = 'cancelled';
+    case Waitlisted = 'waitlisted';
 
     /**
      * @return list<self>
@@ -17,10 +18,11 @@ enum ReservationStatus: string
     public function allowedNextStates(): array
     {
         return match ($this) {
-            self::New => [self::InReview, self::Declined],
-            self::InReview => [self::Replied, self::Declined],
+            self::New => [self::InReview, self::Declined, self::Waitlisted],
+            self::InReview => [self::Replied, self::Declined, self::Waitlisted],
             self::Replied => [self::Confirmed, self::Cancelled],
             self::Confirmed => [self::Cancelled],
+            self::Waitlisted => [self::Confirmed, self::Declined],
             self::Declined, self::Cancelled => [],
         };
     }

--- a/tests/Feature/Models/RestaurantAvailableSeatsAtTest.php
+++ b/tests/Feature/Models/RestaurantAvailableSeatsAtTest.php
@@ -133,6 +133,7 @@ class RestaurantAvailableSeatsAtTest extends TestCase
             ReservationStatus::Replied,
             ReservationStatus::Declined,
             ReservationStatus::Cancelled,
+            ReservationStatus::Waitlisted,
         ] as $status) {
             ReservationRequest::factory()
                 ->forRestaurant($restaurant)

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -125,6 +125,19 @@ class SlotAvailabilityTest extends TestCase
         $this->assertSame(SlotState::Free, $result->state);
     }
 
+    public function test_does_not_count_waitlisted_reservations_as_occupying(): void
+    {
+        // PRD-013: waitlisted requests are parked, not seated — they must never
+        // occupy a table, otherwise the slot would look full to the very waitlist
+        // entry that is waiting for it to free up.
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00', ReservationStatus::Waitlisted);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Free, $result->state);
+    }
+
     public function test_ignores_inactive_tables(): void
     {
         Table::factory()->for($this->restaurant)->inactive()->create(['seats' => 8]);

--- a/tests/Unit/Enums/ReservationStatusTest.php
+++ b/tests/Unit/Enums/ReservationStatusTest.php
@@ -18,11 +18,15 @@ class ReservationStatusTest extends TestCase
         $allowed = [
             [ReservationStatus::New, ReservationStatus::InReview],
             [ReservationStatus::New, ReservationStatus::Declined],
+            [ReservationStatus::New, ReservationStatus::Waitlisted],
             [ReservationStatus::InReview, ReservationStatus::Replied],
             [ReservationStatus::InReview, ReservationStatus::Declined],
+            [ReservationStatus::InReview, ReservationStatus::Waitlisted],
             [ReservationStatus::Replied, ReservationStatus::Confirmed],
             [ReservationStatus::Replied, ReservationStatus::Cancelled],
             [ReservationStatus::Confirmed, ReservationStatus::Cancelled],
+            [ReservationStatus::Waitlisted, ReservationStatus::Confirmed],
+            [ReservationStatus::Waitlisted, ReservationStatus::Declined],
         ];
 
         $rows = [];
@@ -76,11 +80,24 @@ class ReservationStatusTest extends TestCase
         }
     }
 
-    public function test_allowed_next_states_for_new_are_in_review_and_declined(): void
+    public function test_allowed_next_states_for_new_are_in_review_declined_and_waitlisted(): void
     {
         $this->assertEqualsCanonicalizing(
-            [ReservationStatus::InReview, ReservationStatus::Declined],
+            [ReservationStatus::InReview, ReservationStatus::Declined, ReservationStatus::Waitlisted],
             ReservationStatus::New->allowedNextStates()
         );
+    }
+
+    public function test_waitlisted_can_only_move_to_confirmed_or_declined(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [ReservationStatus::Confirmed, ReservationStatus::Declined],
+            ReservationStatus::Waitlisted->allowedNextStates()
+        );
+
+        // A waitlisted request must not jump back to new/in_review/replied or be cancelled directly.
+        foreach ([ReservationStatus::New, ReservationStatus::InReview, ReservationStatus::Replied, ReservationStatus::Cancelled] as $target) {
+            $this->assertFalse(ReservationStatus::Waitlisted->canTransitionTo($target));
+        }
     }
 }


### PR DESCRIPTION
## Summary

First PRD-013 (passive waitlist) issue:

- Adds `ReservationStatus::Waitlisted = 'waitlisted'`
- Wires transitions into the enum's `allowedNextStates()` machine: `new → waitlisted`, `in_review → waitlisted`, `waitlisted → confirmed`, `waitlisted → declined`
- Additive only — status is a string column, so no migration

## Why

The waitlist needs a status to filter and transition on (PRD-013). Banner/filter/UI come in #348–#351.

## Notes

- Every other transition to/from `waitlisted` is forbidden — verified by the existing data-driven transition matrix (now 7×7) plus a focused `test_waitlisted_can_only_move_to_confirmed_or_declined`.
- The enum's `allowedNextStates()` match gains a `Waitlisted` arm, keeping it exhaustive (no `UnhandledMatchError`). It is the only exhaustive match over this enum.
- **Frontend deferred:** the TS `ReservationStatus` union, the dashboard filter chip, and the status badge for waitlisted belong to #349/#350 (dashboard prop + filter). No frontend touched here, so the build/ziggy jobs are unaffected. Until those land, no path sets a reservation to `waitlisted`, so the missing TS member has no runtime effect.

## Test plan

- [x] `php artisan test` — 927 passed
- [x] `./vendor/bin/pint --test` clean
- [x] Transition matrix + focused waitlist test cover allowed and forbidden pairs

Closes #347