### PR TITLE
PRD-013 #348: WaitlistBanner::eligibleNow service + unit tests

### DIFF
--- a/app/Services/Waitlist/WaitlistBanner.php
+++ b/app/Services/Waitlist/WaitlistBanner.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Waitlist;
+
+use App\Enums\ReservationStatus;
+use App\Enums\SlotState;
+use App\Models\ReservationRequest;
+use App\Services\Availability\SlotAvailability;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+/**
+ * Surfaces waitlisted reservations whose desired slot is currently available
+ * (PRD-013), so the dashboard can prompt the owner to pull a waiting guest in
+ * when a cancellation frees a table.
+ *
+ * Read-only and stateless: the availability verdict is delegated to
+ * {@see SlotAvailability}, and tenant scope comes from the explicit
+ * `$restaurantId` with the global RestaurantScope bypassed, so the service
+ * behaves identically from HTTP, a job, or the console.
+ */
+final class WaitlistBanner
+{
+    /** Performance cap: never evaluate more than this many waitlist entries. */
+    private const int MAX_RESULTS = 20;
+
+    public function __construct(
+        private readonly SlotAvailability $availability,
+    ) {}
+
+    /**
+     * Future-dated waitlisted reservations whose slot is not full, oldest wish
+     * first. The query is capped before the availability filter runs, so the
+     * result holds at most {@see self::MAX_RESULTS} entries.
+     *
+     * @return Collection<int, ReservationRequest>
+     */
+    public function eligibleNow(int $restaurantId): Collection
+    {
+        return ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->where('restaurant_id', $restaurantId)
+            ->where('status', ReservationStatus::Waitlisted)
+            ->where('desired_at', '>=', now())
+            ->orderBy('desired_at')
+            ->limit(self::MAX_RESULTS)
+            ->get()
+            ->filter(fn (ReservationRequest $request): bool => $this->slotHasRoom($request))
+            ->values();
+    }
+
+    private function slotHasRoom(ReservationRequest $request): bool
+    {
+        $result = $this->availability->forSlot(
+            $request->restaurant_id,
+            CarbonImmutable::parse($request->desired_at),
+            $request->party_size,
+        );
+
+        return $result->state !== SlotState::Full;
+    }
+}

--- a/app/Services/Waitlist/WaitlistBanner.php
+++ b/app/Services/Waitlist/WaitlistBanner.php
@@ -53,9 +53,15 @@ final class WaitlistBanner
 
     private function slotHasRoom(ReservationRequest $request): bool
     {
+        // The query already excludes null desired_at; the guard keeps the method
+        // safe and explicit if it is ever called from another path.
+        if ($request->desired_at === null) {
+            return false;
+        }
+
         $result = $this->availability->forSlot(
             $request->restaurant_id,
-            CarbonImmutable::parse($request->desired_at),
+            CarbonImmutable::instance($request->desired_at),
             $request->party_size,
         );
 

--- a/tests/Unit/Waitlist/WaitlistBannerTest.php
+++ b/tests/Unit/Waitlist/WaitlistBannerTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Waitlist;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\Waitlist\WaitlistBanner;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WaitlistBannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // UTC + a wide dinner window so the slot maths is not confounded by
+        // timezone conversion (covered separately by SlotAvailability).
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+    }
+
+    private function service(): WaitlistBanner
+    {
+        return app(WaitlistBanner::class);
+    }
+
+    private function waitlisted(string $desiredAtUtc, int $partySize = 2, ?Restaurant $restaurant = null): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($restaurant ?? $this->restaurant)->create([
+            'status' => ReservationStatus::Waitlisted,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => $partySize,
+        ]);
+    }
+
+    private function occupy(Table $table, string $desiredAtUtc): void
+    {
+        $reservation = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => 2,
+        ]);
+
+        ReservationTableAssignment::factory()
+            ->for($reservation, 'reservationRequest')
+            ->for($table)
+            ->create();
+    }
+
+    public function test_lists_only_waitlisted_requests_with_a_free_slot(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+        // A non-waitlisted request at the same slot must be ignored.
+        ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::New,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+
+        $result = $this->service()->eligibleNow($this->restaurant->id);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($waiting->id, $result->first()->id);
+    }
+
+    public function test_excludes_waitlisted_requests_whose_desired_at_is_in_the_past(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->waitlisted('2020-01-01 19:00');
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_excludes_waitlisted_requests_whose_slot_is_full(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00'); // the only table is now busy
+        $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_caps_results_at_twenty(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+        for ($i = 0; $i < 25; $i++) {
+            $this->waitlisted('2026-06-15 19:00', partySize: 1);
+        }
+
+        $this->assertCount(20, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_orders_by_desired_at_ascending(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+        $later = $this->waitlisted('2026-06-15 20:00');
+        $earlier = $this->waitlisted('2026-06-15 18:00');
+
+        $ids = $this->service()->eligibleNow($this->restaurant->id)->pluck('id')->all();
+
+        $this->assertSame([$earlier->id, $later->id], $ids);
+    }
+
+    public function test_scopes_to_the_given_restaurant(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $other = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'opening_hours' => $this->restaurant->opening_hours,
+        ]);
+        Table::factory()->for($other)->create(['seats' => 4]);
+        $this->waitlisted('2026-06-15 19:00', restaurant: $other);
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+}

--- a/tests/Unit/Waitlist/WaitlistBannerTest.php
+++ b/tests/Unit/Waitlist/WaitlistBannerTest.php
@@ -132,4 +132,47 @@ class WaitlistBannerTest extends TestCase
 
         $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
     }
+
+    public function test_includes_waitlisted_requests_whose_slot_is_only_tight(): void
+    {
+        // 4 tables x 4 seats = 16; occupy 3 (12 seats) → 25% free → Tight (not Full),
+        // and one 4-seat table still fits the party, so the entry must appear.
+        $tables = Table::factory()->for($this->restaurant)->count(4)->create(['seats' => 4]);
+        for ($i = 0; $i < 3; $i++) {
+            $this->occupy($tables[$i], '2026-06-15 19:00');
+        }
+        $waiting = $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        $result = $this->service()->eligibleNow($this->restaurant->id);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($waiting->id, $result->first()->id);
+    }
+
+    public function test_excludes_waitlisted_requests_without_a_desired_at(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Waitlisted,
+            'desired_at' => null,
+            'party_size' => 2,
+        ]);
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_keeps_only_entries_whose_slot_is_free_across_different_slots(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        // 18:00 is taken by a confirmed booking; 22:00 is far enough away (buffer +
+        // duration) that the single table is free there again.
+        $this->occupy($table, '2026-06-15 18:00');
+        $this->waitlisted('2026-06-15 18:00', partySize: 4); // full → excluded
+        $free = $this->waitlisted('2026-06-15 22:00', partySize: 4); // free → included
+
+        $result = $this->service()->eligibleNow($this->restaurant->id);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($free->id, $result->first()->id);
+    }
 }


### PR DESCRIPTION
## Summary

PRD-013 #348, building on the waitlist status from #347:

- `app/Services/Waitlist/WaitlistBanner.php` — `eligibleNow(int $restaurantId): Collection`
- Returns waitlisted reservations that are future-dated (`desired_at >= now()`) and whose slot is **not full** (verdict from `SlotAvailability::forSlot`), ordered by `desired_at` ASC, capped at 20
- Stateless, constructor-injected `SlotAvailability`; query uses `withoutGlobalScopes()->where('restaurant_id', $id)` — the service-layer determinism/tenant pattern already used by `SlotAvailability` (works the same from HTTP, jobs, console)

## Why

The dashboard banner (#349/#350) needs the list of waiting guests who could be pulled in right now. This is the read model behind it.

## Test plan

- [x] `php artisan test` — 934 passed (6 new in `WaitlistBannerTest`)
- [x] `./vendor/bin/pint --test` clean
- [x] Covers: lists only waitlisted with a free slot (ignores non-waitlisted), excludes past `desired_at`, excludes full slots, caps at 20, orders by `desired_at` ASC, scopes to the given restaurant

Closes #348