### PR TITLE
PRD-013 #349: dashboard waitlistBanner prop + waitlisted filter (backend)

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,6 +11,7 @@ use App\Http\Resources\ReservationMessageResource;
 use App\Http\Resources\ReservationRequestDetailResource;
 use App\Http\Resources\ReservationRequestResource;
 use App\Models\ReservationRequest;
+use App\Services\Waitlist\WaitlistBanner;
 use App\Support\OpenAiKeyHealth;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -20,10 +21,11 @@ use Inertia\Response;
 
 final class DashboardController extends Controller
 {
-    public function index(DashboardFilterRequest $request): Response
+    public function index(DashboardFilterRequest $request, WaitlistBanner $waitlistBanner): Response
     {
         $validated = $request->validated();
         $selectedId = isset($validated['selected']) ? (int) $validated['selected'] : null;
+        $restaurantId = $request->user()?->restaurant_id;
 
         $filterQuery = Arr::except($request->query(), ['selected']);
         $filters = $filterQuery === []
@@ -48,6 +50,14 @@ final class DashboardController extends Controller
                     ->where('status', ReservationStatus::InReview)
                     ->count(),
             ],
+            // PRD-013: waitlisted reservations whose slot is free again, so the
+            // dashboard can prompt the owner to pull a waiting guest in. Loaded
+            // with the page and refreshed by the existing poll (the frontend adds
+            // it to the reload's `only` set). A plain array (resolve) so the page
+            // can use it directly. Empty when the user has no restaurant.
+            'waitlistBanner' => $restaurantId === null
+                ? []
+                : ReservationRequestResource::collection($waitlistBanner->eligibleNow($restaurantId))->resolve($request),
             'selectedRequest' => fn () => $this->resolveSelected($selectedId, $request),
             'threadMessages' => fn () => $this->resolveThreadMessages($selectedId, $request),
             // Owner-only banner. The flag is global (V1.0 has one OpenAI key

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -451,7 +451,9 @@ watch(
 );
 
 function pollOnly(): string[] {
-    const keys = ['requests', 'stats'];
+    // waitlistBanner is refreshed by the poll so a cancellation that frees a slot
+    // surfaces a waiting guest within one tick (PRD-013), without a full reload.
+    const keys = ['requests', 'stats', 'waitlistBanner'];
     if (props.selectedRequest != null) {
         keys.push('selectedRequest');
     }

--- a/tests/Feature/Waitlist/WaitlistFlowTest.php
+++ b/tests/Feature/Waitlist/WaitlistFlowTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Waitlist;
+
+use App\Enums\ReservationStatus;
+use App\Enums\UserRole;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class WaitlistFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    private User $owner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+        $this->owner = User::factory()->forRestaurant($this->restaurant)->create(['role' => UserRole::Owner]);
+    }
+
+    private function waitlisted(string $desiredAtUtc, int $partySize = 2, ?Restaurant $restaurant = null): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($restaurant ?? $this->restaurant)->create([
+            'status' => ReservationStatus::Waitlisted,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => $partySize,
+        ]);
+    }
+
+    public function test_banner_lists_eligible_waitlisted_reservations(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->has('waitlistBanner', 1)
+                ->where('waitlistBanner.0.id', $waiting->id)
+            );
+    }
+
+    public function test_banner_excludes_a_waitlisted_request_whose_slot_is_full(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $busy = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+        ReservationTableAssignment::factory()->for($busy, 'reservationRequest')->for($table)->create();
+
+        $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+
+    public function test_banner_disappears_after_the_waitlisted_request_is_confirmed(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 1));
+
+        $waiting->update(['status' => ReservationStatus::Confirmed]);
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+
+    public function test_dashboard_filter_shows_only_waitlisted_requests(): void
+    {
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+        ReservationRequest::factory()->for($this->restaurant)->create(['status' => ReservationStatus::New]);
+        ReservationRequest::factory()->for($this->restaurant)->create(['status' => ReservationStatus::Confirmed]);
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard', ['status' => [ReservationStatus::Waitlisted->value]]))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->has('requests.data', 1)
+                ->where('requests.data.0.id', $waiting->id)
+                ->where('requests.data.0.status', 'waitlisted')
+            );
+    }
+
+    public function test_user_from_another_restaurant_does_not_see_the_banner(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->waitlisted('2026-06-15 19:00'); // belongs to $this->restaurant
+
+        $other = Restaurant::factory()->create(['timezone' => 'UTC', 'opening_hours' => $this->restaurant->opening_hours]);
+        $otherOwner = User::factory()->forRestaurant($other)->create(['role' => UserRole::Owner]);
+
+        $this->actingAs($otherOwner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+}

--- a/tests/Feature/Waitlist/WaitlistFlowTest.php
+++ b/tests/Feature/Waitlist/WaitlistFlowTest.php
@@ -66,6 +66,8 @@ class WaitlistFlowTest extends TestCase
     public function test_banner_excludes_a_waitlisted_request_whose_slot_is_full(): void
     {
         $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        // Confirmed + a table assignment is what makes busyTableIds see the only
+        // table as taken, so the slot is genuinely Full for the waiting party.
         $busy = ReservationRequest::factory()->for($this->restaurant)->create([
             'status' => ReservationStatus::Confirmed,
             'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
@@ -77,6 +79,44 @@ class WaitlistFlowTest extends TestCase
 
         $this->actingAs($this->owner)
             ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+
+    public function test_banner_appears_after_a_cancellation_frees_the_slot(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $confirmed = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 4,
+        ]);
+        ReservationTableAssignment::factory()->for($confirmed, 'reservationRequest')->for($table)->create();
+        $waiting = $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        // Slot is full → the waiting guest is hidden.
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+
+        // Cancelling frees the table (Cancelled is non-occupying).
+        $confirmed->update(['status' => ReservationStatus::Cancelled]);
+
+        // Next load: the slot is free again, so the waiting guest surfaces.
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->has('waitlistBanner', 1)
+                ->where('waitlistBanner.0.id', $waiting->id)
+            );
+    }
+
+    public function test_user_without_a_restaurant_sees_an_empty_banner(): void
+    {
+        $user = User::factory()->create(); // restaurant_id is null
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertOk()
             ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
     }
 
@@ -106,6 +146,7 @@ class WaitlistFlowTest extends TestCase
             ->get(route('dashboard', ['status' => [ReservationStatus::Waitlisted->value]]))
             ->assertOk()
             ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('filters.status.0', 'waitlisted') // the value was accepted, not stripped
                 ->has('requests.data', 1)
                 ->where('requests.data.0.id', $waiting->id)
                 ->where('requests.data.0.status', 'waitlisted')


### PR DESCRIPTION
## Summary

PRD-013 #349 (backend), on top of the service from #348:

- `DashboardController` exposes a **`waitlistBanner`** prop = `WaitlistBanner::eligibleNow($restaurantId)`, serialized via `ReservationRequestResource::collection(...)->resolve()` as a plain array (so the page uses `banner.length` directly, like `threadMessages`). Empty when the user has no restaurant.
- The **waitlisted status filter** required no code change: `status.*` already validates with `Rule::enum(ReservationStatus)` and the model's `scopeFilter` does a `whereIn`, so the value added in #347 flows through. Covered by a test so it can't silently regress.

## Why

The dashboard banner (#350) needs the list of waiting guests who could be seated now, and the status filter needs to surface waitlisted entries. This is the server side of both.

## Notes

- The prop is loaded on every dashboard render; the existing 30s poll refreshes it once #350 adds `waitlistBanner` to the reload's `only` set. Method-injected `WaitlistBanner` (stateless service).
- Tenant scope: `eligibleNow` filters by the explicit `restaurant_id`; a cross-tenant test confirms no leakage.

## Test plan

- [x] `php artisan test` — 942 passed (5 new in `WaitlistFlowTest`)
- [x] `./vendor/bin/pint --test` clean
- [x] Covers: banner lists eligible waitlisted, excludes full-slot, disappears after confirm, filter shows only waitlisted, cross-tenant hidden
- [x] No routes/frontend touched → ziggy-drift + JS jobs unaffected

Closes #349