### PR TITLE
PRD-013 #350: waitlist banner + filter chip + drawer transitions

### DIFF
--- a/resources/js/components/WaitlistBanner.vue
+++ b/resources/js/components/WaitlistBanner.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
     /** Waitlisted reservations whose slot is currently free (PRD-013). */
     banner: ReservationRequestRow[];
     /** Restaurant timezone, so wished times read in local time. */
-    timezone?: string;
+    timezone?: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -34,6 +34,8 @@ function when(iso: string | null): string {
     <div
         v-if="banner.length > 0"
         class="rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-900/40 dark:bg-amber-950/40"
+        role="status"
+        aria-live="polite"
         data-testid="waitlist-banner"
     >
         <p class="text-sm font-medium text-amber-900 dark:text-amber-200">{{ headline }}</p>
@@ -42,7 +44,7 @@ function when(iso: string | null): string {
                 <button
                     type="button"
                     class="text-amber-900 underline underline-offset-2 hover:no-underline dark:text-amber-200"
-                    data-testid="waitlist-entry"
+                    :data-testid="`waitlist-entry-${entry.id}`"
                     @click="emit('open', entry.id)"
                 >
                     {{ entry.guest_name }} – {{ when(entry.desired_at) }} ({{ entry.party_size }} P.)

--- a/resources/js/components/WaitlistBanner.vue
+++ b/resources/js/components/WaitlistBanner.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { formatDateTime } from '@/lib/format-datetime';
+import { type ReservationRequestRow } from '@/types';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    /** Waitlisted reservations whose slot is currently free (PRD-013). */
+    banner: ReservationRequestRow[];
+    /** Restaurant timezone, so wished times read in local time. */
+    timezone?: string;
+}>();
+
+const emit = defineEmits<{
+    (e: 'open', id: number): void;
+}>();
+
+const MAX_VISIBLE = 5;
+
+const visible = computed(() => props.banner.slice(0, MAX_VISIBLE));
+const overflow = computed(() => Math.max(0, props.banner.length - MAX_VISIBLE));
+
+const headline = computed(() =>
+    props.banner.length === 1
+        ? '1 Wartender könnte jetzt einen Slot bekommen.'
+        : `${props.banner.length} Wartende könnten jetzt einen Slot bekommen.`,
+);
+
+function when(iso: string | null): string {
+    return formatDateTime(iso, { timeZone: props.timezone });
+}
+</script>
+
+<template>
+    <div
+        v-if="banner.length > 0"
+        class="rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-900/40 dark:bg-amber-950/40"
+        data-testid="waitlist-banner"
+    >
+        <p class="text-sm font-medium text-amber-900 dark:text-amber-200">{{ headline }}</p>
+        <ul class="mt-2 space-y-1 text-sm">
+            <li v-for="entry in visible" :key="entry.id">
+                <button
+                    type="button"
+                    class="text-amber-900 underline underline-offset-2 hover:no-underline dark:text-amber-200"
+                    data-testid="waitlist-entry"
+                    @click="emit('open', entry.id)"
+                >
+                    {{ entry.guest_name }} – {{ when(entry.desired_at) }} ({{ entry.party_size }} P.)
+                </button>
+            </li>
+        </ul>
+        <p v-if="overflow > 0" class="mt-1 text-xs text-amber-800 dark:text-amber-300" data-testid="waitlist-overflow">
+            … und {{ overflow }} weitere
+        </p>
+    </div>
+</template>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import DashboardExportDropdown from '@/components/DashboardExportDropdown.vue';
 import ReservationThreadHistory from '@/components/ReservationThreadHistory.vue';
+import WaitlistBanner from '@/components/WaitlistBanner.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -22,6 +23,7 @@ import {
     type NotificationSettings,
     type PaginatedReservationRequests,
     type ReservationRequestDetail,
+    type ReservationRequestRow,
     type ReservationSource,
     type ReservationStatus,
     type SharedData,
@@ -39,6 +41,7 @@ interface DashboardProps {
     stats: DashboardStats;
     selectedRequest?: ReservationRequestDetail | null;
     threadMessages?: ThreadMessage[] | null;
+    waitlistBanner: ReservationRequestRow[];
     openaiKeyRejectedAt?: string | null;
     sendMode?: 'manual' | 'shadow' | 'auto' | null;
 }
@@ -80,6 +83,7 @@ const STATUS_OPTIONS: { value: ReservationStatus; label: string }[] = [
     { value: 'confirmed', label: 'Bestätigt' },
     { value: 'declined', label: 'Abgelehnt' },
     { value: 'cancelled', label: 'Storniert' },
+    { value: 'waitlisted', label: 'Warteliste' },
 ];
 
 const SOURCE_OPTIONS: { value: ReservationSource; label: string }[] = [
@@ -94,6 +98,7 @@ const STATUS_BADGE_CLASS: Record<ReservationStatus, string> = {
     confirmed: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200',
     declined: 'bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-200',
     cancelled: 'bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300',
+    waitlisted: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200',
 };
 
 const STATUS_LABEL: Record<ReservationStatus, string> = Object.fromEntries(STATUS_OPTIONS.map((s) => [s.value, s.label])) as Record<
@@ -224,6 +229,25 @@ const drawerOpen = computed({
         });
     },
 });
+
+function openReservation(id: number): void {
+    router.visit(detailHref(id), {
+        only: ['selectedRequest'],
+        preserveScroll: true,
+        preserveState: true,
+    });
+}
+
+// PRD-013 waitlist transitions from the drawer. bulk-status validates the
+// transition server-side (canTransitionTo) and the redirect refreshes the
+// dashboard, so the drawer reflects the new status.
+function setReservationStatus(status: ReservationStatus): void {
+    const id = props.selectedRequest?.id;
+    if (id == null) {
+        return;
+    }
+    router.post(route('reservations.bulk-status'), { ids: [id], status }, { preserveScroll: true, preserveState: true });
+}
 
 const rawEmailOpen = ref(false);
 
@@ -544,6 +568,8 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                 </div>
             </header>
 
+            <WaitlistBanner :banner="props.waitlistBanner" :timezone="restaurantTimezone" @open="openReservation" />
+
             <section
                 class="flex flex-col gap-4 rounded-lg border border-border p-4"
                 data-testid="dashboard-filter-bar"
@@ -777,6 +803,30 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                         {{ STATUS_LABEL[props.selectedRequest.status] }}
                     </SheetDescription>
                 </SheetHeader>
+
+                <!-- PRD-013 waitlist transitions: park a new/in-review request, or
+                     resolve a waitlisted one. bulk-status enforces the allowed moves. -->
+                <div
+                    v-if="['new', 'in_review', 'waitlisted'].includes(props.selectedRequest.status)"
+                    class="flex flex-wrap gap-2"
+                    data-testid="waitlist-actions"
+                >
+                    <Button
+                        v-if="props.selectedRequest.status === 'new' || props.selectedRequest.status === 'in_review'"
+                        type="button"
+                        variant="outline"
+                        data-testid="action-waitlist"
+                        @click="setReservationStatus('waitlisted')"
+                    >
+                        Auf Warteliste
+                    </Button>
+                    <template v-if="props.selectedRequest.status === 'waitlisted'">
+                        <Button type="button" data-testid="action-confirm" @click="setReservationStatus('confirmed')">Bestätigen</Button>
+                        <Button type="button" variant="outline" data-testid="action-decline" @click="setReservationStatus('declined')">
+                            Ablehnen
+                        </Button>
+                    </template>
+                </div>
 
                 <div class="-mx-1 inline-flex gap-1 border-b border-border" role="tablist" data-testid="drawer-tabs">
                     <button

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -54,7 +54,7 @@ export interface User {
 
 export type BreadcrumbItemType = BreadcrumbItem;
 
-export type ReservationStatus = 'new' | 'in_review' | 'replied' | 'confirmed' | 'declined' | 'cancelled';
+export type ReservationStatus = 'new' | 'in_review' | 'replied' | 'confirmed' | 'declined' | 'cancelled' | 'waitlisted';
 export type ReservationSource = 'web_form' | 'email';
 
 export interface ReservationRequestRow {


### PR DESCRIPTION
## Summary

PRD-013 #350 (frontend), consuming the prop/service from #348/#349:

- **`WaitlistBanner.vue`** — lists waiting guests whose slot is free (max 5, then "… und N weitere"); each entry is a button that opens its detail drawer. Renders nothing when empty.
- **Dashboard**: renders the banner under the header (timezone-aware times); adds a **"Warteliste" status filter chip** and a **waitlisted badge** colour; the **detail drawer** gains a transition action bar — "Auf Warteliste" for new/in_review, "Bestätigen"/"Ablehnen" for waitlisted — posting to `reservations.bulk-status`.
- Adds `'waitlisted'` to the TS `ReservationStatus` union (deferred from #347), so `STATUS_OPTIONS`/`STATUS_BADGE_CLASS`/`STATUS_LABEL` cover it.

## Why

This is the operator-facing surface of the passive waitlist: see who can be pulled in, filter the list, and move requests on/off the waitlist — all without leaving the dashboard.

## Notes

- Transitions reuse the existing `bulk-status` endpoint, which validates each move via `canTransitionTo` and the update policy; the redirect refreshes the dashboard so the drawer reflects the new status. No new backend.
- Banner opens a reservation via the existing `detailHref(id)` + `only: ['selectedRequest']` selection mechanism.
- Vitest for `WaitlistBanner.vue` is the final PRD-013 issue, **#351**.

## Test plan

- [x] `npm run build` (vue-tsc) clean — Dashboard + WaitlistBanner compile, no type errors
- [x] `npm run lint`, `npm run format:check` clean
- [x] No PHP/route changes → backend suite + ziggy-drift unaffected

Closes #350