### PR TITLE
PRD-014 #352: sync-confirm schema (web_sync_confirm_enabled + reservation_replies.sync_confirm)

### DIFF
--- a/app/Models/ReservationReply.php
+++ b/app/Models/ReservationReply.php
@@ -38,6 +38,7 @@ class ReservationReply extends Model
         'shadow_was_modified',
         'auto_send_decision',
         'auto_send_scheduled_for',
+        'sync_confirm',
     ];
 
     /**
@@ -58,6 +59,7 @@ class ReservationReply extends Model
             'shadow_was_modified' => 'boolean',
             'auto_send_decision' => 'array',
             'auto_send_scheduled_for' => 'datetime',
+            'sync_confirm' => 'boolean',
         ];
     }
 

--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -44,6 +44,7 @@ class Restaurant extends Model
         'send_mode_changed_at',
         'send_mode_changed_by',
         'slot_buffer_minutes',
+        'web_sync_confirm_enabled',
     ];
 
     /**
@@ -72,6 +73,7 @@ class Restaurant extends Model
             'auto_send_min_lead_time_minutes' => 'integer',
             'send_mode_changed_at' => 'datetime',
             'slot_buffer_minutes' => 'integer',
+            'web_sync_confirm_enabled' => 'boolean',
         ];
     }
 

--- a/database/migrations/2026_05_23_000001_add_web_sync_confirm_enabled_to_restaurants_table.php
+++ b/database/migrations/2026_05_23_000001_add_web_sync_confirm_enabled_to_restaurants_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->boolean('web_sync_confirm_enabled')
+                ->default(false)
+                ->after('auto_send_min_lead_time_minutes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->dropColumn('web_sync_confirm_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_05_23_000002_add_sync_confirm_to_reservation_replies_table.php
+++ b/database/migrations/2026_05_23_000002_add_sync_confirm_to_reservation_replies_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->boolean('sync_confirm')->default(false)->after('is_fallback');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->dropColumn('sync_confirm');
+        });
+    }
+};

--- a/tests/Feature/Models/ReservationReplyTest.php
+++ b/tests/Feature/Models/ReservationReplyTest.php
@@ -193,9 +193,9 @@ class ReservationReplyTest extends TestCase
 
     public function test_sync_confirm_defaults_to_false_and_is_a_fillable_boolean(): void
     {
-        $default = ReservationReply::factory()->create();
-        $this->assertFalse($default->fresh()->sync_confirm);
-        $this->assertIsBool($default->fresh()->sync_confirm);
+        $default = ReservationReply::factory()->create()->fresh();
+        $this->assertFalse($default->sync_confirm);
+        $this->assertIsBool($default->sync_confirm);
 
         $synced = ReservationReply::factory()->create(['sync_confirm' => true]);
         $this->assertTrue($synced->fresh()->sync_confirm);

--- a/tests/Feature/Models/ReservationReplyTest.php
+++ b/tests/Feature/Models/ReservationReplyTest.php
@@ -190,4 +190,14 @@ class ReservationReplyTest extends TestCase
         $this->assertNotNull($fresh->approved_at, 'approved_at audit timestamp must remain');
         $this->assertNotNull($fresh->sent_at, 'sent_at audit timestamp must remain');
     }
+
+    public function test_sync_confirm_defaults_to_false_and_is_a_fillable_boolean(): void
+    {
+        $default = ReservationReply::factory()->create();
+        $this->assertFalse($default->fresh()->sync_confirm);
+        $this->assertIsBool($default->fresh()->sync_confirm);
+
+        $synced = ReservationReply::factory()->create(['sync_confirm' => true]);
+        $this->assertTrue($synced->fresh()->sync_confirm);
+    }
 }

--- a/tests/Feature/Models/RestaurantTest.php
+++ b/tests/Feature/Models/RestaurantTest.php
@@ -107,9 +107,9 @@ class RestaurantTest extends TestCase
 
     public function test_web_sync_confirm_enabled_defaults_to_false_and_is_a_fillable_boolean(): void
     {
-        $default = Restaurant::factory()->create();
-        $this->assertFalse($default->fresh()->web_sync_confirm_enabled);
-        $this->assertIsBool($default->fresh()->web_sync_confirm_enabled);
+        $default = Restaurant::factory()->create()->fresh();
+        $this->assertFalse($default->web_sync_confirm_enabled);
+        $this->assertIsBool($default->web_sync_confirm_enabled);
 
         $enabled = Restaurant::factory()->create(['web_sync_confirm_enabled' => true]);
         $this->assertTrue($enabled->fresh()->web_sync_confirm_enabled);

--- a/tests/Feature/Models/RestaurantTest.php
+++ b/tests/Feature/Models/RestaurantTest.php
@@ -104,4 +104,14 @@ class RestaurantTest extends TestCase
         $this->assertNull($restaurant->fresh()->imap_password);
         $this->assertNull(DB::table('restaurants')->where('id', $restaurant->id)->value('imap_password'));
     }
+
+    public function test_web_sync_confirm_enabled_defaults_to_false_and_is_a_fillable_boolean(): void
+    {
+        $default = Restaurant::factory()->create();
+        $this->assertFalse($default->fresh()->web_sync_confirm_enabled);
+        $this->assertIsBool($default->fresh()->web_sync_confirm_enabled);
+
+        $enabled = Restaurant::factory()->create(['web_sync_confirm_enabled' => true]);
+        $this->assertTrue($enabled->fresh()->web_sync_confirm_enabled);
+    }
 }


### PR DESCRIPTION
## Summary

First PRD-014 (sync web-confirm) issue — schema only:

- `restaurants.web_sync_confirm_enabled` — boolean, default `false` (per-restaurant opt-in)
- `reservation_replies.sync_confirm` — boolean, default `false` (marks a reply sent via the sync path, so PRD-008 analytics can measure the sync rate without a new audit path)
- Both added to their model `$fillable` + boolean `casts()`

## Why

PRD-014 confirms eligible web reservations synchronously in the submit path. This lays the data layer; the decider/controller/UI follow in #353–#358. PRD-014 is unblocked — PRD-007 (the auto-send columns it reuses) is already implemented.

## Test plan

- [x] `migrate` → `migrate:rollback --step=2` → `migrate` clean on a throwaway SQLite
- [x] `php artisan test` — 946 passed (2 new: default/cast/fillable for each column)
- [x] `./vendor/bin/pint --test` clean
- [x] No routes/frontend → ziggy-drift + JS jobs unaffected

Closes #352