### PR TITLE
PRD-014 #353: WebSyncConfirmDecider + decision DTO + killswitch

### DIFF
--- a/app/Services/AutoSend/WebSyncConfirmDecider.php
+++ b/app/Services/AutoSend/WebSyncConfirmDecider.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AutoSend;
+
+use App\Enums\SlotState;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Availability\SlotAvailability;
+use Carbon\CarbonImmutable;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Decides whether a web reservation may be confirmed synchronously in the
+ * submit path (PRD-014), or must fall back to the normal owner-approval flow.
+ *
+ * The gate cascade is hard-coded and order-significant — the first tripped gate
+ * wins. Unlike the PRD-007 auto-send path, `first_time_guest` and
+ * `needs_manual_review` are deliberately NOT gates here: web-form input is
+ * structured (no parse risk) and a first-time filter would punish the very
+ * online first-timers the channel exists to win (see PRD-014 risks). The
+ * PRD-007 restaurant limits (`auto_send_party_size_max`,
+ * `auto_send_min_lead_time_minutes`) are reused.
+ *
+ * `final`, stateless: availability is delegated to {@see SlotAvailability}.
+ */
+final class WebSyncConfirmDecider
+{
+    public const string REASON_GLOBAL_KILL = 'global_kill';
+
+    public const string REASON_DISABLED = 'web_sync_confirm_disabled';
+
+    public const string REASON_SLOT_NOT_FREE = 'slot_not_deterministic_free';
+
+    public const string REASON_PARTY_SIZE_OVER_LIMIT = 'party_size_over_limit';
+
+    public const string REASON_SHORT_NOTICE = 'short_notice';
+
+    public function __construct(
+        private readonly SlotAvailability $availability,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function decide(ReservationRequest $request): WebSyncConfirmDecision
+    {
+        // 1. Global incident killswitch — stops every sync-confirm at once.
+        if ((bool) config('reservations.web_sync_confirm.kill', false)) {
+            return WebSyncConfirmDecision::skip(self::REASON_GLOBAL_KILL);
+        }
+
+        // 2. Per-restaurant opt-in.
+        $restaurant = $request->restaurant;
+        if ($restaurant === null) {
+            $this->logger->warning('web sync confirm: reservation has no restaurant, skipping', [
+                'reservation_request_id' => $request->id,
+            ]);
+
+            return WebSyncConfirmDecision::skip(self::REASON_DISABLED);
+        }
+
+        if (! $restaurant->web_sync_confirm_enabled) {
+            return WebSyncConfirmDecision::skip(self::REASON_DISABLED);
+        }
+
+        // 3. Slot must be deterministically free (a missing time can never be).
+        if ($request->desired_at === null) {
+            return WebSyncConfirmDecision::skip(self::REASON_SLOT_NOT_FREE);
+        }
+
+        $slot = $this->availability->forSlot(
+            $request->restaurant_id,
+            CarbonImmutable::instance($request->desired_at),
+            $request->party_size,
+        );
+
+        if ($slot->state !== SlotState::Free) {
+            return WebSyncConfirmDecision::skip(self::REASON_SLOT_NOT_FREE);
+        }
+
+        // 4. Reused PRD-007 hard limits.
+        if ($request->party_size > $restaurant->auto_send_party_size_max) {
+            return WebSyncConfirmDecision::skip(self::REASON_PARTY_SIZE_OVER_LIMIT);
+        }
+
+        if ($this->isShortNotice($request, $restaurant)) {
+            return WebSyncConfirmDecision::skip(self::REASON_SHORT_NOTICE);
+        }
+
+        return WebSyncConfirmDecision::proceed($slot);
+    }
+
+    private function isShortNotice(ReservationRequest $request, Restaurant $restaurant): bool
+    {
+        $minutesUntilDesired = now()->diffInMinutes($request->desired_at, false);
+
+        return $minutesUntilDesired < $restaurant->auto_send_min_lead_time_minutes;
+    }
+}

--- a/app/Services/AutoSend/WebSyncConfirmDecider.php
+++ b/app/Services/AutoSend/WebSyncConfirmDecider.php
@@ -74,6 +74,8 @@ final class WebSyncConfirmDecider
             $request->party_size,
         );
 
+        // Only a Free slot proceeds — Tight (≤25% capacity left) is bookable from
+        // the dashboard but too close to full for an unattended confirmation.
         if ($slot->state !== SlotState::Free) {
             return WebSyncConfirmDecision::skip(self::REASON_SLOT_NOT_FREE);
         }
@@ -92,6 +94,12 @@ final class WebSyncConfirmDecider
 
     private function isShortNotice(ReservationRequest $request, Restaurant $restaurant): bool
     {
+        // Defensive: the cascade already returns on a null desired_at, but guard
+        // here too (matching AutoSendDecider) so the method is safe in isolation.
+        if ($request->desired_at === null) {
+            return false;
+        }
+
         $minutesUntilDesired = now()->diffInMinutes($request->desired_at, false);
 
         return $minutesUntilDesired < $restaurant->auto_send_min_lead_time_minutes;

--- a/app/Services/AutoSend/WebSyncConfirmDecision.php
+++ b/app/Services/AutoSend/WebSyncConfirmDecision.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AutoSend;
+
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use InvalidArgumentException;
+
+/**
+ * Outcome of {@see WebSyncConfirmDecider} for a web reservation (PRD-014).
+ *
+ * `proceed` carries the deterministic slot verdict the controller needs to
+ * assign a table; `skip` carries the gate reason that sent the request back to
+ * the normal owner-approval path. Exactly one of the two is populated.
+ */
+final readonly class WebSyncConfirmDecision
+{
+    public const string STATE_PROCEED = 'proceed';
+
+    public const string STATE_SKIP = 'skip';
+
+    private function __construct(
+        public string $state,
+        public ?string $reason,
+        public ?SlotAvailabilityResult $slot,
+    ) {}
+
+    public static function proceed(SlotAvailabilityResult $slot): self
+    {
+        return new self(self::STATE_PROCEED, null, $slot);
+    }
+
+    public static function skip(string $reason): self
+    {
+        if (trim($reason) === '') {
+            throw new InvalidArgumentException('A skip decision must carry a non-empty reason.');
+        }
+
+        return new self(self::STATE_SKIP, $reason, null);
+    }
+
+    public function shouldProceed(): bool
+    {
+        return $this->state === self::STATE_PROCEED;
+    }
+}

--- a/config/reservations.php
+++ b/config/reservations.php
@@ -63,4 +63,19 @@ return [
             'Beginne mit Anrede („Guten Tag [Name],"), ende mit Grußformel und Restaurant-Name.',
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Synchronous web confirmation (PRD-014)
+    |--------------------------------------------------------------------------
+    |
+    | Global incident killswitch for the sync-confirm path. Setting
+    | WEB_SYNC_CONFIRM_GLOBAL_KILL=true stops every synchronous confirmation
+    | immediately, regardless of per-restaurant opt-in — e.g. during an OpenAI
+    | outage that would otherwise make each web submit wait out the 5s timeout.
+    |
+    */
+    'web_sync_confirm' => [
+        'kill' => (bool) env('WEB_SYNC_CONFIRM_GLOBAL_KILL', false),
+    ],
 ];

--- a/tests/Unit/AutoSend/WebSyncConfirmDeciderTest.php
+++ b/tests/Unit/AutoSend/WebSyncConfirmDeciderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AutoSend;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\AutoSend\WebSyncConfirmDecider;
+use App\Services\AutoSend\WebSyncConfirmDecision;
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class WebSyncConfirmDeciderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Freeze "now" inside the dinner window so lead-time and opening-hours
+        // checks are deterministic. 2026-05-23 is a Saturday.
+        Carbon::setTestNow('2026-05-23 18:00:00');
+
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+            'web_sync_confirm_enabled' => true,
+            'auto_send_party_size_max' => 10,
+            'auto_send_min_lead_time_minutes' => 90,
+        ]);
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function decider(): WebSyncConfirmDecider
+    {
+        return app(WebSyncConfirmDecider::class);
+    }
+
+    private function reservation(string $desiredAtUtc, int $partySize = 2): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($this->restaurant)->create([
+            'source' => ReservationSource::WebForm,
+            'status' => ReservationStatus::New,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => $partySize,
+        ]);
+    }
+
+    public function test_it_skips_when_global_kill_is_active(): void
+    {
+        config()->set('reservations.web_sync_confirm.kill', true);
+        $request = $this->reservation('2026-06-15 19:00');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecision::STATE_SKIP, $decision->state);
+        $this->assertSame(WebSyncConfirmDecider::REASON_GLOBAL_KILL, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_restaurant_toggle_is_off(): void
+    {
+        $this->restaurant->update(['web_sync_confirm_enabled' => false]);
+        $request = $this->reservation('2026-06-15 19:00');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_DISABLED, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_slot_is_not_deterministic_free(): void
+    {
+        // Occupy the (single) table at the slot so it is full, not free.
+        $busy = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+        ReservationTableAssignment::factory()
+            ->for($busy, 'reservationRequest')
+            ->for(Table::query()->firstOrFail())
+            ->create();
+
+        $request = $this->reservation('2026-06-15 19:00');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SLOT_NOT_FREE, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_party_size_is_over_the_limit(): void
+    {
+        // A 12-seat table keeps the slot genuinely free for 11 (so the slot gate
+        // passes), but 11 still exceeds the auto-send cap of 10.
+        Table::factory()->for($this->restaurant)->create(['seats' => 12]);
+        $request = $this->reservation('2026-06-15 19:00', partySize: 11);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_PARTY_SIZE_OVER_LIMIT, $decision->reason);
+    }
+
+    public function test_it_skips_on_short_notice(): void
+    {
+        // 30 minutes out, inside the dinner window, but under the 90-min lead.
+        $request = $this->reservation('2026-05-23 18:30');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SHORT_NOTICE, $decision->reason);
+    }
+
+    public function test_it_proceeds_when_all_gates_pass(): void
+    {
+        $request = $this->reservation('2026-06-15 19:00', partySize: 2);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertTrue($decision->shouldProceed());
+        $this->assertNull($decision->reason);
+        $this->assertInstanceOf(SlotAvailabilityResult::class, $decision->slot);
+    }
+}

--- a/tests/Unit/AutoSend/WebSyncConfirmDeciderTest.php
+++ b/tests/Unit/AutoSend/WebSyncConfirmDeciderTest.php
@@ -6,6 +6,7 @@ namespace Tests\Unit\AutoSend;
 
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
+use App\Enums\SlotState;
 use App\Models\ReservationRequest;
 use App\Models\ReservationTableAssignment;
 use App\Models\Restaurant;
@@ -140,5 +141,61 @@ class WebSyncConfirmDeciderTest extends TestCase
         $this->assertTrue($decision->shouldProceed());
         $this->assertNull($decision->reason);
         $this->assertInstanceOf(SlotAvailabilityResult::class, $decision->slot);
+        $this->assertSame(SlotState::Free, $decision->slot->state);
+    }
+
+    public function test_it_skips_when_the_slot_is_only_tight(): void
+    {
+        // setUp's 8-seat table is occupied and only a free 2-seat table remains:
+        // 2/10 = 20% free (≤ 25%) → Tight, which must not proceed unattended.
+        $eight = Table::query()->firstOrFail();
+        Table::factory()->for($this->restaurant)->create(['seats' => 2]);
+        $busy = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+        ReservationTableAssignment::factory()->for($busy, 'reservationRequest')->for($eight)->create();
+
+        $decision = $this->decider()->decide($this->reservation('2026-06-15 19:00', partySize: 2));
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SLOT_NOT_FREE, $decision->reason);
+    }
+
+    public function test_it_skips_when_desired_at_is_null(): void
+    {
+        $request = ReservationRequest::factory()->for($this->restaurant)->create([
+            'source' => ReservationSource::WebForm,
+            'status' => ReservationStatus::New,
+            'desired_at' => null,
+            'party_size' => 2,
+        ]);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SLOT_NOT_FREE, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_request_has_no_restaurant(): void
+    {
+        // An (unsaved) request pointing at a non-existent restaurant: the relation
+        // resolves to null, so the decider logs and skips as disabled.
+        $request = new ReservationRequest([
+            'restaurant_id' => 999_999,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_DISABLED, $decision->reason);
+    }
+
+    public function test_it_proceeds_at_exactly_the_minimum_lead_time(): void
+    {
+        // now is frozen at 18:00; 19:30 is exactly the 90-min lead (not < 90).
+        $decision = $this->decider()->decide($this->reservation('2026-05-23 19:30', partySize: 2));
+
+        $this->assertTrue($decision->shouldProceed());
     }
 }


### PR DESCRIPTION
## Summary

PRD-014 #353, on top of the schema from #352:

- `WebSyncConfirmDecider::decide(ReservationRequest)` — the hard-gate cascade, first tripped gate wins: `global_kill` → `web_sync_confirm_disabled` → `slot_not_deterministic_free` → `party_size_over_limit` → `short_notice`.
- `WebSyncConfirmDecision` DTO — `proceed` carries the `SlotAvailabilityResult`; `skip` carries the gate reason (mirrors the `AutoSendDecision` factory style).
- `config/reservations.php` → `web_sync_confirm.kill` from `WEB_SYNC_CONFIRM_GLOBAL_KILL`.

## Why

This is the gatekeeper for PRD-014: only deterministically-free web requests that clear the reused PRD-007 limits may be confirmed synchronously. The store-path wiring follows in #355.

## Decisions

- **`first_time_guest` / `needs_manual_review` are NOT gates** here (per PRD-014): web-form input is structured (no parse risk), and a first-time filter would block 90% of online first-timers the channel exists to win.
- Reuses PRD-007's `auto_send_party_size_max` / `auto_send_min_lead_time_minutes` (already implemented).
- Slot gate precedes party/short-notice: a party larger than every table is "full", which is reported as `slot_not_deterministic_free` (covered in tests with a fitting table so the party-cap gate is reachable).

## Test plan

- [x] `php artisan test` — 952 passed (6 new: one per gate + proceed; `Carbon::setTestNow` for deterministic lead-time)
- [x] `./vendor/bin/pint --test` clean
- [x] No routes/frontend → ziggy/JS jobs unaffected

Closes #353