### PR TITLE
docs: 2026-05-23 session handoff

### DIFF
--- a/docs/HANDOFF-2026-05-23.md
+++ b/docs/HANDOFF-2026-05-23.md
@@ -1,0 +1,149 @@
+# Handoff — Stand 2026-05-23
+
+Übergabe-Dokument für die nächste Session. Snapshot zum Datum oben; nicht evergreen.
+Maßgeblich bleiben die PRDs in `docs/`, `CLAUDE.md` und die GitHub-Issues.
+
+---
+
+## TL;DR
+
+- **PRD-012** (Telefon/Walk-in-Erfassung) und **PRD-013** (passive Warteliste) sind **vollständig** auf `dev`, beide Epics geschlossen.
+- **PRD-014** (Sync-Web-Confirm) ist **angefangen**: `#352` (Schema) + `#353` (Decider) gemerged. Verbleibend: `#354`–`#358`.
+- **PRD-015** (DSGVO-Self-Service) ist **gescoped, noch nicht begonnen**: `#359`–`#364`.
+- `dev` ist **13 Commits vor `main`**. `main` ist unangetastet — der `dev → main`-Release ist ein **expliziter Owner-Freigabe-Schritt** (noch nicht erfolgt).
+- Tests grün: **956 PHPUnit** (3095 Assertions) + **112 Vitest** (14 Dateien). CI (Backend PHP 8.4 / Frontend Node 20 / Ziggy-Drift) durchgehend grün.
+
+---
+
+## Branch- & Release-Stand
+
+- Aktueller Arbeits-Branch: `dev` (sauber, in sync mit `origin/dev`).
+- `origin/main..origin/dev` = **13 Commits** (die 13 gemergten PRs dieser Session, #341→#353 als Squash-Commits #365→#377).
+- **`main` bleibt unangetastet.** `dev → main` wird als eigener Release-PR (`Release: <bezeichnung>`) erst nach expliziter Owner-Freigabe erstellt — siehe `CLAUDE.md` § Branch-Strategie. Aktuell **keine** Freigabe erteilt.
+
+---
+
+## Was in dieser Session gebaut wurde
+
+### PRD-012 — Manuelle Erfassung Telefon/Walk-in ✅ komplett (Epic #337 zu)
+
+| Issue | Inhalt |
+|---|---|
+| #341 | `ReservationSource::Phone/WalkIn`, `reservation_requests.created_by_user_id` + `note`, Model-Fillable/Cast, `createdBy()`-Relation |
+| #342 | `QuickReservationController@create` + Request + Route + Live-Verfügbarkeits-Prop (`forSlot`) |
+| #343 | `@store` + Transaktion + `lockForUpdate` + Auto-Tisch (alle Tische einer Kombination) + `confirmed`, kein KI/Mail |
+| #344 | `resources/js/pages/Reservations/Quick.vue` — Keyboard-First, debounced Live-Verfügbarkeit, Banner, Tisch-Override |
+| #345 | Dashboard-Header-Button „Telefon-Reservierung" |
+| #346 | Vitest für `Quick.vue` |
+
+### PRD-013 — Warteliste passiv ✅ komplett (Epic #338 zu)
+
+| Issue | Inhalt |
+|---|---|
+| #347 | `ReservationStatus::Waitlisted` + Übergänge (`new`/`in_review` → `waitlisted`, `waitlisted` → `confirmed`/`declined`); Waitlist ist **non-occupying** (Test gepinnt) |
+| #348 | `app/Services/Waitlist/WaitlistBanner::eligibleNow` (free-slot Wartende, ≤20, oldest-first) |
+| #349 | Dashboard-Prop `waitlistBanner` (im Poll-`only`-Set) + waitlisted-Filter (lief schon via `Rule::enum`) |
+| #350 | `WaitlistBanner.vue` + „Warteliste"-Filter-Chip + Badge + Drawer-Übergangs-Buttons (→ `bulk-status`); `'waitlisted'` im TS-Typ |
+| #351 | Vitest für `WaitlistBanner.vue` |
+
+### PRD-014 — Sync-Web-Confirm 🚧 angefangen (Epic #339 offen)
+
+| Issue | Status |
+|---|---|
+| #352 | ✅ Schema: `restaurants.web_sync_confirm_enabled` + `reservation_replies.sync_confirm` (beide bool default false) |
+| #353 | ✅ `app/Services/AutoSend/WebSyncConfirmDecider` + `WebSyncConfirmDecision` DTO + `WEB_SYNC_CONFIRM_GLOBAL_KILL` config |
+
+---
+
+## Offene Issues (Stand 2026-05-23)
+
+Alle sofort baubar (PRD-007 **ist** implementiert — der frühere „blockiert"-Vermerk war falsch und wurde korrigiert).
+
+### PRD-014 (Epic #339) — Reihenfolge & Abhängigkeiten
+
+```
+#354 generateSync  ─┐ (unabhängig, PRD-005 vorhanden)
+#352 schema ✅ ─────┤
+#353 decider ✅ ────┘
+                    ▼
+#355 store-sync-path (braucht #353 + #354)
+   ├─► #356 ReservationReplyMail syncConfirm-Flag
+   └─► #357 PublicForm/ConfirmedSync.vue
+#358 Settings-Toggle (Settings/SendMode.vue, unabhängig)
+```
+
+- **#354** `OpenAiReplyGenerator::generateSync` — 5 s Hard-Timeout am OpenAI-Client, wirft `OpenAiTimeoutException`; bestehendes async `generate` unverändert. Kein API-Key in Strings/Logs.
+- **#355** `StoreReservationRequest` Sync-Pfad: `WebSyncConfirmDecider::decide` → bei `proceed` sync `generateSync` + `ReservationTableAssignment` + sync Mail + `confirmed` + `sync_confirm=true` + render `ConfirmedSync`; bei jedem Fehler/Timeout Fallthrough zum V1-Pfad (`new` + `Submitted`). `lockForUpdate` auf den vorgeschlagenen Tisch (Race vs. #343). Nur `web_form`-Source.
+- **#356** `ReservationReplyMail` optionales `syncConfirm: bool` + Template-Zeile „automatisch erstellt".
+- **#357** `resources/js/pages/PublicForm/ConfirmedSync.vue` (öffentlich, kein Layout).
+- **#358** Toggle in `resources/js/pages/Settings/SendMode.vue` (⚠️ **nicht** `AutoSend.vue` — so heißt die PRD-007-Seite real) + policy-guarded Update.
+
+### PRD-015 (Epic #340) — DSGVO Self-Service, noch nicht begonnen
+
+```
+#359 gdpr_audits (PII-frei) + Model + Service
+   ├─► #360 HasGdprLink-Trait + ReservationReplyMail-Footer
+   ├─► #361 GdprSelfServiceController@show (signed) + view-audit + Page
+   │      └─► #362 @delete + confirm_date + Hard-Delete + audit
+   │      └─► #363 Public GdprSelfService.vue + GdprDeleted.vue
+   └─► #364 Dashboard Bulk-Delete (E-Mail) + Owner-Policy + audit
+```
+
+### Altlasten (PRD-010, V2/V3-Sound-Assets — kein Code-Blocker)
+
+- **#200** `[Epic] PRD-010: Push & Sound-Alerts` (Tracking)
+- **#244** CC0-Sound-Assets in `public/sounds/` + LICENSE.txt (braucht echte Binärdateien)
+
+---
+
+## Nächster Schritt
+
+**#354** (`OpenAiReplyGenerator::generateSync`) ziehen — kleinstes unblockiertes PRD-014-Issue, Voraussetzung für #355. Danach #355 → #356/#357 → #358; dann PRD-015 ab #359.
+
+Epic #339 schließt nach #354–358; Epic #340 nach PRD-015.
+
+---
+
+## Arbeits-Workflow (verbindlich, pro Issue eine Schleife)
+
+1. `git checkout dev && git pull --ff-only origin dev && git checkout -b feature/<nr>-<slug>`
+2. Umsetzen **streng nach den Acceptance Criteria** des Issues; bestehende Patterns fortführen.
+3. Tests schreiben (Pest/PHPUnit + ggf. Vitest) — **jedes** Szenario (happy/edge/error).
+4. Grün machen: `php artisan test`, `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check`; bei Vue-Änderung zusätzlich `npm run build` (vue-tsc) und `npm run test` (Vitest).
+5. Atomare Commits (Imperativ-Englisch, `Refs #<nr>`). **Keine** KI-Attribution/Co-Authored-By in Commits/PRs/Kommentaren.
+6. Push, **PR gegen `dev`** (`gh pr create --base dev`), englischer Body (Summary/Why/Test plan, `Closes #<nr>`).
+7. **Self-Review (Pflicht):** Skill `code-review:code-review <PR#>` bzw. 5 Lenses (CLAUDE.md / Bug-Scan / Git-History / Prior-Comments / Comments-vs-Impl). Findings ≥80 als PR-Kommentar; reale Findings fixen, schwache/CLAUDE-widersprechende **begründet ablehnen**.
+8. **CI grün prüfen** (`gh pr checks <PR#>` — alle 3 Jobs), dann **Squash-Merge** nach `dev` (`gh pr merge --squash --delete-branch`).
+9. Issue **manuell schließen** (+ Abschlusskommentar) — Auto-Close greift bei `dev`-Merges nicht.
+10. Erst dann das nächste Issue.
+
+`dev → main` ist separat und braucht **Owner-Freigabe**.
+
+---
+
+## Gotchas aus dieser Session (Zeit-Sparer)
+
+- **Tests sind PHPUnit**, kein Pest (trotz Doku); Lauf via `php artisan test` (kein `composer test`-Script).
+- **Ziggy:** nach neuen **oder umsortierten** Routes `php artisan ziggy:generate --types-only resources/js/ziggy.d.ts` und die getrackte `ziggy.d.ts` committen — der CI-`ziggy-drift`-Job vergleicht. (Eine Route nur zu **verschieben** ändert die Reihenfolge in `ziggy.d.ts`.)
+- **Tenant-Scope:** in HTTP-Controllern auf den globalen `RestaurantScope` verlassen — **niemals** `where('restaurant_id', auth()->user()->…)` im Controller (CLAUDE.md-Verbot). In **Services** dagegen `withoutGlobalScopes()->where('restaurant_id', $id)` (Determinismus, laufen auch aus Jobs/Console).
+- **Inertia-Tests** für noch nicht existierende Vue-Seiten: `->component('Name', false)` (zweiter Param überspringt die Datei-Existenzprüfung).
+- **Vue native `<select :value="x">`**: liefert via `_value` den echten Typ (auch `null`/number), nicht den String — kein Bug.
+- **`v-model.number` am Wrapper-`<Input>` ist ein No-op** → numerische Felder explizit `Number()`-coercen (Submit **und** Reload-Pfad).
+- **`lockForUpdate` ist auf SQLite ein No-op** — Locking-Logik via in-Transaktion-Recheck testen (sequenzielle Doppel-Buchung), nicht via echter Parallelität.
+- **`SlotAvailability::forSlot`** erwartet UTC-`CarbonImmutable`; lokale Operator-Eingaben via `App\Support\Timezone::localToUtc(...)->toImmutable()` umwandeln; Cast-`Carbon` → `CarbonImmutable::instance()` (kein `parse()`-String-Roundtrip).
+- **Status/Source-Enums** werden in `AnalyticsAggregator` über `::cases()` iteriert → neue Werte tauchen automatisch als Zähl-Buckets auf (Frontend ignoriert Extra-Keys; TS-Typ/Anzeige separat nachziehen).
+- **PRD-007 (Auto-Send) ist gebaut** (V2-Welle): `AutoSendDecider`, `restaurants.auto_send_party_size_max`/`auto_send_min_lead_time_minutes`, Settings-Seite **`SendMode.vue`**. Aus nur-V1-Milestones **nicht** auf „ungebaut" schließen — V2/V3 sind über `v2`/`v3`-Labels getrackt.
+
+## Bekannte Follow-ups / Tech-Debt
+
+- **WaitlistBanner / WebSyncConfirmDecider N+1:** `forSlot` löst Restaurant+Tische pro Eintrag/Aufruf neu auf. Bei der Dashboard-Banner-Schleife (≤20) akzeptabel; falls das PRD-013-`<50 ms`-Ziel in Prod kippt, eine Batch-Methode auf `SlotAvailability` einführen.
+- **`bulk-status` `skipped`-Flash** wird nirgends im Dashboard angezeigt (betrifft auch die bestehende Bulk-Toolbar). Drawer-Übergangs-Buttons sind auf gültige Übergänge gegated, daher unkritisch — aber ein echtes Feedback-Loch, falls gewünscht.
+- **V4-PRDs (PRD-016/021/022 etc.) bewusst NICHT geschrieben** — Roadmap-Politik (`docs/superpowers/specs/2026-04-29-v3-plus-roadmap-design.md` §9/§10): V4 bleibt auf Bullet-Niveau bis V3 live + Pilot. „Keine V4-Issues" ist gewollt, kein Loch.
+
+---
+
+## Schnell-Referenz
+
+- PRDs: `docs/PRD-012`…`PRD-015`. Roadmap/Politik: `docs/README.md` + `docs/superpowers/specs/`.
+- Entscheidungen: `docs/decisions/`. Bekannte Fehler: `docs/TROUBLESHOOTING.md`.
+- Verhaltensregeln: `/Users/private/CLAUDE.md` + projektspezifische `CLAUDE.md`.


### PR DESCRIPTION
## Summary

Adds `docs/HANDOFF-2026-05-23.md` — a point-in-time handoff so the next session can continue seamlessly.

Covers: what was built (PRD-012 ✅, PRD-013 ✅, PRD-014 #352/#353 ✅), the open-issue map with dependencies (#354–358 PRD-014, #359–364 PRD-015), the branch/release state (`dev` 13 commits ahead of `main`, release pending owner approval), the per-issue next steps, the verbatim working workflow, and the gotchas/tech-debt learned this session.

## Why

Requested as a session handoff. Snapshot doc, dated (not evergreen); the PRDs, `CLAUDE.md`, and the GitHub issues remain authoritative.

## Test plan

- [x] Docs-only change — no code, routes, or tests touched; CI (Backend/Frontend/Ziggy-drift) unaffected
- [x] Facts cross-checked against `gh issue list`, `git rev-list origin/main..origin/dev`, and the merged PRs