### PR TITLE
PRD-014 #354: OpenAiReplyGenerator::generateSync with 5 s hard timeout

### DIFF
--- a/app/Exceptions/AI/OpenAiTimeoutException.php
+++ b/app/Exceptions/AI/OpenAiTimeoutException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Exceptions\AI;
 
 use RuntimeException;
+use Throwable;
 
 /**
  * Signals that the synchronous reply generation (PRD-014 web sync-confirm)
@@ -15,11 +16,15 @@ use RuntimeException;
  * owner review) instead of surfacing a UI error. Unlike the async
  * `generate`, the sync path never returns the neutral fallback text — a
  * confirmation must always carry a real AI reply.
+ *
+ * The originating transport exception is chained as `$previous` so the
+ * underlying cURL/Guzzle detail stays available for debugging (it is
+ * never logged with the API key).
  */
 final class OpenAiTimeoutException extends RuntimeException
 {
-    public function __construct(string $message = 'OpenAI sync reply generation timed out.')
+    public function __construct(string $message = 'OpenAI sync reply generation timed out.', ?Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, 0, $previous);
     }
 }

--- a/app/Exceptions/AI/OpenAiTimeoutException.php
+++ b/app/Exceptions/AI/OpenAiTimeoutException.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\AI;
+
+use RuntimeException;
+
+/**
+ * Signals that the synchronous reply generation (PRD-014 web sync-confirm)
+ * exceeded its hard timeout budget or otherwise failed transport-side.
+ *
+ * The sync path runs inside the public submit latency, so the caller
+ * catches this and falls back to the V1 path (`status = new`, normal
+ * owner review) instead of surfacing a UI error. Unlike the async
+ * `generate`, the sync path never returns the neutral fallback text — a
+ * confirmation must always carry a real AI reply.
+ */
+final class OpenAiTimeoutException extends RuntimeException
+{
+    public function __construct(string $message = 'OpenAI sync reply generation timed out.')
+    {
+        parent::__construct($message);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,7 +8,11 @@ use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\WebklexImapMailboxFactory;
 use App\Services\Exports\Contracts\ExportGenerator;
 use App\Services\Exports\FormatRoutingExportGenerator;
+use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Support\ServiceProvider;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
+use Psr\Log\LoggerInterface;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -18,8 +22,50 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(ImapMailboxFactory::class, WebklexImapMailboxFactory::class);
-        $this->app->bind(ReplyGenerator::class, OpenAiReplyGenerator::class);
         $this->app->bind(ExportGenerator::class, FormatRoutingExportGenerator::class);
+
+        // The generator needs two timeout regimes: the default 30 s client
+        // for the async job (`generate`), and a short-budget client for the
+        // PRD-014 sync-confirm path (`generateSync`). The factory builds the
+        // latter on demand with the requested timeout.
+        $this->app->bind(OpenAiReplyGenerator::class, fn ($app): OpenAiReplyGenerator => new OpenAiReplyGenerator(
+            $app->make(ClientContract::class),
+            $app->make(LoggerInterface::class),
+            fn (int $timeout): ClientContract => $this->buildTimeoutBoundOpenAiClient($timeout),
+        ));
+        $this->app->bind(ReplyGenerator::class, OpenAiReplyGenerator::class);
+    }
+
+    /**
+     * Build an OpenAI client whose HTTP timeout is `$timeout` seconds,
+     * mirroring the openai-php Laravel ServiceProvider construction but with
+     * the sync hard-limit instead of the global `openai.request_timeout`.
+     */
+    private function buildTimeoutBoundOpenAiClient(int $timeout): ClientContract
+    {
+        $apiKey = config('openai.api_key');
+        $organization = config('openai.organization');
+        $project = config('openai.project');
+        $baseUri = config('openai.base_uri');
+
+        if (! is_string($apiKey) || ($organization !== null && ! is_string($organization))) {
+            throw ApiKeyIsMissing::create();
+        }
+
+        $factory = \OpenAI::factory()
+            ->withApiKey($apiKey)
+            ->withOrganization($organization)
+            ->withHttpClient(new GuzzleClient(['timeout' => $timeout]));
+
+        if (is_string($project)) {
+            $factory->withProject($project);
+        }
+
+        if (is_string($baseUri)) {
+            $factory->withBaseUri($baseUri);
+        }
+
+        return $factory->make();
     }
 
     /**

--- a/app/Services/AI/Contracts/ReplyGenerator.php
+++ b/app/Services/AI/Contracts/ReplyGenerator.php
@@ -7,10 +7,15 @@ namespace App\Services\AI\Contracts;
 /**
  * Producer of a German reply text from a deterministic Context-JSON.
  *
- * Implementations MUST never throw; on every error path they return the
- * neutral fallback string. This contract is the seam used by the job
- * layer (and tests) to substitute in a real OpenAI client, a stub, or a
+ * Implementations of `generate` MUST never throw; on every error path they
+ * return the neutral fallback string. This contract is the seam used by the
+ * job layer (and tests) to substitute in a real OpenAI client, a stub, or a
  * future provider (Azure / Anthropic) without changing call sites.
+ *
+ * Concrete classes may expose additional, non-interface methods with their
+ * own contracts — e.g. `OpenAiReplyGenerator::generateSync` (PRD-014), which
+ * deliberately throws on every failure. Such methods are outside this
+ * never-throw guarantee and are not part of the provider-swap seam.
  */
 interface ReplyGenerator
 {

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -37,7 +37,8 @@ use Throwable;
  * fallback and instead throws on every failure, letting the caller fall
  * back to the V1 path. See its docblock for the per-error mapping.
  *
- * Logging hygiene: only `$e->getMessage()` is logged. No API key, no
+ * Logging hygiene: only the exception message (and, for classified HTTP
+ * errors, the numeric status code) is logged. No API key, no
  * Authorization header, no full context payload, no guest data.
  */
 final class OpenAiReplyGenerator implements ReplyGenerator
@@ -116,8 +117,18 @@ final class OpenAiReplyGenerator implements ReplyGenerator
      *   - empty completion → `RuntimeException`
      *   - 401 / 429 / 5xx → the underlying OpenAI exception propagates
      *
-     * Logging hygiene matches `generate`: only `$e->getMessage()` is logged,
-     * never the API key, headers, context payload, or guest data.
+     * Error mapping (every branch is logged and then thrown — the sync path
+     * never returns the fallback):
+     *   - 401 → `OpenAiAuthenticationException` (classified like `generate`,
+     *     so the caller can surface the admin key-check notification)
+     *   - 429 → `OpenAiRateLimitException`
+     *   - transport failure / 5 s timeout → `OpenAiTimeoutException`
+     *   - 5xx, empty completion, malformed payload → the originating
+     *     exception propagates
+     *
+     * Logging hygiene matches `generate`: only the exception message (and,
+     * for classified HTTP errors, the numeric status) is logged — never the
+     * API key, headers, context payload, or guest data.
      *
      * @param  array<string, mixed>  $context  the JSON produced by
      *                                         ReservationContextBuilder::build()
@@ -142,6 +153,23 @@ final class OpenAiReplyGenerator implements ReplyGenerator
             OpenAiKeyHealth::clear();
 
             return $content;
+        } catch (ErrorException $e) {
+            $this->logger->warning('openai sync reply generation failed', [
+                'status' => $e->getStatusCode(),
+                'error' => $e->getErrorMessage(),
+            ]);
+
+            if ($e->getStatusCode() === 401) {
+                throw new OpenAiAuthenticationException;
+            }
+
+            throw $e;
+        } catch (RateLimitException $e) {
+            $this->logger->warning('openai sync reply generation rate-limited', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new OpenAiRateLimitException;
         } catch (TransporterException $e) {
             // Guzzle connection timeout / network failure within the 5 s
             // budget surfaces here (openai-php wraps it).
@@ -149,7 +177,16 @@ final class OpenAiReplyGenerator implements ReplyGenerator
                 'error' => $e->getMessage(),
             ]);
 
-            throw new OpenAiTimeoutException;
+            throw new OpenAiTimeoutException(previous: $e);
+        } catch (Throwable $e) {
+            // 5xx, empty completion, malformed payload — log for parity with
+            // `generate`, then propagate so the caller falls back to V1
+            // (never the neutral fallback text).
+            $this->logger->warning('openai sync reply generation failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
         }
     }
 

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -6,12 +6,16 @@ namespace App\Services\AI;
 
 use App\Exceptions\AI\OpenAiAuthenticationException;
 use App\Exceptions\AI\OpenAiRateLimitException;
+use App\Exceptions\AI\OpenAiTimeoutException;
 use App\Services\AI\Contracts\ReplyGenerator;
 use App\Support\OpenAiKeyHealth;
+use Closure;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Exceptions\ErrorException;
 use OpenAI\Exceptions\RateLimitException;
+use OpenAI\Exceptions\TransporterException;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -19,7 +23,7 @@ use Throwable;
  * `ReservationContextBuilder`) into a German reply text via OpenAI Chat
  * Completions.
  *
- * Error matrix (PRD-005 / #71):
+ * Async `generate` error matrix (PRD-005 / #71):
  *   - HTTP 401 or RateLimit/Server errors are classified as
  *     `OpenAiAuthenticationException` / `OpenAiRateLimitException` and
  *     RETHROWN so the job layer can drive the admin notification (#76)
@@ -27,6 +31,11 @@ use Throwable;
  *   - Every other error path — empty completion, network failure, 5xx,
  *     timeout, malformed payload — returns the neutral fallback so the
  *     caller never raises.
+ *
+ * The sync `generateSync` (PRD-014) has the OPPOSITE error contract: a
+ * web sync-confirm must carry a real AI reply, so it NEVER returns the
+ * fallback and instead throws on every failure, letting the caller fall
+ * back to the V1 path. See its docblock for the per-error mapping.
  *
  * Logging hygiene: only `$e->getMessage()` is logged. No API key, no
  * Authorization header, no full context payload, no guest data.
@@ -37,9 +46,18 @@ final class OpenAiReplyGenerator implements ReplyGenerator
 
     private const float TEMPERATURE = 0.4;
 
+    /**
+     * @param  (Closure(int): ClientContract)|null  $syncClientFactory
+     *                                                                  Builds a client whose HTTP timeout equals the sync hard-limit
+     *                                                                  (PRD-014). Bound in production so `generateSync` can run a
+     *                                                                  5 s-bounded call; left null in unit tests, where the injected
+     *                                                                  client (a fake) is used directly so `OpenAI::fake()` applies.
+     *                                                                  The async `generate` always uses the default 30 s `$client`.
+     */
     public function __construct(
         private readonly ClientContract $client,
         private readonly LoggerInterface $logger,
+        private readonly ?Closure $syncClientFactory = null,
     ) {}
 
     /**
@@ -49,16 +67,7 @@ final class OpenAiReplyGenerator implements ReplyGenerator
     public function generate(array $context): string
     {
         try {
-            $tonality = $this->extractTonality($context);
-
-            $response = $this->client->chat()->create([
-                'model' => config('reservations.ai.openai_model', 'gpt-4o-mini'),
-                'temperature' => self::TEMPERATURE,
-                'messages' => [
-                    ['role' => 'system', 'content' => $this->systemPrompt($tonality)],
-                    ['role' => 'user', 'content' => json_encode($context, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)],
-                ],
-            ]);
+            $response = $this->client->chat()->create($this->chatCreatePayload($context));
 
             $content = trim((string) ($response->choices[0]->message->content ?? ''));
 
@@ -92,6 +101,78 @@ final class OpenAiReplyGenerator implements ReplyGenerator
 
             return self::FALLBACK_TEXT;
         }
+    }
+
+    /**
+     * Synchronous reply generation for the PRD-014 web sync-confirm path.
+     *
+     * Runs inside the public submit latency with a hard `$timeout`-second
+     * budget enforced by the `syncClientFactory` client. Unlike `generate`,
+     * it NEVER returns the neutral fallback: a confirmation must carry a
+     * real AI reply, so every failure throws and the caller falls back to
+     * the V1 path.
+     *
+     *   - transport failure / 5 s timeout → `OpenAiTimeoutException`
+     *   - empty completion → `RuntimeException`
+     *   - 401 / 429 / 5xx → the underlying OpenAI exception propagates
+     *
+     * Logging hygiene matches `generate`: only `$e->getMessage()` is logged,
+     * never the API key, headers, context payload, or guest data.
+     *
+     * @param  array<string, mixed>  $context  the JSON produced by
+     *                                         ReservationContextBuilder::build()
+     */
+    public function generateSync(array $context, int $timeout = 5): string
+    {
+        $client = $this->syncClientFactory !== null
+            ? ($this->syncClientFactory)($timeout)
+            : $this->client;
+
+        try {
+            $response = $client->chat()->create($this->chatCreatePayload($context));
+
+            $content = trim((string) ($response->choices[0]->message->content ?? ''));
+
+            if ($content === '') {
+                throw new RuntimeException('OpenAI returned an empty completion for the sync reply.');
+            }
+
+            // Successful authenticated call — clear the admin "OpenAI key
+            // check" banner (#76), mirroring `generate`.
+            OpenAiKeyHealth::clear();
+
+            return $content;
+        } catch (TransporterException $e) {
+            // Guzzle connection timeout / network failure within the 5 s
+            // budget surfaces here (openai-php wraps it).
+            $this->logger->warning('openai sync reply generation timed out', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new OpenAiTimeoutException;
+        }
+    }
+
+    /**
+     * The Chat Completions request body shared by the async `generate` and
+     * the sync `generateSync`: same model, temperature, system prompt and
+     * the deterministic context JSON as the user message.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function chatCreatePayload(array $context): array
+    {
+        $tonality = $this->extractTonality($context);
+
+        return [
+            'model' => config('reservations.ai.openai_model', 'gpt-4o-mini'),
+            'temperature' => self::TEMPERATURE,
+            'messages' => [
+                ['role' => 'system', 'content' => $this->systemPrompt($tonality)],
+                ['role' => 'user', 'content' => json_encode($context, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)],
+            ],
+        ];
     }
 
     /**

--- a/tests/Unit/Services/AI/OpenAiReplyGeneratorGenerateSyncTest.php
+++ b/tests/Unit/Services/AI/OpenAiReplyGeneratorGenerateSyncTest.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Exceptions\AI\OpenAiTimeoutException;
+use App\Services\AI\OpenAiReplyGenerator;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Exceptions\TransporterException;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Testing\ClientFake;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * Covers the synchronous reply path used by the PRD-014 web sync-confirm
+ * flow. The submit path can only confirm with a *real* AI reply, so
+ * `generateSync` throws on every failure (timeout, empty completion)
+ * instead of returning the neutral fallback the async `generate` uses.
+ */
+class OpenAiReplyGeneratorGenerateSyncTest extends TestCase
+{
+    private const string LEAK_SENTINEL = 'sk-test-LEAK-CHECK-12345';
+
+    private function makeContext(string $tonality = 'casual'): array
+    {
+        return [
+            'restaurant' => [
+                'name' => 'La Trattoria',
+                'tonality' => $tonality,
+            ],
+            'request' => [
+                'guest_name' => 'Anna Müller',
+                'party_size' => 4,
+                'desired_at' => '2026-05-13 19:30',
+                'message' => 'Möglichst Fensterplatz, danke.',
+            ],
+            'availability' => [
+                'is_open_at_desired_time' => true,
+                'closed_reason' => null,
+                'slot_state' => 'free',
+                'is_available' => true,
+                'alternative_slots' => [],
+            ],
+        ];
+    }
+
+    private function makeGenerator(ClientFake $fake): OpenAiReplyGenerator
+    {
+        return new OpenAiReplyGenerator($fake, new NullLogger);
+    }
+
+    private function timeoutException(): TransporterException
+    {
+        // Mirrors what openai-php raises in production: a Guzzle connection
+        // timeout (ClientExceptionInterface) wrapped into TransporterException.
+        return new TransporterException(
+            new ConnectException(
+                'cURL error 28: Operation timed out after 5000 milliseconds',
+                new Request('POST', 'https://api.openai.com/v1/chat/completions'),
+            ),
+        );
+    }
+
+    public function test_it_generates_a_reply_synchronously(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    [
+                        'index' => 0,
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => "  Guten Tag Anna,\n\nIhr Tisch um 19:30 ist bestätigt.\n\nViele Grüße  ",
+                        ],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $reply = $this->makeGenerator($fake)->generateSync($this->makeContext());
+
+        $this->assertSame(
+            "Guten Tag Anna,\n\nIhr Tisch um 19:30 ist bestätigt.\n\nViele Grüße",
+            $reply
+        );
+    }
+
+    public function test_it_throws_openai_timeout_exception_on_timeout(): void
+    {
+        $fake = OpenAI::fake([
+            $this->timeoutException(),
+        ]);
+
+        $this->expectException(OpenAiTimeoutException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_throws_instead_of_returning_the_fallback_when_completion_is_empty(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => '   '], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        // A blank completion must never be sent as a confirmation; the caller
+        // falls back to the V1 path instead.
+        $this->expectException(RuntimeException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_passes_the_timeout_to_the_sync_client_factory(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        $capturedTimeout = null;
+        $factory = function (int $timeout) use ($fake, &$capturedTimeout): ClientContract {
+            $capturedTimeout = $timeout;
+
+            return $fake;
+        };
+
+        $generator = new OpenAiReplyGenerator($fake, new NullLogger, $factory);
+
+        $generator->generateSync($this->makeContext(), timeout: 3);
+
+        $this->assertSame(3, $capturedTimeout);
+    }
+
+    public function test_it_defaults_to_a_five_second_timeout(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        $capturedTimeout = null;
+        $factory = function (int $timeout) use ($fake, &$capturedTimeout): ClientContract {
+            $capturedTimeout = $timeout;
+
+            return $fake;
+        };
+
+        (new OpenAiReplyGenerator($fake, new NullLogger, $factory))->generateSync($this->makeContext());
+
+        $this->assertSame(5, $capturedTimeout);
+    }
+
+    public function test_the_api_key_never_appears_in_logs_or_the_thrown_exception(): void
+    {
+        config()->set('openai.api_key', self::LEAK_SENTINEL);
+
+        $captured = [];
+        Log::shouldReceive('warning')->andReturnUsing(function (string $message, array $context) use (&$captured): void {
+            $captured[] = ['message' => $message, 'context' => $context];
+        });
+        Log::shouldReceive('debug')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+
+        $fake = OpenAI::fake([
+            $this->timeoutException(),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, Log::getFacadeRoot());
+
+        $thrownMessage = '';
+        try {
+            $generator->generateSync($this->makeContext());
+        } catch (OpenAiTimeoutException $e) {
+            $thrownMessage = $e->getMessage();
+        }
+
+        $serialized = json_encode($captured, JSON_UNESCAPED_UNICODE);
+        $this->assertNotFalse($serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $thrownMessage);
+    }
+}

--- a/tests/Unit/Services/AI/OpenAiReplyGeneratorGenerateSyncTest.php
+++ b/tests/Unit/Services/AI/OpenAiReplyGeneratorGenerateSyncTest.php
@@ -4,12 +4,18 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Services\AI;
 
+use App\Exceptions\AI\OpenAiAuthenticationException;
+use App\Exceptions\AI\OpenAiRateLimitException;
 use App\Exceptions\AI\OpenAiTimeoutException;
 use App\Services\AI\OpenAiReplyGenerator;
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use Illuminate\Support\Facades\Log;
 use OpenAI\Contracts\ClientContract;
+use OpenAI\Exceptions\ErrorException;
+use OpenAI\Exceptions\RateLimitException;
+use OpenAI\Exceptions\ServerException;
 use OpenAI\Exceptions\TransporterException;
 use OpenAI\Laravel\Facades\OpenAI;
 use OpenAI\Responses\Chat\CreateResponse;
@@ -121,6 +127,44 @@ class OpenAiReplyGeneratorGenerateSyncTest extends TestCase
         $this->makeGenerator($fake)->generateSync($this->makeContext());
     }
 
+    public function test_it_classifies_a_401_as_an_authentication_exception(): void
+    {
+        $fake = OpenAI::fake([
+            new ErrorException(
+                ['message' => 'invalid api key', 'type' => 'invalid_request_error'],
+                new Response(401),
+            ),
+        ]);
+
+        $this->expectException(OpenAiAuthenticationException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_classifies_a_429_as_a_rate_limit_exception(): void
+    {
+        $fake = OpenAI::fake([
+            new RateLimitException(new Response(429)),
+        ]);
+
+        $this->expectException(OpenAiRateLimitException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_propagates_a_server_error_instead_of_returning_the_fallback(): void
+    {
+        $fake = OpenAI::fake([
+            new ServerException(new Response(500)),
+        ]);
+
+        // A 5xx must not yield a confirmation; it propagates so the caller
+        // falls back to the V1 path.
+        $this->expectException(ServerException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
     public function test_it_passes_the_timeout_to_the_sync_client_factory(): void
     {
         $fake = OpenAI::fake([
@@ -188,6 +232,36 @@ class OpenAiReplyGeneratorGenerateSyncTest extends TestCase
         try {
             $generator->generateSync($this->makeContext());
         } catch (OpenAiTimeoutException $e) {
+            $thrownMessage = $e->getMessage();
+        }
+
+        $serialized = json_encode($captured, JSON_UNESCAPED_UNICODE);
+        $this->assertNotFalse($serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $thrownMessage);
+    }
+
+    public function test_the_api_key_never_leaks_on_the_classified_401_path(): void
+    {
+        config()->set('openai.api_key', self::LEAK_SENTINEL);
+
+        $captured = [];
+        Log::shouldReceive('warning')->andReturnUsing(function (string $message, array $context) use (&$captured): void {
+            $captured[] = ['message' => $message, 'context' => $context];
+        });
+        Log::shouldReceive('debug')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+
+        $fake = OpenAI::fake([
+            new ErrorException(['message' => 'unauthorised'], new Response(401)),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, Log::getFacadeRoot());
+
+        $thrownMessage = '';
+        try {
+            $generator->generateSync($this->makeContext());
+        } catch (OpenAiAuthenticationException $e) {
             $thrownMessage = $e->getMessage();
         }
 


### PR DESCRIPTION
## Summary

Adds the synchronous reply path for the PRD-014 web sync-confirm flow.

- `OpenAiReplyGenerator::generateSync(array $context, int $timeout = 5): string` — runs a timeout-bounded Chat Completions call.
- New `App\Exceptions\AI\OpenAiTimeoutException`; a transport timeout (openai-php wraps the Guzzle `ConnectException` into `TransporterException`) maps to it.
- **Fail-closed contract** (opposite of async `generate`): a sync confirmation must carry a real AI reply, so `generateSync` never returns the neutral fallback — a timeout throws `OpenAiTimeoutException`, an empty completion throws `RuntimeException`. The caller (#355) falls back to the V1 path.
- The 5 s budget is enforced by an optional `syncClientFactory` closure: bound in `AppServiceProvider` to a Guzzle client built with the sync hard-limit (mirroring the openai-php ServiceProvider construction); left `null` in unit tests so the injected fake is used and `OpenAI::fake()` applies.
- The async `generate` (30 s, fallback-returning, job pipeline) is unchanged; the shared chat-create payload was extracted to remove duplication.
- No API key in returned strings, logs, or exceptions (logging hygiene matches `generate`).

### Signature note
PRD-014 / the issue sketch `generateSync(ReservationRequest $r, …)`, but the established pattern keeps the generator a pure formatter over the deterministic context-array (`generate(array $context)`), DB-free and testable. `generateSync` follows that pattern; the #355 controller builds the context via `ReservationContextBuilder` (exactly as the job does) and passes it in.

## Why

PRD-014 § Controller-Erweiterung: web submits that hit a deterministically free slot should be confirmed within the submit latency. That requires a synchronous, hard-bounded OpenAI call that fails closed instead of returning a placeholder.

## Test plan

- [x] `php artisan test` — 962 passed (3103 assertions); 6 new tests in `OpenAiReplyGeneratorGenerateSyncTest`:
  - generates a reply synchronously
  - throws `OpenAiTimeoutException` on timeout
  - throws (not fallback) on empty completion
  - passes the timeout to the sync client factory + defaults to 5 s
  - API key never leaks into logs or the thrown exception
- [x] `./vendor/bin/pint --test` — pass (project-wide)
- [x] No routes/JS touched → Ziggy/Vitest unaffected

Closes #354