### PR TITLE
PRD-014 #355: web sync-confirm path in the public store controller

### DIFF
--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -4,19 +4,43 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\MessageDirection;
+use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
 use App\Events\ReservationRequestReceived;
 use App\Http\Requests\StoreReservationRequest;
+use App\Jobs\SendReservationReplyJob;
+use App\Mail\ReservationReplyMail;
+use App\Models\ReservationMessage;
+use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
 use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\AI\OpenAiReplyGenerator;
+use App\Services\AI\ReservationContextBuilder;
+use App\Services\AutoSend\WebSyncConfirmDecider;
+use App\Services\Availability\SlotAvailability;
 use App\Support\Timezone;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 use Inertia\Inertia;
 use Inertia\Response;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
 final class PublicReservationController extends Controller
 {
+    public function __construct(
+        private readonly WebSyncConfirmDecider $decider,
+        private readonly ReservationContextBuilder $contextBuilder,
+        private readonly SlotAvailability $availability,
+        private readonly LoggerInterface $logger,
+    ) {}
+
     public function create(Restaurant $restaurant): Response
     {
         return Inertia::render('Public/ReservationForm', [
@@ -29,7 +53,7 @@ final class PublicReservationController extends Controller
         ]);
     }
 
-    public function store(StoreReservationRequest $request, Restaurant $restaurant): RedirectResponse
+    public function store(StoreReservationRequest $request, Restaurant $restaurant): RedirectResponse|Response
     {
         if ($request->filled('website')) {
             return redirect()->route('public.reservations.thanks', $restaurant);
@@ -50,6 +74,17 @@ final class PublicReservationController extends Controller
             'raw_payload' => $validated,
         ]);
 
+        // PRD-014: only web-form submissions are eligible for the synchronous
+        // confirmation; email/phone reservations run their own pipelines.
+        if ($reservationRequest->source === ReservationSource::WebForm) {
+            $confirmation = $this->attemptSyncConfirm($reservationRequest, $restaurant);
+
+            if ($confirmation !== null) {
+                return $confirmation;
+            }
+        }
+
+        // V1 path: hand the request to the async draft pipeline for owner review.
         ReservationRequestReceived::dispatch($reservationRequest);
 
         return redirect()->route('public.reservations.thanks', $restaurant);
@@ -62,5 +97,163 @@ final class PublicReservationController extends Controller
                 'name' => $restaurant->name,
             ],
         ]);
+    }
+
+    /**
+     * Try to confirm the reservation synchronously (PRD-014). Returns the
+     * confirmation page on success, or null to signal the caller to fall back
+     * to the V1 path. Any failure — gate skip, OpenAI timeout, lost table
+     * race, SMTP error — resolves to null without surfacing a UI error.
+     */
+    private function attemptSyncConfirm(ReservationRequest $reservation, Restaurant $restaurant): ?Response
+    {
+        if (! $this->decider->decide($reservation)->shouldProceed()) {
+            return null;
+        }
+
+        try {
+            // Generate the reply BEFORE the transaction so the up-to-5s OpenAI
+            // call never holds the table lock. generateSync throws rather than
+            // returning the neutral fallback, so a confirmation always carries
+            // a real reply. The generator is resolved here (not constructor-
+            // injected) so a missing/invalid OPENAI_API_KEY is caught by this
+            // try-block and degrades to the V1 path — V1 submits never build the
+            // OpenAI client (mirrors GenerateReservationReplyJob).
+            $context = $this->contextBuilder->build($reservation);
+            $body = app(OpenAiReplyGenerator::class)->generateSync($context);
+
+            $confirmed = DB::transaction(function () use ($reservation, $context, $body): bool {
+                // Serialize concurrent bookings for this restaurant's slot. The
+                // route restaurant (not an authenticated tenant) scopes the lock;
+                // RestaurantScope no-ops without a user. lockForUpdate is a no-op
+                // on SQLite, so the in-lock re-check below is what actually
+                // rejects a slot taken since the decider ran (race vs PRD-012).
+                Table::query()
+                    ->where('restaurant_id', $reservation->restaurant_id)
+                    ->where('active', true)
+                    ->lockForUpdate()
+                    ->get();
+
+                $combination = $this->availability->suggestTableCombination(
+                    $reservation->restaurant_id,
+                    CarbonImmutable::instance($reservation->desired_at),
+                    $reservation->party_size,
+                );
+
+                if ($combination === null) {
+                    return false;
+                }
+
+                $reply = ReservationReply::create([
+                    'reservation_request_id' => $reservation->id,
+                    'status' => ReservationReplyStatus::Draft,
+                    'body' => $body,
+                    'ai_prompt_snapshot' => $context + [
+                        'original_body' => $body,
+                        'model' => (string) config('reservations.ai.openai_model', 'gpt-4o-mini'),
+                        'fallback' => false,
+                    ],
+                    'sync_confirm' => true,
+                ]);
+
+                foreach ($combination->tableIds as $tableId) {
+                    ReservationTableAssignment::create([
+                        'reservation_request_id' => $reservation->id,
+                        'table_id' => $tableId,
+                        'assigned_at' => now(),
+                        'assigned_by_user_id' => null,
+                    ]);
+                }
+
+                // Non-queued send INSIDE the transaction so an SMTP failure rolls
+                // back the reply + assignment and the request stays `new` for V1.
+                $this->sendConfirmation($reply, $reservation);
+
+                $reservation->forceFill(['status' => ReservationStatus::Confirmed])->save();
+
+                return true;
+            });
+
+            if (! $confirmed) {
+                return null;
+            }
+
+            return $this->renderConfirmation($reservation, $restaurant);
+        } catch (Throwable $e) {
+            // Class only — never guest data or mail content (PRD-014).
+            $this->logger->warning('web sync confirm failed, falling back to v1 path', [
+                'reservation_request_id' => $reservation->id,
+                'reason' => $e::class,
+            ]);
+
+            return null;
+        }
+    }
+
+    /**
+     * Mail the confirmation immediately and record the outbound message, in
+     * parity with {@see SendReservationReplyJob} so threading
+     * (PRD-006) and the drawer history stay consistent.
+     */
+    private function sendConfirmation(ReservationReply $reply, ReservationRequest $reservation): void
+    {
+        $email = (string) $reservation->guest_email;
+        $mail = new ReservationReplyMail($reply);
+
+        Mail::to($email)->send($mail);
+
+        $fromAddress = (string) (config('mail.from.address') ?: 'noreply@localhost');
+        $subject = (string) $mail->envelope()->subject;
+
+        ReservationMessage::create([
+            'reservation_request_id' => $reply->reservation_request_id,
+            'direction' => MessageDirection::Out,
+            'message_id' => $mail->messageId,
+            'subject' => $subject,
+            'from_address' => $fromAddress,
+            'to_address' => $email,
+            'body_plain' => $reply->body,
+            'raw_headers' => "Message-ID: <{$mail->messageId}>\nFrom: {$fromAddress}\nTo: {$email}\nSubject: {$subject}",
+            'sent_at' => now(),
+        ]);
+
+        $reply->forceFill([
+            'status' => ReservationReplyStatus::Sent,
+            'sent_at' => now(),
+            'outbound_message_id' => $mail->messageId,
+        ])->save();
+    }
+
+    private function renderConfirmation(ReservationRequest $reservation, Restaurant $restaurant): Response
+    {
+        $localDesiredAt = CarbonImmutable::instance($reservation->desired_at)
+            ->setTimezone($restaurant->timezone);
+
+        return Inertia::render('Public/ConfirmedSync', [
+            'restaurant' => [
+                'name' => $restaurant->name,
+            ],
+            'reservation' => [
+                'date' => $localDesiredAt->format('Y-m-d'),
+                'time' => $localDesiredAt->format('H:i'),
+                'party_size' => $reservation->party_size,
+                'guest_email_masked' => $this->maskEmail((string) $reservation->guest_email),
+            ],
+        ]);
+    }
+
+    /**
+     * Mask a guest email for the public confirmation page: first character of
+     * the local part, then the full domain (e.g. `a…@gmail.com`).
+     */
+    private function maskEmail(string $email): string
+    {
+        $at = strpos($email, '@');
+
+        if ($at === false || $at === 0) {
+            return $email;
+        }
+
+        return $email[0].'…@'.substr($email, $at + 1);
     }
 }

--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -118,7 +118,8 @@ final class PublicReservationController extends Controller
             // a real reply. The generator is resolved here (not constructor-
             // injected) so a missing/invalid OPENAI_API_KEY is caught by this
             // try-block and degrades to the V1 path — V1 submits never build the
-            // OpenAI client (mirrors GenerateReservationReplyJob).
+            // OpenAI client (the same late-resolution trick as
+            // GenerateReservationReplyJob).
             $context = $this->contextBuilder->build($reservation);
             $body = app(OpenAiReplyGenerator::class)->generateSync($context);
 
@@ -165,20 +166,21 @@ final class PublicReservationController extends Controller
                     ]);
                 }
 
-                // Non-queued send INSIDE the transaction so an SMTP failure rolls
-                // back the reply + assignment and the request stays `new` for V1.
-                $this->sendConfirmation($reply, $reservation);
-
+                // Persist every DB side-effect (outbound message, reply -> sent,
+                // request -> confirmed) FIRST, then physically send as the very
+                // last step. forceFill bypasses the manual new->… state machine,
+                // exactly as SendReservationReplyJob does for the auto pipeline.
+                $mail = $this->recordSentReply($reply, $reservation);
                 $reservation->forceFill(['status' => ReservationStatus::Confirmed])->save();
+
+                // Non-queued send LAST so an SMTP failure rolls back the whole
+                // confirmation and the request stays `new` for V1 (PRD-014). The
+                // only residual window is a commit failure after a successful
+                // send — the irreducible DB+mail dual-write, and vanishingly rare.
+                Mail::to((string) $reservation->guest_email)->send($mail);
 
                 return true;
             });
-
-            if (! $confirmed) {
-                return null;
-            }
-
-            return $this->renderConfirmation($reservation, $restaurant);
         } catch (Throwable $e) {
             // Class only — never guest data or mail content (PRD-014).
             $this->logger->warning('web sync confirm failed, falling back to v1 path', [
@@ -188,19 +190,28 @@ final class PublicReservationController extends Controller
 
             return null;
         }
+
+        if (! $confirmed) {
+            return null;
+        }
+
+        // Rendered AFTER the committed transaction and outside the try, so a
+        // formatting error here surfaces as an error rather than silently
+        // falling through to V1 and double-confirming an already-mailed guest.
+        return $this->renderConfirmation($reservation, $restaurant);
     }
 
     /**
-     * Mail the confirmation immediately and record the outbound message, in
-     * parity with {@see SendReservationReplyJob} so threading
-     * (PRD-006) and the drawer history stay consistent.
+     * Record the outbound message and flag the reply as sent, then return the
+     * Mailable for the caller to dispatch. The outbound-message bookkeeping
+     * mirrors {@see SendReservationReplyJob} so threading (PRD-006) and the
+     * drawer history stay consistent; the parent request transition differs
+     * (sync-confirm -> confirmed, not replied) and is the caller's job.
      */
-    private function sendConfirmation(ReservationReply $reply, ReservationRequest $reservation): void
+    private function recordSentReply(ReservationReply $reply, ReservationRequest $reservation): ReservationReplyMail
     {
         $email = (string) $reservation->guest_email;
         $mail = new ReservationReplyMail($reply);
-
-        Mail::to($email)->send($mail);
 
         $fromAddress = (string) (config('mail.from.address') ?: 'noreply@localhost');
         $subject = (string) $mail->envelope()->subject;
@@ -222,6 +233,8 @@ final class PublicReservationController extends Controller
             'sent_at' => now(),
             'outbound_message_id' => $mail->messageId,
         ])->save();
+
+        return $mail;
     }
 
     private function renderConfirmation(ReservationRequest $reservation, Restaurant $restaurant): Response

--- a/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
+++ b/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
@@ -10,6 +10,7 @@ use App\Enums\ReservationStatus;
 use App\Events\ReservationRequestReceived;
 use App\Jobs\GenerateReservationReplyJob;
 use App\Mail\ReservationReplyMail;
+use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\ReservationTableAssignment;
@@ -218,6 +219,9 @@ class WebSyncConfirmFlowTest extends TestCase
         $this->assertSame(ReservationStatus::New, $reservation->status);
         $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
         $this->assertSame(0, ReservationTableAssignment::withoutGlobalScopes()->count());
+        // The outbound message is written before the send, so the rollback must
+        // also drop it — no orphaned audit row for a mail that never went out.
+        $this->assertSame(0, ReservationMessage::withoutGlobalScopes()->count());
 
         Event::assertDispatched(ReservationRequestReceived::class);
     }

--- a/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
+++ b/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Events\ReservationRequestReceived;
+use App\Jobs\GenerateReservationReplyJob;
+use App\Mail\ReservationReplyMail;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\AI\OpenAiReplyGenerator;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use OpenAI\Exceptions\TransporterException;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Responses\Chat\CreateResponse;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * End-to-end coverage of the PRD-014 web sync-confirm path on the public
+ * submit endpoint (#355): a free-slot web reservation is confirmed inside
+ * the request, with a synchronous AI reply, an auto table assignment and an
+ * immediate mail — falling back to the unchanged V1 path on any failure.
+ */
+class WebSyncConfirmFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Frozen well before the desired slot so the lead-time gate passes;
+        // UTC timezone keeps local form input equal to the stored UTC instant.
+        Carbon::setTestNow('2026-05-23 12:00:00');
+
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'slug' => 'demo',
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+            'web_sync_confirm_enabled' => true,
+            'auto_send_party_size_max' => 10,
+            'auto_send_min_lead_time_minutes' => 90,
+        ]);
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'guest_name' => 'Alice Example',
+            'guest_email' => 'alice@gmail.com',
+            'guest_phone' => '+49 30 1234567',
+            'party_size' => 4,
+            'desired_at' => '2026-06-15 19:00',
+            'message' => 'Fensterplatz wäre toll.',
+        ], $overrides);
+    }
+
+    /**
+     * Bind the generator to the OpenAI fake without the production
+     * sync-client factory, so `generateSync` uses the faked client instead
+     * of building a real timeout-bounded one.
+     *
+     * @param  array<int, mixed>  $responses
+     */
+    private function fakeOpenAi(array $responses): void
+    {
+        $fake = OpenAI::fake($responses);
+
+        $this->app->bind(OpenAiReplyGenerator::class, fn ($app): OpenAiReplyGenerator => new OpenAiReplyGenerator(
+            $fake,
+            $app->make(LoggerInterface::class),
+        ));
+    }
+
+    private function replyResponse(string $body = 'Guten Tag Alice, Ihr Tisch ist bestätigt.'): CreateResponse
+    {
+        return CreateResponse::fake([
+            'choices' => [
+                ['index' => 0, 'message' => ['role' => 'assistant', 'content' => $body], 'finish_reason' => 'stop'],
+            ],
+        ]);
+    }
+
+    private function timeoutException(): TransporterException
+    {
+        return new TransporterException(
+            new ConnectException(
+                'cURL error 28: Operation timed out',
+                new Request('POST', 'https://api.openai.com/v1/chat/completions'),
+            ),
+        );
+    }
+
+    public function test_sync_confirm_succeeds_and_sends_mail(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        Mail::fake();
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $this->withHeaders(['X-Inertia' => 'true'])
+            ->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertOk();
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::Confirmed, $reservation->status);
+        $this->assertSame(ReservationSource::WebForm, $reservation->source);
+
+        $reply = ReservationReply::withoutGlobalScopes()->sole();
+        $this->assertTrue($reply->sync_confirm);
+        $this->assertSame(ReservationReplyStatus::Sent, $reply->status);
+        $this->assertNotNull($reply->sent_at);
+
+        Mail::assertSent(ReservationReplyMail::class);
+        // The sync path handled everything — the async draft pipeline must not fire.
+        Event::assertNotDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_sync_confirm_renders_the_confirmed_sync_page(): void
+    {
+        Mail::fake();
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            // Second arg false: the Vue page lands in #357; skip the file check.
+            ->assertInertia(fn ($page) => $page
+                ->component('Public/ConfirmedSync', false)
+                ->where('reservation.party_size', 4)
+                ->where('reservation.date', '2026-06-15')
+                ->where('reservation.time', '19:00')
+                ->where('reservation.guest_email_masked', 'a…@gmail.com')
+                ->where('restaurant.name', $this->restaurant->name)
+            );
+    }
+
+    public function test_sync_confirm_creates_a_table_assignment(): void
+    {
+        Mail::fake();
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $this->withHeaders(['X-Inertia' => 'true'])
+            ->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertOk();
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $table = Table::query()->withoutGlobalScopes()->sole();
+
+        $assignment = ReservationTableAssignment::withoutGlobalScopes()->sole();
+        $this->assertSame($reservation->id, $assignment->reservation_request_id);
+        $this->assertSame($table->id, $assignment->table_id);
+        $this->assertNull($assignment->assigned_by_user_id);
+    }
+
+    public function test_sync_confirm_falls_back_on_openai_timeout(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        Mail::fake();
+        $this->fakeOpenAi([$this->timeoutException()]);
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::New, $reservation->status);
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+        $this->assertSame(0, ReservationTableAssignment::withoutGlobalScopes()->count());
+
+        Mail::assertNothingSent();
+        // V1 path must take over so the request still gets an async draft.
+        Event::assertDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_sync_confirm_falls_back_on_smtp_failure(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        // Make the synchronous send throw; the transaction must roll back the
+        // reply + assignment and the controller must fall through to V1.
+        Mail::shouldReceive('to')->andReturnSelf();
+        Mail::shouldReceive('send')->andThrow(new RuntimeException('smtp down'));
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::New, $reservation->status);
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+        $this->assertSame(0, ReservationTableAssignment::withoutGlobalScopes()->count());
+
+        Event::assertDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_two_submits_for_the_same_slot_confirm_only_once(): void
+    {
+        Mail::fake();
+        // Both submits may attempt a sync reply; queue two responses.
+        $this->fakeOpenAi([$this->replyResponse(), $this->replyResponse()]);
+
+        // First submit takes the only table for the slot.
+        $this->withHeaders(['X-Inertia' => 'true'])
+            ->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertOk();
+
+        // Second submit for the same slot can no longer find a free table, so it
+        // falls back to the V1 path (status new). (lockForUpdate is a no-op on
+        // SQLite; the in-transaction re-check is what serialises real bookings.)
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $confirmed = ReservationRequest::withoutGlobalScopes()
+            ->where('status', ReservationStatus::Confirmed)->count();
+        $new = ReservationRequest::withoutGlobalScopes()
+            ->where('status', ReservationStatus::New)->count();
+
+        $this->assertSame(1, $confirmed);
+        $this->assertSame(1, $new);
+        Mail::assertSent(ReservationReplyMail::class, 1);
+    }
+
+    public function test_v1_path_when_sync_confirm_is_disabled_for_the_restaurant(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        Mail::fake();
+        $this->restaurant->update(['web_sync_confirm_enabled' => false]);
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::New, $reservation->status);
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+        Mail::assertNothingSent();
+        Event::assertDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_email_source_request_is_never_sync_confirmed(): void
+    {
+        // An email-ingested request runs the async draft pipeline, never the
+        // sync-confirm path: the resulting reply must not be flagged sync_confirm.
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $request = ReservationRequest::factory()->for($this->restaurant)->create([
+            'source' => ReservationSource::Email,
+            'status' => ReservationStatus::New,
+            'desired_at' => Carbon::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 4,
+        ]);
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $reply = ReservationReply::withoutGlobalScopes()->sole();
+        $this->assertFalse((bool) $reply->sync_confirm);
+        $this->assertSame(0, ReservationTableAssignment::withoutGlobalScopes()->count());
+    }
+}


### PR DESCRIPTION
## Summary

Extends `PublicReservationController@store` with the PRD-014 synchronous confirmation path (additive — the V1 flow is untouched on every fall-through).

On a `web_form` submit, after creating the request:
1. `WebSyncConfirmDecider::decide` — only `proceed` continues.
2. Generate the reply via `OpenAiReplyGenerator::generateSync` **before** the transaction, so the up-to-5 s OpenAI call never holds the table lock. The generator is resolved lazily so a missing/invalid `OPENAI_API_KEY` degrades to V1 (V1 submits never build the OpenAI client — mirrors `GenerateReservationReplyJob`).
3. In a `DB::transaction`: lock the restaurant's active tables, **re-resolve** the table combination inside the lock (race guard vs PRD-012), create the reply (`sync_confirm = true`), assign each table, send the mail non-queued, record the outbound `ReservationMessage` (threading parity with `SendReservationReplyJob`), flip the request to `confirmed` and the reply to `sent`.
4. Render `Public/ConfirmedSync` (date/time/party + masked email).

Any failure — gate skip, OpenAI timeout, lost-table race, SMTP error — rolls the transaction back and falls through to the V1 path (`new`, `ReservationRequestReceived` dispatched), with a PII-free warning log.

### Naming note
PRD/issue reference `PublicForm/ConfirmedSync` and `Submitted`, but the shipped pages live in `resources/js/pages/Public/` and the V1 flow redirects to `public.reservations.thanks` (`Public/Thanks`). I followed the real structure: success renders `Public/ConfirmedSync` (page in #357), fallback keeps the existing redirect.

## Why

PRD-014 § Controller-Erweiterung: confirm free-slot web reservations within the submit latency to lift online conversion, while every non-ideal case stays on the safe V1 review path.

## Test plan

- [x] `php artisan test` — 974 passed (3167 assertions). New `WebSyncConfirmFlowTest`:
  - succeeds + sends mail; renders `Public/ConfirmedSync`; creates the table assignment
  - falls back on OpenAI timeout; falls back on SMTP failure (transaction rolls back)
  - two submits for the same slot confirm only once (in-lock re-check)
  - V1 path when disabled; email-source request is never sync-confirmed
- [x] `./vendor/bin/pint --test` clean
- [x] No routes/JS touched → Ziggy/Vitest unaffected (ConfirmedSync.vue is #357)

Closes #355