### PR TITLE
PRD-014 #356: ReservationReplyMail syncConfirm flag + template line

### DIFF
--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -211,7 +211,7 @@ final class PublicReservationController extends Controller
     private function recordSentReply(ReservationReply $reply, ReservationRequest $reservation): ReservationReplyMail
     {
         $email = (string) $reservation->guest_email;
-        $mail = new ReservationReplyMail($reply);
+        $mail = new ReservationReplyMail($reply, syncConfirm: true);
 
         $fromAddress = (string) (config('mail.from.address') ?: 'noreply@localhost');
         $subject = (string) $mail->envelope()->subject;

--- a/app/Mail/ReservationReplyMail.php
+++ b/app/Mail/ReservationReplyMail.php
@@ -34,8 +34,16 @@ final class ReservationReplyMail extends Mailable
 
     public readonly string $messageId;
 
-    public function __construct(public readonly ReservationReply $reply)
-    {
+    /**
+     * @param  bool  $syncConfirm  true when sent through the PRD-014 web
+     *                             sync-confirm path; surfaces a transparency
+     *                             line in the template (same intent as the
+     *                             PRD-007 auto-send notice).
+     */
+    public function __construct(
+        public readonly ReservationReply $reply,
+        public readonly bool $syncConfirm = false,
+    ) {
         $this->messageId = self::generateMessageId($reply->id);
     }
 
@@ -100,6 +108,7 @@ final class ReservationReplyMail extends Mailable
                 // escaping does not apply — and HTML-escaping inside a
                 // plaintext mail is incorrect by definition.
                 'body' => $this->reply->body,
+                'syncConfirm' => $this->syncConfirm,
             ],
         );
     }

--- a/resources/views/emails/reservation-reply.blade.php
+++ b/resources/views/emails/reservation-reply.blade.php
@@ -1,1 +1,5 @@
+@if ($syncConfirm)
+Diese Bestätigung wurde automatisch erstellt.
+
+@endif
 {!! $body !!}

--- a/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
+++ b/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
@@ -143,7 +143,8 @@ class WebSyncConfirmFlowTest extends TestCase
         $this->assertSame(ReservationReplyStatus::Sent, $reply->status);
         $this->assertNotNull($reply->sent_at);
 
-        Mail::assertSent(ReservationReplyMail::class);
+        // Sent with the sync-confirm transparency flag (#356).
+        Mail::assertSent(ReservationReplyMail::class, fn (ReservationReplyMail $mail): bool => $mail->syncConfirm === true);
         // The sync path handled everything — the async draft pipeline must not fire.
         Event::assertNotDispatched(ReservationRequestReceived::class);
     }

--- a/tests/Feature/Mail/ReservationReplyMailTest.php
+++ b/tests/Feature/Mail/ReservationReplyMailTest.php
@@ -66,6 +66,26 @@ class ReservationReplyMailTest extends TestCase
         $mailable->assertDontSeeInText('&amp;');
     }
 
+    public function test_it_shows_the_automated_line_when_sync_confirm_is_true(): void
+    {
+        $reply = $this->makeReply('Guten Tag, Ihr Tisch ist bestätigt.');
+
+        $mailable = new ReservationReplyMail($reply, syncConfirm: true);
+
+        $mailable->assertSeeInText('Diese Bestätigung wurde automatisch erstellt.');
+        $mailable->assertSeeInText('Guten Tag, Ihr Tisch ist bestätigt.');
+    }
+
+    public function test_it_omits_the_automated_line_by_default(): void
+    {
+        $reply = $this->makeReply('Guten Tag, Ihr Tisch ist bestätigt.');
+
+        $mailable = new ReservationReplyMail($reply);
+
+        $mailable->assertDontSeeInText('automatisch erstellt');
+        $mailable->assertSeeInText('Guten Tag, Ihr Tisch ist bestätigt.');
+    }
+
     public function test_uses_the_application_from_address(): void
     {
         config()->set('mail.from.address', 'no-reply@test.tld');


### PR DESCRIPTION
## Summary

- `ReservationReplyMail` gains an optional `syncConfirm: bool` (default `false`).
- When `true`, the plaintext template prepends "Diese Bestätigung wurde automatisch erstellt." (transparency, same intent as the PRD-007 auto-send notice); when `false`, the template renders exactly as before.
- The #355 web sync-confirm send now passes `syncConfirm: true`.

## Why

PRD-014 § Mailable-Anpassung: a guest receiving an automatically-issued confirmation should be told it was created automatically.

## Test plan

- [x] `php artisan test` — 976 passed (3172 assertions). New mail tests: shows the line when `syncConfirm` true; omits it by default (existing body/threading tests unchanged). `WebSyncConfirmFlowTest` now asserts the sync mail carries `syncConfirm === true`.
- [x] `./vendor/bin/pint --test` clean
- [x] No routes/JS touched → Ziggy/Vitest unaffected

Closes #356