### PR TITLE
PRD-014 #357: Public/ConfirmedSync.vue confirmation page

### DIFF
--- a/resources/js/pages/Public/ConfirmedSync.vue
+++ b/resources/js/pages/Public/ConfirmedSync.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { Head } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    restaurant: {
+        name: string;
+    };
+    reservation: {
+        date: string;
+        time: string;
+        party_size: number;
+        guest_email_masked: string;
+    };
+}>();
+
+// The server sends the date already localised to the restaurant timezone as
+// `YYYY-MM-DD`; reformat to German `DD.MM.YYYY` by string split rather than
+// re-parsing through Date(), which would re-introduce a timezone shift.
+const germanDate = computed(() => {
+    const [year, month, day] = props.reservation.date.split('-');
+
+    return year && month && day ? `${day}.${month}.${year}` : props.reservation.date;
+});
+</script>
+
+<template>
+    <PublicLayout :heading="`Reservierung bei ${restaurant.name} bestätigt`" description="Ihr Tisch ist reserviert – eine Bestätigung ist unterwegs.">
+        <Head :title="`Reservierung bestätigt – ${restaurant.name}`" />
+
+        <dl class="space-y-3 text-sm">
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Datum</dt>
+                <dd class="font-medium">{{ germanDate }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Uhrzeit</dt>
+                <dd class="font-medium">{{ reservation.time }} Uhr</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Personen</dt>
+                <dd class="font-medium">{{ reservation.party_size }}</dd>
+            </div>
+        </dl>
+
+        <p class="mt-6 text-sm text-muted-foreground">Eine Bestätigung haben wir an {{ reservation.guest_email_masked }} geschickt.</p>
+
+        <p class="mt-4 border-t border-border pt-4 text-xs text-muted-foreground">
+            Diese Bestätigung wurde automatisch ausgesprochen, weil Ihr Wunschtermin frei war.
+        </p>
+    </PublicLayout>
+</template>

--- a/resources/js/pages/Public/ConfirmedSync.vue
+++ b/resources/js/pages/Public/ConfirmedSync.vue
@@ -26,7 +26,7 @@ const germanDate = computed(() => {
 </script>
 
 <template>
-    <PublicLayout :heading="`Reservierung bei ${restaurant.name} bestätigt`" description="Ihr Tisch ist reserviert – eine Bestätigung ist unterwegs.">
+    <PublicLayout :heading="`Reservierung bei ${restaurant.name} bestätigt`" description="Ihr Tisch ist reserviert.">
         <Head :title="`Reservierung bestätigt – ${restaurant.name}`" />
 
         <dl class="space-y-3 text-sm">

--- a/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
+++ b/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
@@ -155,9 +155,8 @@ class WebSyncConfirmFlowTest extends TestCase
         $this->fakeOpenAi([$this->replyResponse()]);
 
         $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
-            // Second arg false: the Vue page lands in #357; skip the file check.
             ->assertInertia(fn ($page) => $page
-                ->component('Public/ConfirmedSync', false)
+                ->component('Public/ConfirmedSync')
                 ->where('reservation.party_size', 4)
                 ->where('reservation.date', '2026-06-15')
                 ->where('reservation.time', '19:00')


### PR DESCRIPTION
## Summary

Adds `resources/js/pages/Public/ConfirmedSync.vue`, rendered by the #355 sync-confirm success path.

- Shows the confirmed reservation: date (German `DD.MM.YYYY`), time, party size as plain text.
- Masked guest email (`a…@gmail.com`, masked server-side in #355).
- Footer note explaining the confirmation was issued automatically because the slot was free.
- Uses the non-auth `PublicLayout` (same chrome as `Public/Thanks`).

The date is reformatted by string split rather than `new Date(...)`, so the already-localized server date is not shifted by the browser timezone.

### Naming note
PRD/issue reference `PublicForm/ConfirmedSync`; the shipped public pages live in `resources/js/pages/Public/`, so the page is `Public/ConfirmedSync.vue` (consistent with `Public/Thanks`, `Public/ReservationForm`).

## Why

PRD-014 § Bestätigungsseiten: a guest whose web reservation is confirmed instantly should see a clear confirmation with the booking details, not the generic "request received" page.

## Test plan

- [x] `php artisan test tests/Feature/AutoSend/WebSyncConfirmFlowTest.php` — 8 passed; the render test now verifies the component file exists (skip flag removed).
- [x] `npm run build` (vue-tsc) clean; `npm run lint` clean; `npm run format:check` clean.
- [x] `npm run test` (Vitest) — 112 passed. No Vitest added: presentational page, consistent with `Public/Thanks`/`ReservationForm` (none have Vitest); the props contract is covered by the #355 Inertia feature test.
- [x] No routes added → Ziggy unaffected.

Closes #357