### PR TITLE
PRD-014 #358: web sync-confirm toggle on the SendMode settings page

### DIFF
--- a/app/Http/Controllers/Settings/SendModeSettingsController.php
+++ b/app/Http/Controllers/Settings/SendModeSettingsController.php
@@ -55,6 +55,7 @@ class SendModeSettingsController extends Controller
             'partySizeMax' => $restaurant->auto_send_party_size_max,
             'minLeadTimeMinutes' => $restaurant->auto_send_min_lead_time_minutes,
             'sendModeChangedAt' => $restaurant->send_mode_changed_at?->toIso8601String(),
+            'webSyncConfirmEnabled' => $restaurant->web_sync_confirm_enabled,
             'shadowStats' => $this->shadowStats($restaurant),
         ]);
     }
@@ -82,6 +83,12 @@ class SendModeSettingsController extends Controller
         if ($modeChanged) {
             $payload['send_mode_changed_at'] = now();
             $payload['send_mode_changed_by'] = $user->id;
+        }
+
+        // PRD-014 toggle: only touch the flag when the form sends it, so other
+        // callers of this endpoint leave it untouched.
+        if ($request->has('web_sync_confirm_enabled')) {
+            $payload['web_sync_confirm_enabled'] = $request->boolean('web_sync_confirm_enabled');
         }
 
         $restaurant->update($payload);

--- a/app/Http/Controllers/Settings/SendModeSettingsController.php
+++ b/app/Http/Controllers/Settings/SendModeSettingsController.php
@@ -71,13 +71,14 @@ class SendModeSettingsController extends Controller
 
         Gate::authorize('manageSendMode', $restaurant);
 
-        $newMode = SendMode::from($request->validated('send_mode'));
+        $validated = $request->validated();
+        $newMode = SendMode::from($validated['send_mode']);
         $modeChanged = $restaurant->send_mode !== $newMode;
 
         $payload = [
             'send_mode' => $newMode,
-            'auto_send_party_size_max' => $request->validated('auto_send_party_size_max'),
-            'auto_send_min_lead_time_minutes' => $request->validated('auto_send_min_lead_time_minutes'),
+            'auto_send_party_size_max' => $validated['auto_send_party_size_max'],
+            'auto_send_min_lead_time_minutes' => $validated['auto_send_min_lead_time_minutes'],
         ];
 
         if ($modeChanged) {
@@ -85,10 +86,10 @@ class SendModeSettingsController extends Controller
             $payload['send_mode_changed_by'] = $user->id;
         }
 
-        // PRD-014 toggle: only touch the flag when the form sends it, so other
-        // callers of this endpoint leave it untouched.
-        if ($request->has('web_sync_confirm_enabled')) {
-            $payload['web_sync_confirm_enabled'] = $request->boolean('web_sync_confirm_enabled');
+        // PRD-014 toggle: only touch the flag when the form sends it (the rule
+        // is `sometimes`), so other callers of this endpoint leave it untouched.
+        if (array_key_exists('web_sync_confirm_enabled', $validated)) {
+            $payload['web_sync_confirm_enabled'] = $validated['web_sync_confirm_enabled'];
         }
 
         $restaurant->update($payload);

--- a/app/Http/Requests/Settings/SendModeSettingsUpdateRequest.php
+++ b/app/Http/Requests/Settings/SendModeSettingsUpdateRequest.php
@@ -25,6 +25,10 @@ class SendModeSettingsUpdateRequest extends FormRequest
             'send_mode' => ['required', 'string', Rule::enum(SendMode::class)],
             'auto_send_party_size_max' => ['required', 'integer', 'min:1', 'max:50'],
             'auto_send_min_lead_time_minutes' => ['required', 'integer', 'min:0', 'max:1440'],
+            // PRD-014 web sync-confirm opt-in. Optional so the field can be
+            // added to the shared form without forcing every caller to send it;
+            // the controller only persists it when present.
+            'web_sync_confirm_enabled' => ['sometimes', 'boolean'],
         ];
     }
 }

--- a/resources/js/pages/settings/SendMode.vue
+++ b/resources/js/pages/settings/SendMode.vue
@@ -5,6 +5,7 @@ import { computed, ref } from 'vue';
 import HeadingSmall from '@/components/HeadingSmall.vue';
 import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -27,6 +28,7 @@ interface Props {
     partySizeMax: number;
     minLeadTimeMinutes: number;
     sendModeChangedAt: string | null;
+    webSyncConfirmEnabled: boolean;
     shadowStats: ShadowStats;
 }
 
@@ -38,6 +40,7 @@ const form = useForm({
     send_mode: props.sendMode,
     auto_send_party_size_max: props.partySizeMax,
     auto_send_min_lead_time_minutes: props.minLeadTimeMinutes,
+    web_sync_confirm_enabled: props.webSyncConfirmEnabled,
 });
 
 const pendingMode = ref<SendMode | null>(null);
@@ -177,6 +180,24 @@ const triggerKillswitch = () => {
                         <Label for="min-lead-time"> Mindest-Vorlauf in Minuten </Label>
                         <Input id="min-lead-time" type="number" min="0" max="1440" v-model="form.auto_send_min_lead_time_minutes" />
                         <InputError :message="form.errors.auto_send_min_lead_time_minutes" />
+                    </div>
+
+                    <div class="rounded-lg border border-border p-4 md:col-span-2">
+                        <div class="flex items-center gap-3">
+                            <Checkbox
+                                id="web-sync-confirm-toggle"
+                                :checked="form.web_sync_confirm_enabled"
+                                :disabled="form.processing"
+                                data-testid="web-sync-confirm-toggle"
+                                @update:checked="(value) => (form.web_sync_confirm_enabled = Boolean(value))"
+                            />
+                            <Label for="web-sync-confirm-toggle">Online-Sofort-Bestätigung aktivieren</Label>
+                        </div>
+                        <p class="mt-2 text-sm text-muted-foreground">
+                            Wenn Web-Anfragen einen eindeutig freien Slot treffen, wird die Bestätigung direkt nach dem Absenden versandt. Greift
+                            NICHT bei knappem oder belegtem Slot, bei Gruppen über der Auto-Versand-Grenze oder bei zu kurzem Vorlauf.
+                        </p>
+                        <InputError :message="form.errors.web_sync_confirm_enabled" />
                     </div>
 
                     <div class="md:col-span-2">

--- a/tests/Feature/AutoSend/SendModeSettingsTest.php
+++ b/tests/Feature/AutoSend/SendModeSettingsTest.php
@@ -159,6 +159,95 @@ class SendModeSettingsTest extends TestCase
             ->assertSessionHasErrors('send_mode');
     }
 
+    public function test_it_exposes_web_sync_confirm_enabled_on_the_edit_page(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $restaurant->forceFill(['web_sync_confirm_enabled' => true])->save();
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->get(route('settings.send-mode.edit'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('settings/SendMode')
+                ->where('webSyncConfirmEnabled', true)
+            );
+    }
+
+    public function test_it_allows_owner_to_enable_web_sync_confirm(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $owner = $this->makeOwner($restaurant);
+        $this->assertFalse((bool) $restaurant->fresh()->web_sync_confirm_enabled);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+                'web_sync_confirm_enabled' => true,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertTrue($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
+    public function test_it_allows_owner_to_disable_web_sync_confirm(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $restaurant->forceFill(['web_sync_confirm_enabled' => true])->save();
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+                'web_sync_confirm_enabled' => false,
+            ])
+            ->assertRedirect();
+
+        $this->assertFalse($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
+    public function test_it_forbids_staff_from_enabling_web_sync_confirm(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $staff = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Staff,
+        ]);
+
+        $this->actingAs($staff)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+                'web_sync_confirm_enabled' => true,
+            ])
+            ->assertForbidden();
+
+        $this->assertFalse($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
+    public function test_it_leaves_web_sync_confirm_untouched_when_the_field_is_absent(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $restaurant->forceFill(['web_sync_confirm_enabled' => true])->save();
+        $owner = $this->makeOwner($restaurant);
+
+        // A submit without the toggle field must not silently disable it.
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+            ])
+            ->assertRedirect();
+
+        $this->assertTrue($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
     private function makeRestaurantWithMode(SendMode $mode): Restaurant
     {
         $restaurant = Restaurant::factory()->create();


### PR DESCRIPTION
## Summary

Adds the per-restaurant opt-in for the PRD-014 web sync-confirm path to the existing PRD-007 settings page.

- `resources/js/pages/Settings/SendMode.vue`: a "Online-Sofort-Bestätigung aktivieren" checkbox bound to `web_sync_confirm_enabled`, with the "greift NICHT bei knappem/belegtem Slot, Gruppen über der Grenze, zu kurzem Vorlauf" explainer.
- `SendModeSettingsController`: `edit` exposes `webSyncConfirmEnabled`; `update` persists it.
- `SendModeSettingsUpdateRequest`: validates `web_sync_confirm_enabled` as an optional boolean (`sometimes|boolean`); the controller only writes it when the form sends it, so existing callers of the shared endpoint leave the flag untouched.
- Authorization reuses the owner-only `manageSendMode` policy gate.

### Naming note
PRD-014 §Settings-UI references `Settings/AutoSend.vue`, but the PRD-007 page shipped as `Settings/SendMode.vue` (per the issue note) — the toggle is added there.

## Why

PRD-014 § Settings-UI: the sync-confirm path is opt-in per restaurant; the owner needs a control to enable it, alongside the existing send-mode configuration.

## Test plan

- [x] `php artisan test` — 981 passed (3193 assertions). New SendMode tests: owner can enable/disable; edit page exposes the flag; staff forbidden; the flag is left untouched when the field is absent.
- [x] `npm run build` (vue-tsc) / `npm run lint` / `npm run format:check` clean; `npm run test` (Vitest) 112 passed.
- [x] No routes added → Ziggy unaffected.

Closes #358