### PR TITLE
PRD-015 #359: PII-free gdpr_audits table + model

### DIFF
--- a/app/Models/GdprAudit.php
+++ b/app/Models/GdprAudit.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Append-only, PII-FREE audit row for GDPR self-service actions (PRD-015).
+ *
+ * Records only that an access/erasure action happened in a restaurant and
+ * when — `action` (`view` | `delete` | `owner_bulk_delete`) plus
+ * `restaurant_id` and `created_at`. It deliberately stores no guest email,
+ * reservation id, IP or user-agent: the table proves the *volume* of
+ * requests per restaurant, not *who* did *what*. That separation is what
+ * keeps the audit data itself outside the erasure claim it records.
+ *
+ * Writer pattern mirrors {@see AutoSendAudit}: a single static `record()`,
+ * `$timestamps = false`, no soft-deletes.
+ */
+class GdprAudit extends Model
+{
+    public const string ACTION_VIEW = 'view';
+
+    public const string ACTION_DELETE = 'delete';
+
+    public const string ACTION_OWNER_BULK_DELETE = 'owner_bulk_delete';
+
+    public $timestamps = false;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'action',
+        'restaurant_id',
+        'created_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
+    }
+
+    /**
+     * Single writer for GDPR audit rows. Call sites pass only the action and
+     * the tenant — never any guest-identifying data, by design.
+     */
+    public static function record(string $action, int $restaurantId): self
+    {
+        return self::create([
+            'action' => $action,
+            'restaurant_id' => $restaurantId,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/database/migrations/2026_05_23_000003_create_gdpr_audits_table.php
+++ b/database/migrations/2026_05_23_000003_create_gdpr_audits_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('gdpr_audits', function (Blueprint $table) {
+            $table->id();
+            // view | delete | owner_bulk_delete
+            $table->string('action');
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            // Append-only and deliberately PII-FREE (PRD-015 § Datenmodell):
+            // no guest_email, reservation_id, IP or user-agent — the table
+            // answers "how many access/erasure requests in restaurant X", not
+            // "who did what", so it never falls under the same erasure claim.
+            $table->dateTime('created_at')->useCurrent();
+
+            $table->index(['restaurant_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('gdpr_audits');
+    }
+};

--- a/tests/Feature/Gdpr/GdprAuditTest.php
+++ b/tests/Feature/Gdpr/GdprAuditTest.php
@@ -9,6 +9,7 @@ use App\Models\Restaurant;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class GdprAuditTest extends TestCase
@@ -28,6 +29,29 @@ class GdprAuditTest extends TestCase
         $this->assertTrue(Carbon::parse('2026-05-23 12:00:00')->equalTo($audit->created_at));
 
         Carbon::setTestNow();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function actionProvider(): iterable
+    {
+        yield 'view' => [GdprAudit::ACTION_VIEW];
+        yield 'delete' => [GdprAudit::ACTION_DELETE];
+        yield 'owner_bulk_delete' => [GdprAudit::ACTION_OWNER_BULK_DELETE];
+    }
+
+    #[DataProvider('actionProvider')]
+    public function test_record_persists_each_action_constant(string $action): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        GdprAudit::record($action, $restaurant->id);
+
+        $this->assertDatabaseHas('gdpr_audits', [
+            'action' => $action,
+            'restaurant_id' => $restaurant->id,
+        ]);
     }
 
     public function test_the_table_has_no_pii_columns(): void

--- a/tests/Feature/Gdpr/GdprAuditTest.php
+++ b/tests/Feature/Gdpr/GdprAuditTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Gdpr;
+
+use App\Models\GdprAudit;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class GdprAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_record_writes_a_row_with_action_and_restaurant_only(): void
+    {
+        Carbon::setTestNow('2026-05-23 12:00:00');
+        $restaurant = Restaurant::factory()->create();
+
+        $audit = GdprAudit::record(GdprAudit::ACTION_VIEW, $restaurant->id);
+
+        $this->assertDatabaseCount('gdpr_audits', 1);
+        $this->assertSame(GdprAudit::ACTION_VIEW, $audit->action);
+        $this->assertSame($restaurant->id, $audit->restaurant_id);
+        $this->assertTrue(Carbon::parse('2026-05-23 12:00:00')->equalTo($audit->created_at));
+
+        Carbon::setTestNow();
+    }
+
+    public function test_the_table_has_no_pii_columns(): void
+    {
+        $columns = Schema::getColumnListing('gdpr_audits');
+
+        sort($columns);
+        $this->assertSame(['action', 'created_at', 'id', 'restaurant_id'], $columns);
+
+        // Explicit guard against PII creeping in via a later migration.
+        foreach (['guest_email', 'guest_name', 'guest_phone', 'reservation_id', 'reservation_request_id', 'ip_address', 'user_agent'] as $forbidden) {
+            $this->assertNotContains($forbidden, $columns, "gdpr_audits must not carry the PII column [{$forbidden}].");
+        }
+    }
+
+    public function test_the_table_has_no_updated_at(): void
+    {
+        // Append-only: a row is either written or absent, never updated.
+        $this->assertFalse(Schema::hasColumn('gdpr_audits', 'updated_at'));
+    }
+}


### PR DESCRIPTION
## Summary

The audit foundation for PRD-015 GDPR self-service.

- New `gdpr_audits` table: `id`, `action` (`view` | `delete` | `owner_bulk_delete`), `restaurant_id` (FK, cascade), `created_at`. Append-only (`useCurrent`, no `updated_at`).
- **Deliberately PII-free** — no guest email, reservation id, IP or user-agent. The table proves request *volume* per restaurant, not *who did what*, which keeps the audit data outside the erasure claim it records.
- `App\Models\GdprAudit` with a single static `record(string $action, int $restaurantId)` writer, `$timestamps = false`, action constants.

### Pattern note
Issue #359 sketched a separate injectable `GdprAudit` service "for mocking", but per decision this follows the established codebase audit pattern — a static writer on the model, exactly like `AutoSendAudit::write()` (there is no `app/Services/*Audit*` precedent). Tests assert on the DB row directly (no mocking needed).

## Why

PRD-015 § Datenmodell: every self-service action (view/delete) and the owner bulk-delete must be auditable without storing PII, so the count of access/erasure requests is available (PRD-008) while the audit trail can't itself become subject to erasure.

## Test plan

- [x] `php artisan test` — 984 passed (3206 assertions). New `GdprAuditTest`: `record` writes action+restaurant+created_at only; the table column list is exactly `{id, action, restaurant_id, created_at}` with explicit guards against PII columns; no `updated_at`.
- [x] `php artisan migrate` up + `migrate:rollback` down both clean; `migrate:fresh` clean.
- [x] `./vendor/bin/pint --test` clean. No routes/JS → Ziggy/Vitest unaffected.

Closes #359