### PR TITLE
PRD-015 #361: signed GDPR self-service show endpoint

### DIFF
--- a/app/Http/Controllers/GdprSelfServiceController.php
+++ b/app/Http/Controllers/GdprSelfServiceController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\GdprAudit;
+use App\Models\ReservationRequest;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Public, login-less GDPR self-service (PRD-015, Art. 15 + 17). Every route
+ * is `signed`: the link in each confirmation mail carries a 30-day signature
+ * tied to the specific reservation id, so there is no auth user and no
+ * cross-tenant exposure — a signature for restaurant A's reservation cannot
+ * be replayed against restaurant B's id.
+ *
+ * Each action records a PII-free {@see GdprAudit} row (the only trace kept);
+ * guest data itself is never logged.
+ */
+final class GdprSelfServiceController extends Controller
+{
+    public function show(ReservationRequest $reservation): Response
+    {
+        GdprAudit::record(GdprAudit::ACTION_VIEW, $reservation->restaurant_id);
+
+        return Inertia::render('Public/GdprSelfService', [
+            'reservation' => [
+                'guest_name' => $reservation->guest_name,
+                'guest_email' => $reservation->guest_email,
+                'guest_phone' => $reservation->guest_phone,
+                'party_size' => $reservation->party_size,
+                'status' => $reservation->status->value,
+                'note' => $reservation->note,
+                'desired_at' => $reservation->desired_at?->toIso8601String(),
+                'created_at' => $reservation->created_at?->toIso8601String(),
+            ],
+            'restaurant' => [
+                'name' => $reservation->restaurant->name,
+                'timezone' => $reservation->restaurant->timezone,
+            ],
+        ]);
+    }
+}

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -92,6 +92,13 @@ declare module 'ziggy-js' {
             "binding": "slug"
         }
     ],
+    "gdpr.self-service": [
+        {
+            "name": "reservation",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "profile.edit": [],
     "profile.update": [],
     "profile.destroy": [],

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ExportController;
+use App\Http\Controllers\GdprSelfServiceController;
 use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\QuickReservationController;
 use App\Http\Controllers\ReservationMessagesController;
@@ -107,6 +108,13 @@ Route::post('r/{restaurant:slug}/reservations', [PublicReservationController::cl
 
 Route::get('r/{restaurant:slug}/reservations/thanks', [PublicReservationController::class, 'thanks'])
     ->name('public.reservations.thanks');
+
+// Public, login-less GDPR self-service (PRD-015). Signed link from the
+// confirmation mail; the signature is the only guard (no auth, scoped by id).
+Route::get('gdpr/{reservation}', [GdprSelfServiceController::class, 'show'])
+    ->whereNumber('reservation')
+    ->middleware('signed')
+    ->name('gdpr.self-service');
 
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';

--- a/tests/Feature/Gdpr/GdprSelfServiceTest.php
+++ b/tests/Feature/Gdpr/GdprSelfServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Gdpr;
+
+use App\Models\GdprAudit;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class GdprSelfServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function reservation(Restaurant $restaurant, array $overrides = []): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($restaurant)->create(array_merge([
+            'guest_name' => 'Anna Müller',
+            'guest_email' => 'anna@gmail.com',
+        ], $overrides));
+    }
+
+    private function signedShowUrl(ReservationRequest $reservation, ?Carbon $expiresAt = null): string
+    {
+        return URL::temporarySignedRoute(
+            'gdpr.self-service',
+            $expiresAt ?? now()->addDays(30),
+            ['reservation' => $reservation->id],
+        );
+    }
+
+    public function test_it_renders_self_service_page_with_a_valid_token(): void
+    {
+        $restaurant = Restaurant::factory()->create(['name' => 'La Trattoria']);
+        $reservation = $this->reservation($restaurant, ['party_size' => 4]);
+
+        $this->get($this->signedShowUrl($reservation))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Public/GdprSelfService', false)
+                ->where('reservation.guest_name', 'Anna Müller')
+                ->where('reservation.guest_email', 'anna@gmail.com')
+                ->where('reservation.party_size', 4)
+                ->where('restaurant.name', 'La Trattoria')
+            );
+    }
+
+    public function test_it_returns_403_without_a_signature(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant);
+
+        $this->get(route('gdpr.self-service', ['reservation' => $reservation->id]))
+            ->assertForbidden();
+    }
+
+    public function test_it_returns_403_with_an_expired_signature(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant);
+
+        $url = $this->signedShowUrl($reservation, now()->subMinute());
+
+        $this->get($url)->assertForbidden();
+    }
+
+    public function test_it_records_a_view_audit_without_pii(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant);
+
+        $this->get($this->signedShowUrl($reservation))->assertOk();
+
+        $this->assertDatabaseCount('gdpr_audits', 1);
+        $audit = GdprAudit::query()->sole();
+        $this->assertSame(GdprAudit::ACTION_VIEW, $audit->action);
+        $this->assertSame($restaurant->id, $audit->restaurant_id);
+        // The audit row carries no PII by schema; guard the serialized row too.
+        $this->assertStringNotContainsString('anna@gmail.com', json_encode($audit->getAttributes(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_a_signature_for_one_reservation_does_not_resolve_another(): void
+    {
+        $restaurantA = Restaurant::factory()->create();
+        $restaurantB = Restaurant::factory()->create();
+        $reservationA = $this->reservation($restaurantA);
+        $reservationB = $this->reservation($restaurantB);
+
+        // Take A's valid signature and swap in B's id: the signature no longer
+        // matches the URL, so cross-tenant access is rejected.
+        $signedForA = $this->signedShowUrl($reservationA);
+        $tampered = str_replace(
+            '/gdpr/'.$reservationA->id.'?',
+            '/gdpr/'.$reservationB->id.'?',
+            $signedForA,
+        );
+
+        $this->get($tampered)->assertForbidden();
+    }
+
+    public function test_it_does_not_log_pii_on_show(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant, ['guest_email' => 'leak-check@gmail.com']);
+
+        $captured = [];
+        Log::listen(function ($message) use (&$captured): void {
+            $captured[] = json_encode([$message->message, $message->context], JSON_THROW_ON_ERROR);
+        });
+
+        $this->get($this->signedShowUrl($reservation))->assertOk();
+
+        $this->assertStringNotContainsString('leak-check@gmail.com', implode("\n", $captured));
+        $this->assertStringNotContainsString('Anna Müller', implode("\n", $captured));
+    }
+}


### PR DESCRIPTION
## Summary

- New public route `GET /gdpr/{reservation}` (`gdpr.self-service`, `signed` middleware, numeric id).
- `GdprSelfServiceController@show`: records a PII-free `view` audit (`GdprAudit::record`), renders `Public/GdprSelfService` with the reservation data + restaurant name/timezone.
- The 30-day signature is tied to the reservation id — no auth user; a signature for restaurant A's reservation cannot resolve restaurant B's id (cross-tenant guard is the signature itself).
- Ziggy types regenerated for the new route.

### Scope notes
- The 15-min **delete token** is added to `show` in **#362** (it needs the delete route, which #362 registers). #361's `show` renders the data view only.
- `Public/GdprSelfService.vue` lands in **#363**; the render test uses `assertInertia(->component('Public/GdprSelfService', false))` until then.
- Expired/invalid signature returns a plain 403 (Laravel `signed`). The friendly "Link abgelaufen" page is a UX follow-up (would need custom exception rendering in `bootstrap/app.php`); the tests assert the 403.

## Why

PRD-015 § Routing/Controller: guests must be able to see their stored data (Art. 15) via a signed, login-less link from the confirmation mail.

## Test plan

- [x] `php artisan test` — 993 passed (3238 assertions). New `GdprSelfServiceTest`: renders with a valid token; 403 without/with-expired signature; records a PII-free view audit; a signature for one reservation does not resolve another (cross-tenant); does not log PII on show.
- [x] `./vendor/bin/pint --test`, `npm run format:check`, `npm run build` clean.
- [x] `php artisan ziggy:generate --types-only` run; `ziggy.d.ts` committed (CI ziggy-drift).

Closes #361