### PR TITLE
PRD-015 #360: HasGdprLink trait + reply mail footer

### DIFF
--- a/app/Mail/Concerns/HasGdprLink.php
+++ b/app/Mail/Concerns/HasGdprLink.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail\Concerns;
+
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Central generator for the GDPR self-service link (PRD-015) so no outbound
+ * mailable forgets the Art. 15/17 footer. Every mailable that reaches a guest
+ * (PRD-005 manual reply, PRD-007 auto-send, PRD-014 sync-confirm) uses this.
+ *
+ * The link is produced at render time, so each send carries a fresh 30-day
+ * signature — a guest replying within an active thread always gets a live
+ * link rather than an expired one.
+ */
+trait HasGdprLink
+{
+    private const int GDPR_LINK_TTL_DAYS = 30;
+
+    /**
+     * A 30-day signed `gdpr.self-service` URL for the given reservation request.
+     */
+    protected function gdprLink(int $reservationId): string
+    {
+        return URL::temporarySignedRoute(
+            'gdpr.self-service',
+            now()->addDays(self::GDPR_LINK_TTL_DAYS),
+            ['reservation' => $reservationId],
+        );
+    }
+}

--- a/app/Mail/ReservationReplyMail.php
+++ b/app/Mail/ReservationReplyMail.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Mail;
 
 use App\Enums\MessageDirection;
+use App\Mail\Concerns\HasGdprLink;
 use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use Illuminate\Bus\Queueable;
@@ -29,6 +30,7 @@ use Illuminate\Queue\SerializesModels;
  */
 final class ReservationReplyMail extends Mailable
 {
+    use HasGdprLink;
     use Queueable;
     use SerializesModels;
 
@@ -109,6 +111,8 @@ final class ReservationReplyMail extends Mailable
                 // plaintext mail is incorrect by definition.
                 'body' => $this->reply->body,
                 'syncConfirm' => $this->syncConfirm,
+                // Generated per send so each mail carries a live 30-day link.
+                'gdprLink' => $this->gdprLink($this->reply->reservation_request_id),
             ],
         );
     }

--- a/resources/views/emails/reservation-reply.blade.php
+++ b/resources/views/emails/reservation-reply.blade.php
@@ -3,3 +3,8 @@ Diese Bestätigung wurde automatisch erstellt.
 
 @endif
 {!! $body !!}
+
+─────────────────────────────────────────────
+Datenschutz: Welche Daten haben wir von dir?
+Hier ansehen oder löschen → {!! $gdprLink !!}
+─────────────────────────────────────────────

--- a/tests/Feature/Mail/ReservationReplyMailGdprLinkTest.php
+++ b/tests/Feature/Mail/ReservationReplyMailGdprLinkTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mail;
+
+use App\Enums\ReservationReplyStatus;
+use App\Mail\ReservationReplyMail;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationReplyMailGdprLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeReply(): ReservationReply
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Approved,
+            'body' => 'Guten Tag, gerne!',
+        ]);
+    }
+
+    public function test_it_includes_the_gdpr_link_in_the_body(): void
+    {
+        $reply = $this->makeReply();
+
+        $mailable = new ReservationReplyMail($reply);
+
+        $mailable->assertSeeInText('Datenschutz: Welche Daten haben wir von dir?');
+        $mailable->assertSeeInText('/gdpr/'.$reply->reservation_request_id);
+    }
+
+    public function test_the_link_is_signed_and_the_route_resolves(): void
+    {
+        $reply = $this->makeReply();
+
+        $rendered = (new ReservationReplyMail($reply))->render();
+
+        $this->assertSame(
+            1,
+            preg_match('#https?://\S+/gdpr/\d+\?[^\s<"]+#', $rendered, $matches),
+            'A signed GDPR link should appear in the rendered mail.'
+        );
+
+        // The extracted signed URL must resolve (valid signature → 200, not 403).
+        $this->get($matches[0])->assertOk();
+    }
+
+    public function test_the_link_targets_the_reservation_request(): void
+    {
+        $reply = $this->makeReply();
+
+        $rendered = (new ReservationReplyMail($reply))->render();
+        preg_match('#/gdpr/(\d+)\?#', $rendered, $matches);
+
+        $this->assertSame($reply->reservation_request_id, (int) $matches[1]);
+    }
+}


### PR DESCRIPTION
## Summary

- New `App\Mail\Concerns\HasGdprLink` trait: a central generator for a 30-day signed `gdpr.self-service` URL, so no mailable forgets the Art. 15/17 footer.
- `ReservationReplyMail` uses the trait and embeds the link as a plaintext footer ("Datenschutz: Welche Daten haben wir von dir? … → <link>"). It applies to all three send paths (PRD-005 / PRD-007 / PRD-014) since they all use this mailable.
- The link is generated at `content()` time → every send carries a fresh full-30-day signature (active threads never hit an expired link).
- Rendered raw (`{!! $gdprLink !!}`) so the URL's query-string `&` survives in the plaintext mail (framework-generated URL, no user input).

## Why

PRD-015 § Signed-URL-Strategie / § Erweiterung der Mailables: every confirmation mail must surface a visible self-service link; centralising generation in a trait prevents a compliance gap if a path forgets it.

## Test plan

- [x] `php artisan test` — 996 passed (3243 assertions). New `ReservationReplyMailGdprLinkTest`: link appears in the body; the rendered signed URL resolves (GET → 200, valid signature); the link targets the reservation request id. Existing mail/threading/sync-confirm tests still green (footer is additive).
- [x] `./vendor/bin/pint --test` clean. No routes/JS → Ziggy/Vitest unaffected.

Closes #360