### PR TITLE
PRD-015 #363: public GdprSelfService + GdprDeleted pages

### DIFF
--- a/resources/js/pages/Public/GdprDeleted.vue
+++ b/resources/js/pages/Public/GdprDeleted.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { Head } from '@inertiajs/vue3';
+
+defineProps<{
+    restaurant: {
+        name: string;
+    };
+}>();
+</script>
+
+<template>
+    <PublicLayout heading="Deine Daten wurden gelöscht" description="Die Löschung ist abgeschlossen.">
+        <Head title="Daten gelöscht" />
+
+        <p class="text-sm text-muted-foreground">Wir haben alle gespeicherten Daten zu deiner Reservierung bei {{ restaurant.name }} entfernt.</p>
+    </PublicLayout>
+</template>

--- a/resources/js/pages/Public/GdprSelfService.vue
+++ b/resources/js/pages/Public/GdprSelfService.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { formatDateTime } from '@/lib/format-datetime';
+import { Head, useForm } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    reservation: {
+        guest_name: string;
+        guest_email: string;
+        guest_phone: string | null;
+        party_size: number;
+        status: string;
+        note: string | null;
+        desired_at: string | null;
+        created_at: string | null;
+    };
+    restaurant: {
+        name: string;
+        timezone: string;
+    };
+    deleteToken: string;
+}>();
+
+const STATUS_LABELS: Record<string, string> = {
+    new: 'Neu',
+    in_review: 'In Prüfung',
+    replied: 'Beantwortet',
+    confirmed: 'Bestätigt',
+    declined: 'Abgelehnt',
+    waitlisted: 'Warteliste',
+};
+
+const statusLabel = computed(() => STATUS_LABELS[props.reservation.status] ?? props.reservation.status);
+
+const localDateTime = (iso: string | null): string => (iso ? formatDateTime(iso, { timeZone: props.restaurant.timezone }) : '–');
+
+const desiredAt = computed(() => localDateTime(props.reservation.desired_at));
+const createdAt = computed(() => localDateTime(props.reservation.created_at));
+
+const form = useForm({ confirm_date: '' });
+
+const submitDelete = () => {
+    // Posts to the short-lived signed delete URL issued by the show endpoint.
+    form.post(props.deleteToken, { preserveScroll: true });
+};
+</script>
+
+<template>
+    <PublicLayout
+        :heading="`Deine Daten beim Restaurant ${restaurant.name}`"
+        description="Hier siehst du alle Daten, die wir zu deiner Reservierung gespeichert haben."
+    >
+        <Head title="Datenschutz – Deine Daten" />
+
+        <dl class="space-y-3 text-sm">
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Reservierung am</dt>
+                <dd class="font-medium">{{ desiredAt }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Personen</dt>
+                <dd class="font-medium">{{ reservation.party_size }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Status</dt>
+                <dd class="font-medium">{{ statusLabel }}</dd>
+            </div>
+        </dl>
+
+        <h2 class="mb-3 mt-6 text-sm font-semibold">Persönliche Daten</h2>
+        <dl class="space-y-3 text-sm">
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Name</dt>
+                <dd class="font-medium">{{ reservation.guest_name }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">E-Mail</dt>
+                <dd class="font-medium">{{ reservation.guest_email }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Telefon</dt>
+                <dd class="font-medium">{{ reservation.guest_phone ?? '–' }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Anmerkung</dt>
+                <dd class="font-medium">{{ reservation.note ?? '–' }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Eingegangen am</dt>
+                <dd class="font-medium">{{ createdAt }}</dd>
+            </div>
+        </dl>
+
+        <form class="mt-8 rounded-lg border border-destructive/40 p-4" @submit.prevent="submitDelete">
+            <h2 class="text-sm font-semibold text-destructive">Daten löschen</h2>
+            <p class="mt-1 text-sm text-muted-foreground">
+                Bitte bestätige durch Eingabe des Reservierungs-Datums (TT.MM.JJJJ). Anschließend werden alle gespeicherten Daten zu dieser
+                Reservierung unwiderruflich gelöscht.
+            </p>
+            <div class="mt-3 grid gap-2">
+                <Label for="confirm-date" class="sr-only">Reservierungs-Datum</Label>
+                <Input id="confirm-date" v-model="form.confirm_date" placeholder="TT.MM.JJJJ" autocomplete="off" class="max-w-40" />
+                <InputError :message="form.errors.confirm_date" />
+            </div>
+            <Button type="submit" variant="destructive" class="mt-3" :disabled="form.processing"> Löschen bestätigen </Button>
+        </form>
+    </PublicLayout>
+</template>

--- a/tests/Feature/Gdpr/GdprDeleteTest.php
+++ b/tests/Feature/Gdpr/GdprDeleteTest.php
@@ -64,7 +64,7 @@ class GdprDeleteTest extends TestCase
         $this->get($showUrl)
             ->assertOk()
             ->assertInertia(fn ($page) => $page
-                ->component('Public/GdprSelfService', false)
+                ->component('Public/GdprSelfService')
                 ->where('deleteToken', fn (string $token): bool => str_contains($token, '/gdpr/'.$reservation->id.'/delete')
                     && str_contains($token, 'signature='))
             );
@@ -96,7 +96,12 @@ class GdprDeleteTest extends TestCase
 
         $this->post($this->signedDeleteUrl($reservation), [
             'confirm_date' => $this->expectedConfirmDate($reservation),
-        ])->assertOk();
+        ])
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Public/GdprDeleted')
+                ->where('restaurant.name', $this->restaurant->name)
+            );
 
         $this->assertDatabaseMissing('reservation_requests', ['id' => $reservation->id]);
         $this->assertDatabaseMissing('reservation_replies', ['reservation_request_id' => $reservation->id]);

--- a/tests/Feature/Gdpr/GdprSelfServiceTest.php
+++ b/tests/Feature/Gdpr/GdprSelfServiceTest.php
@@ -42,7 +42,7 @@ class GdprSelfServiceTest extends TestCase
         $this->get($this->signedShowUrl($reservation))
             ->assertOk()
             ->assertInertia(fn ($page) => $page
-                ->component('Public/GdprSelfService', false)
+                ->component('Public/GdprSelfService')
                 ->where('reservation.guest_name', 'Anna Müller')
                 ->where('reservation.guest_email', 'anna@gmail.com')
                 ->where('reservation.party_size', 4)


### PR DESCRIPTION
## Summary

The two public Inertia pages for GDPR self-service (no auth layout — `PublicLayout`, like `Public/Thanks`):

- `Public/GdprSelfService.vue`: reservation summary + personal data (timestamps via `formatDateTime` in the restaurant timezone; status shown with a German label), plus a delete-confirm box (date input `TT.MM.JJJJ`) that posts to the short-lived signed delete token from `show`.
- `Public/GdprDeleted.vue`: the post-deletion success message with the restaurant name.

Now that the pages exist, the #361/#362 feature tests verify the component files (dropped `component(…, false)`), and the delete test additionally asserts the `Public/GdprDeleted` component renders.

### Naming note
PRD references `Public/GdprSelfService` / `Public/GdprDeleted` and the controllers already render those names; pages live under `resources/js/pages/Public/` per the shipped convention.

## Why

PRD-015 § Public-Inertia-Seite: a visible, login-less data view + erasure confirm for the guest.

## Test plan

- [x] `php artisan test` — 1004 passed (3289 assertions); GDPR feature tests now assert both component files exist.
- [x] `npm run lint`, `npm run format:check`, `npm run build` (vue-tsc) clean; `npm run test` (Vitest) 112 passed.
- [x] No Vitest added: presentational pages, consistent with the other `Public/*` pages; the props/render and the delete interaction are covered by the #361/#362 server-side feature tests.
- [x] No routes → Ziggy unaffected.

Closes #363