### PR TITLE
PRD-015 #364: owner GDPR bulk-delete by email

### DIFF
--- a/app/Http/Controllers/ReservationRequestController.php
+++ b/app/Http/Controllers/ReservationRequestController.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Enums\ReservationStatus;
+use App\Http\Requests\BulkGdprDeleteRequest;
 use App\Http\Requests\BulkStatusRequest;
+use App\Models\GdprAudit;
 use App\Models\ReservationRequest;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
 final class ReservationRequestController extends Controller
@@ -75,5 +79,42 @@ final class ReservationRequestController extends Controller
             'updated' => $updated,
             'skipped' => array_values($skipped),
         ]);
+    }
+
+    /**
+     * GDPR Art. 17 owner bulk-delete (PRD-015): hard-delete every reservation
+     * with the given guest email — plus its messages, replies and table
+     * assignments — in one transaction, and write a single PII-free
+     * `owner_bulk_delete` audit row.
+     *
+     * Matching is on the EXACT email (not the dashboard's name-or-email LIKE
+     * search) so an erasure request never sweeps up an unrelated guest. Tenant
+     * scope is the global RestaurantScope (authenticated owner), so only the
+     * owner's own restaurant is touched; authorization is the `manage` policy
+     * enforced in {@see BulkGdprDeleteRequest}.
+     */
+    public function bulkGdprDelete(BulkGdprDeleteRequest $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $restaurantId = $user->restaurant_id;
+        $email = $request->validated('email');
+
+        $reservations = ReservationRequest::query()
+            ->where('guest_email', $email)
+            ->get();
+
+        DB::transaction(function () use ($reservations): void {
+            foreach ($reservations as $reservation) {
+                $reservation->messages()->delete();
+                $reservation->replies()->delete();
+                $reservation->tableAssignments()->delete();
+                $reservation->delete();
+            }
+        });
+
+        GdprAudit::record(GdprAudit::ACTION_OWNER_BULK_DELETE, $restaurantId);
+
+        return back()->with('success', $reservations->count().' Reservierung(en) DSGVO-konform gelöscht.');
     }
 }

--- a/app/Http/Requests/BulkGdprDeleteRequest.php
+++ b/app/Http/Requests/BulkGdprDeleteRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Owner-only dashboard GDPR bulk-delete by email (PRD-015 § Dashboard-Bulk-Delete).
+ * Authorization is the `manage` policy on the user's own restaurant — owners
+ * only, staff get a 403 (deletion is destructive and Art. 17 is owner-driven
+ * here). Tenant scope on the actual delete comes from the global RestaurantScope.
+ */
+class BulkGdprDeleteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $restaurant = $this->user()?->restaurant;
+
+        return $restaurant !== null && Gate::allows('manage', $restaurant);
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'max:190'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'email.required' => 'Bitte eine E-Mail-Adresse angeben.',
+        ];
+    }
+}

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import DashboardExportDropdown from '@/components/DashboardExportDropdown.vue';
+import InputError from '@/components/InputError.vue';
 import ReservationThreadHistory from '@/components/ReservationThreadHistory.vue';
 import WaitlistBanner from '@/components/WaitlistBanner.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -29,7 +31,7 @@ import {
     type SharedData,
     type ThreadMessage,
 } from '@/types';
-import { Head, Link, router, usePage } from '@inertiajs/vue3';
+import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
 import { ChevronDown, Info, Phone } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 
@@ -53,6 +55,7 @@ const breadcrumbs: BreadcrumbItem[] = [{ title: 'Dashboard', href: '/dashboard' 
 const page = usePage<SharedData>();
 const restaurantName = computed(() => page.props.restaurant?.name ?? '');
 const restaurantTimezone = computed(() => page.props.restaurant?.timezone);
+const isOwner = computed(() => page.props.auth.user.role === 'owner');
 
 // PRD-007 mode banner. Shows yellow for shadow (test mode, no risk to
 // guests yet) and red for auto (mail flows without operator approval),
@@ -167,6 +170,27 @@ function toggleSource(value: ReservationSource) {
 
 function submitSearch() {
     applyFilter({ q: search.value });
+}
+
+// GDPR Art. 17 owner bulk-delete by exact email (PRD-015).
+const gdprDeleteOpen = ref(false);
+const gdprDeleteForm = useForm({ email: '' });
+
+function openGdprDelete() {
+    gdprDeleteForm.clearErrors();
+    // Prefill from the current search term when it looks like an email.
+    gdprDeleteForm.email = search.value.includes('@') ? search.value.trim() : '';
+    gdprDeleteOpen.value = true;
+}
+
+function submitGdprDelete() {
+    gdprDeleteForm.post(route('reservations.bulk-delete'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            gdprDeleteOpen.value = false;
+            gdprDeleteForm.reset();
+        },
+    });
 }
 
 function commitDateRange() {
@@ -641,6 +665,17 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                     <Button v-if="hasActiveFilters" type="button" variant="ghost" class="h-9" data-testid="filter-clear" @click="clearAllFilters">
                         Filter zurücksetzen
                     </Button>
+
+                    <Button
+                        v-if="isOwner"
+                        type="button"
+                        variant="ghost"
+                        class="h-9 text-destructive hover:text-destructive"
+                        data-testid="gdpr-bulk-delete-open"
+                        @click="openGdprDelete"
+                    >
+                        DSGVO-Löschung
+                    </Button>
                 </div>
             </section>
 
@@ -1027,5 +1062,41 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                 </template>
             </SheetContent>
         </Sheet>
+
+        <Dialog v-model:open="gdprDeleteOpen">
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Daten DSGVO-konform löschen</DialogTitle>
+                    <DialogDescription>
+                        Alle Reservierungen mit dieser E-Mail-Adresse – samt Nachrichten, Antworten und Tisch-Zuordnungen – werden unwiderruflich
+                        gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <form class="grid gap-2" @submit.prevent="submitGdprDelete">
+                    <Input
+                        v-model="gdprDeleteForm.email"
+                        type="email"
+                        placeholder="gast@example.com"
+                        autocomplete="off"
+                        data-testid="gdpr-bulk-delete-email"
+                    />
+                    <InputError :message="gdprDeleteForm.errors.email" />
+                </form>
+
+                <DialogFooter>
+                    <Button type="button" variant="ghost" @click="gdprDeleteOpen = false">Abbrechen</Button>
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        data-testid="gdpr-bulk-delete-confirm"
+                        :disabled="gdprDeleteForm.processing || gdprDeleteForm.email.length === 0"
+                        @click="submitGdprDelete"
+                    >
+                        Endgültig löschen
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     </AppLayout>
 </template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -26,6 +26,7 @@ declare module 'ziggy-js' {
         }
     ],
     "reservations.bulk-status": [],
+    "reservations.bulk-delete": [],
     "reservation-replies.approve": [
         {
             "name": "reply",

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,11 @@ Route::post('reservations/bulk-status', [ReservationRequestController::class, 'b
     ->middleware(['auth', 'verified'])
     ->name('reservations.bulk-status');
 
+// Owner-only GDPR bulk-delete by email (PRD-015); authorization in the request.
+Route::post('reservations/bulk-delete', [ReservationRequestController::class, 'bulkGdprDelete'])
+    ->middleware(['auth', 'verified'])
+    ->name('reservations.bulk-delete');
+
 Route::post('reservation-replies/{reply}/approve', [ReservationReplyController::class, 'approve'])
     ->middleware(['auth', 'verified', 'can:approve,reply'])
     ->name('reservation-replies.approve');

--- a/tests/Feature/Dashboard/DashboardBulkDeleteTest.php
+++ b/tests/Feature/Dashboard/DashboardBulkDeleteTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Dashboard;
+
+use App\Enums\UserRole;
+use App\Models\GdprAudit;
+use App\Models\ReservationMessage;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardBulkDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->restaurant = Restaurant::factory()->create();
+    }
+
+    private function owner(): User
+    {
+        return User::factory()->create(['restaurant_id' => $this->restaurant->id, 'role' => UserRole::Owner]);
+    }
+
+    private function staff(): User
+    {
+        return User::factory()->create(['restaurant_id' => $this->restaurant->id, 'role' => UserRole::Staff]);
+    }
+
+    public function test_owner_can_bulk_delete_email_matches_with_related_records(): void
+    {
+        $match = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+        ReservationReply::factory()->create(['reservation_request_id' => $match->id]);
+        ReservationMessage::factory()->create(['reservation_request_id' => $match->id]);
+        $table = Table::factory()->for($this->restaurant)->create();
+        ReservationTableAssignment::factory()->for($match, 'reservationRequest')->for($table)->create();
+
+        $other = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'someone-else@gmail.com']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseMissing('reservation_requests', ['id' => $match->id]);
+        $this->assertDatabaseMissing('reservation_replies', ['reservation_request_id' => $match->id]);
+        $this->assertDatabaseMissing('reservation_messages', ['reservation_request_id' => $match->id]);
+        $this->assertDatabaseMissing('reservation_table_assignments', ['reservation_request_id' => $match->id]);
+
+        // A non-matching email is untouched.
+        $this->assertDatabaseHas('reservation_requests', ['id' => $other->id]);
+    }
+
+    public function test_match_is_on_exact_email_not_a_substring(): void
+    {
+        $exact = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'anna@gmail.com']);
+        $similar = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'anna@gmail.community.org']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'anna@gmail.com'])
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('reservation_requests', ['id' => $exact->id]);
+        $this->assertDatabaseHas('reservation_requests', ['id' => $similar->id]);
+    }
+
+    public function test_service_user_cannot_bulk_delete(): void
+    {
+        $reservation = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+
+        $this->actingAs($this->staff())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('reservation_requests', ['id' => $reservation->id]);
+        $this->assertSame(0, GdprAudit::query()->count());
+    }
+
+    public function test_bulk_delete_writes_an_owner_audit_entry_without_pii(): void
+    {
+        ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertRedirect();
+
+        $audit = GdprAudit::query()->sole();
+        $this->assertSame(GdprAudit::ACTION_OWNER_BULK_DELETE, $audit->action);
+        $this->assertSame($this->restaurant->id, $audit->restaurant_id);
+        $this->assertStringNotContainsString('gast@gmail.com', json_encode($audit->getAttributes(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_bulk_delete_does_not_cross_the_tenant_boundary(): void
+    {
+        $otherRestaurant = Restaurant::factory()->create();
+        $foreign = ReservationRequest::factory()->for($otherRestaurant)->create(['guest_email' => 'gast@gmail.com']);
+        $own = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertRedirect();
+
+        // Same email in another restaurant is never touched.
+        $this->assertDatabaseHas('reservation_requests', ['id' => $foreign->id]);
+        $this->assertDatabaseMissing('reservation_requests', ['id' => $own->id]);
+
+        // The audit is scoped to the acting owner's restaurant.
+        $audit = GdprAudit::query()->sole();
+        $this->assertSame($this->restaurant->id, $audit->restaurant_id);
+    }
+
+    public function test_email_is_required(): void
+    {
+        $this->actingAs($this->owner())
+            ->from('/dashboard')
+            ->post(route('reservations.bulk-delete'), [])
+            ->assertRedirect('/dashboard')
+            ->assertSessionHasErrors('email');
+    }
+}


### PR DESCRIPTION
## Summary

- New `POST /reservations/bulk-delete` (`reservations.bulk-delete`), owner-only via `BulkGdprDeleteRequest::authorize` (`manage` policy → staff 403).
- `ReservationRequestController@bulkGdprDelete`: hard-deletes every reservation with the **exact** guest email — plus messages, replies, table assignments — in one transaction; writes a single PII-free `owner_bulk_delete` audit.
- **Exact email match** (not the dashboard's name-or-email LIKE `q` search) so an Art. 17 erasure never sweeps up an unrelated guest. Tenant scope is the global `RestaurantScope` (authenticated owner) → only the owner's restaurant is touched.
- `Dashboard.vue`: owner-only "DSGVO-Löschung" button + confirm dialog (email prefilled from the current search when it looks like an email). PII-free success flash (count only).
- Ziggy types regenerated.

## Why

PRD-015 § Dashboard-Bulk-Delete: owners need a visible way to fulfil an Art. 17 erasure request for a guest across all their reservations.

## Test plan

- [x] `php artisan test` — 1010 passed (3314 assertions). New `DashboardBulkDeleteTest`: owner can bulk-delete email matches + related records; exact-email (not substring) matching; staff 403; PII-free owner audit; no cross-tenant deletion; email required.
- [x] `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check`, `npm run build` clean; `npm run test` (Vitest) 112 passed.
- [x] `ziggy:generate --types-only` run + committed (CI ziggy-drift).

Closes #364