### PR TITLE
Release: V3 backlog — manual entry, waitlist, sync-confirm, GDPR self-service (PRD-012–015)

### DIFF
--- a/app/Enums/ReservationSource.php
+++ b/app/Enums/ReservationSource.php
@@ -6,4 +6,6 @@ enum ReservationSource: string
 {
     case WebForm = 'web_form';
     case Email = 'email';
+    case Phone = 'phone';
+    case WalkIn = 'walk_in';
 }

--- a/app/Enums/ReservationStatus.php
+++ b/app/Enums/ReservationStatus.php
@@ -10,6 +10,7 @@ enum ReservationStatus: string
     case Confirmed = 'confirmed';
     case Declined = 'declined';
     case Cancelled = 'cancelled';
+    case Waitlisted = 'waitlisted';
 
     /**
      * @return list<self>
@@ -17,10 +18,11 @@ enum ReservationStatus: string
     public function allowedNextStates(): array
     {
         return match ($this) {
-            self::New => [self::InReview, self::Declined],
-            self::InReview => [self::Replied, self::Declined],
+            self::New => [self::InReview, self::Declined, self::Waitlisted],
+            self::InReview => [self::Replied, self::Declined, self::Waitlisted],
             self::Replied => [self::Confirmed, self::Cancelled],
             self::Confirmed => [self::Cancelled],
+            self::Waitlisted => [self::Confirmed, self::Declined],
             self::Declined, self::Cancelled => [],
         };
     }

--- a/app/Exceptions/AI/OpenAiTimeoutException.php
+++ b/app/Exceptions/AI/OpenAiTimeoutException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\AI;
+
+use RuntimeException;
+use Throwable;
+
+/**
+ * Signals that the synchronous reply generation (PRD-014 web sync-confirm)
+ * exceeded its hard timeout budget or otherwise failed transport-side.
+ *
+ * The sync path runs inside the public submit latency, so the caller
+ * catches this and falls back to the V1 path (`status = new`, normal
+ * owner review) instead of surfacing a UI error. Unlike the async
+ * `generate`, the sync path never returns the neutral fallback text — a
+ * confirmation must always carry a real AI reply.
+ *
+ * The originating transport exception is chained as `$previous` so the
+ * underlying cURL/Guzzle detail stays available for debugging (it is
+ * never logged with the API key).
+ */
+final class OpenAiTimeoutException extends RuntimeException
+{
+    public function __construct(string $message = 'OpenAI sync reply generation timed out.', ?Throwable $previous = null)
+    {
+        parent::__construct($message, 0, $previous);
+    }
+}

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -11,6 +11,7 @@ use App\Http\Resources\ReservationMessageResource;
 use App\Http\Resources\ReservationRequestDetailResource;
 use App\Http\Resources\ReservationRequestResource;
 use App\Models\ReservationRequest;
+use App\Services\Waitlist\WaitlistBanner;
 use App\Support\OpenAiKeyHealth;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -20,10 +21,11 @@ use Inertia\Response;
 
 final class DashboardController extends Controller
 {
-    public function index(DashboardFilterRequest $request): Response
+    public function index(DashboardFilterRequest $request, WaitlistBanner $waitlistBanner): Response
     {
         $validated = $request->validated();
         $selectedId = isset($validated['selected']) ? (int) $validated['selected'] : null;
+        $restaurantId = $request->user()?->restaurant_id;
 
         $filterQuery = Arr::except($request->query(), ['selected']);
         $filters = $filterQuery === []
@@ -48,6 +50,14 @@ final class DashboardController extends Controller
                     ->where('status', ReservationStatus::InReview)
                     ->count(),
             ],
+            // PRD-013: waitlisted reservations whose slot is free again, so the
+            // dashboard can prompt the owner to pull a waiting guest in. Loaded
+            // with the page and refreshed by the existing poll (the frontend adds
+            // it to the reload's `only` set). A plain array (resolve) so the page
+            // can use it directly. Empty when the user has no restaurant.
+            'waitlistBanner' => $restaurantId === null
+                ? []
+                : ReservationRequestResource::collection($waitlistBanner->eligibleNow($restaurantId))->resolve($request),
             'selectedRequest' => fn () => $this->resolveSelected($selectedId, $request),
             'threadMessages' => fn () => $this->resolveThreadMessages($selectedId, $request),
             // Owner-only banner. The flag is global (V1.0 has one OpenAI key

--- a/app/Http/Controllers/GdprSelfServiceController.php
+++ b/app/Http/Controllers/GdprSelfServiceController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\GdprAudit;
+use App\Models\ReservationRequest;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Public, login-less GDPR self-service (PRD-015, Art. 15 + 17). Every route
+ * is `signed`: the link in each confirmation mail carries a 30-day signature
+ * tied to the specific reservation id, so there is no auth user and no
+ * cross-tenant exposure — a signature for restaurant A's reservation cannot
+ * be replayed against restaurant B's id.
+ *
+ * Each action records a PII-free {@see GdprAudit} row (the only trace kept);
+ * guest data itself is never logged.
+ */
+final class GdprSelfServiceController extends Controller
+{
+    public function show(ReservationRequest $reservation): Response
+    {
+        GdprAudit::record(GdprAudit::ACTION_VIEW, $reservation->restaurant_id);
+
+        return Inertia::render('Public/GdprSelfService', [
+            'reservation' => [
+                'guest_name' => $reservation->guest_name,
+                'guest_email' => $reservation->guest_email,
+                'guest_phone' => $reservation->guest_phone,
+                'party_size' => $reservation->party_size,
+                'status' => $reservation->status->value,
+                'note' => $reservation->note,
+                'desired_at' => $reservation->desired_at?->toIso8601String(),
+                'created_at' => $reservation->created_at?->toIso8601String(),
+            ],
+            'restaurant' => [
+                'name' => $reservation->restaurant->name,
+                'timezone' => $reservation->restaurant->timezone,
+            ],
+        ]);
+    }
+}

--- a/app/Http/Controllers/GdprSelfServiceController.php
+++ b/app/Http/Controllers/GdprSelfServiceController.php
@@ -4,8 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\GdprDeleteRequest;
 use App\Models\GdprAudit;
 use App\Models\ReservationRequest;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\URL;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -21,6 +26,9 @@ use Inertia\Response;
  */
 final class GdprSelfServiceController extends Controller
 {
+    /** Short confirm window for the destructive delete step (PRD-015). */
+    private const int DELETE_TOKEN_TTL_MINUTES = 15;
+
     public function show(ReservationRequest $reservation): Response
     {
         GdprAudit::record(GdprAudit::ACTION_VIEW, $reservation->restaurant_id);
@@ -40,6 +48,61 @@ final class GdprSelfServiceController extends Controller
                 'name' => $reservation->restaurant->name,
                 'timezone' => $reservation->restaurant->timezone,
             ],
+            // Short-lived signed token for the confirm step — a deliberately
+            // tighter window than the 30-day view link.
+            'deleteToken' => URL::temporarySignedRoute(
+                'gdpr.self-service.delete',
+                now()->addMinutes(self::DELETE_TOKEN_TTL_MINUTES),
+                ['reservation' => $reservation->id],
+            ),
         ]);
+    }
+
+    public function delete(GdprDeleteRequest $request, ReservationRequest $reservation): Response|RedirectResponse
+    {
+        // Anti-bot confirm: the typed date must equal the reservation date (in
+        // the restaurant's timezone — the date the guest actually booked, and
+        // the one the page shows them).
+        $expected = $this->expectedConfirmDate($reservation);
+        if ($expected === null || $request->validated('confirm_date') !== $expected) {
+            return back()->withErrors([
+                'confirm_date' => 'Das eingegebene Datum stimmt nicht mit der Reservierung überein.',
+            ]);
+        }
+
+        // Capture tenant context before the row is gone (no PII is kept).
+        $restaurantId = $reservation->restaurant_id;
+        $restaurantName = $reservation->restaurant->name;
+
+        DB::transaction(function () use ($reservation): void {
+            $reservation->messages()->delete();
+            $reservation->replies()->delete();
+            $reservation->tableAssignments()->delete();
+            $reservation->delete();
+        });
+
+        GdprAudit::record(GdprAudit::ACTION_DELETE, $restaurantId);
+
+        return Inertia::render('Public/GdprDeleted', [
+            'restaurant' => [
+                'name' => $restaurantName,
+            ],
+        ]);
+    }
+
+    /**
+     * The reservation date the guest must type to confirm deletion, in the
+     * restaurant timezone (`d.m.Y`). Null when the reservation has no desired
+     * time — confirmation then cannot match, so the data is left untouched.
+     */
+    private function expectedConfirmDate(ReservationRequest $reservation): ?string
+    {
+        if ($reservation->desired_at === null) {
+            return null;
+        }
+
+        return CarbonImmutable::instance($reservation->desired_at)
+            ->setTimezone($reservation->restaurant->timezone)
+            ->format('d.m.Y');
     }
 }

--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -211,7 +211,7 @@ final class PublicReservationController extends Controller
     private function recordSentReply(ReservationReply $reply, ReservationRequest $reservation): ReservationReplyMail
     {
         $email = (string) $reservation->guest_email;
-        $mail = new ReservationReplyMail($reply);
+        $mail = new ReservationReplyMail($reply, syncConfirm: true);
 
         $fromAddress = (string) (config('mail.from.address') ?: 'noreply@localhost');
         $subject = (string) $mail->envelope()->subject;

--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -4,19 +4,43 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\MessageDirection;
+use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationSource;
 use App\Enums\ReservationStatus;
 use App\Events\ReservationRequestReceived;
 use App\Http\Requests\StoreReservationRequest;
+use App\Jobs\SendReservationReplyJob;
+use App\Mail\ReservationReplyMail;
+use App\Models\ReservationMessage;
+use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
 use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\AI\OpenAiReplyGenerator;
+use App\Services\AI\ReservationContextBuilder;
+use App\Services\AutoSend\WebSyncConfirmDecider;
+use App\Services\Availability\SlotAvailability;
 use App\Support\Timezone;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
 use Inertia\Inertia;
 use Inertia\Response;
+use Psr\Log\LoggerInterface;
+use Throwable;
 
 final class PublicReservationController extends Controller
 {
+    public function __construct(
+        private readonly WebSyncConfirmDecider $decider,
+        private readonly ReservationContextBuilder $contextBuilder,
+        private readonly SlotAvailability $availability,
+        private readonly LoggerInterface $logger,
+    ) {}
+
     public function create(Restaurant $restaurant): Response
     {
         return Inertia::render('Public/ReservationForm', [
@@ -29,7 +53,7 @@ final class PublicReservationController extends Controller
         ]);
     }
 
-    public function store(StoreReservationRequest $request, Restaurant $restaurant): RedirectResponse
+    public function store(StoreReservationRequest $request, Restaurant $restaurant): RedirectResponse|Response
     {
         if ($request->filled('website')) {
             return redirect()->route('public.reservations.thanks', $restaurant);
@@ -50,6 +74,17 @@ final class PublicReservationController extends Controller
             'raw_payload' => $validated,
         ]);
 
+        // PRD-014: only web-form submissions are eligible for the synchronous
+        // confirmation; email/phone reservations run their own pipelines.
+        if ($reservationRequest->source === ReservationSource::WebForm) {
+            $confirmation = $this->attemptSyncConfirm($reservationRequest, $restaurant);
+
+            if ($confirmation !== null) {
+                return $confirmation;
+            }
+        }
+
+        // V1 path: hand the request to the async draft pipeline for owner review.
         ReservationRequestReceived::dispatch($reservationRequest);
 
         return redirect()->route('public.reservations.thanks', $restaurant);
@@ -62,5 +97,176 @@ final class PublicReservationController extends Controller
                 'name' => $restaurant->name,
             ],
         ]);
+    }
+
+    /**
+     * Try to confirm the reservation synchronously (PRD-014). Returns the
+     * confirmation page on success, or null to signal the caller to fall back
+     * to the V1 path. Any failure — gate skip, OpenAI timeout, lost table
+     * race, SMTP error — resolves to null without surfacing a UI error.
+     */
+    private function attemptSyncConfirm(ReservationRequest $reservation, Restaurant $restaurant): ?Response
+    {
+        if (! $this->decider->decide($reservation)->shouldProceed()) {
+            return null;
+        }
+
+        try {
+            // Generate the reply BEFORE the transaction so the up-to-5s OpenAI
+            // call never holds the table lock. generateSync throws rather than
+            // returning the neutral fallback, so a confirmation always carries
+            // a real reply. The generator is resolved here (not constructor-
+            // injected) so a missing/invalid OPENAI_API_KEY is caught by this
+            // try-block and degrades to the V1 path — V1 submits never build the
+            // OpenAI client (the same late-resolution trick as
+            // GenerateReservationReplyJob).
+            $context = $this->contextBuilder->build($reservation);
+            $body = app(OpenAiReplyGenerator::class)->generateSync($context);
+
+            $confirmed = DB::transaction(function () use ($reservation, $context, $body): bool {
+                // Serialize concurrent bookings for this restaurant's slot. The
+                // route restaurant (not an authenticated tenant) scopes the lock;
+                // RestaurantScope no-ops without a user. lockForUpdate is a no-op
+                // on SQLite, so the in-lock re-check below is what actually
+                // rejects a slot taken since the decider ran (race vs PRD-012).
+                Table::query()
+                    ->where('restaurant_id', $reservation->restaurant_id)
+                    ->where('active', true)
+                    ->lockForUpdate()
+                    ->get();
+
+                $combination = $this->availability->suggestTableCombination(
+                    $reservation->restaurant_id,
+                    CarbonImmutable::instance($reservation->desired_at),
+                    $reservation->party_size,
+                );
+
+                if ($combination === null) {
+                    return false;
+                }
+
+                $reply = ReservationReply::create([
+                    'reservation_request_id' => $reservation->id,
+                    'status' => ReservationReplyStatus::Draft,
+                    'body' => $body,
+                    'ai_prompt_snapshot' => $context + [
+                        'original_body' => $body,
+                        'model' => (string) config('reservations.ai.openai_model', 'gpt-4o-mini'),
+                        'fallback' => false,
+                    ],
+                    'sync_confirm' => true,
+                ]);
+
+                foreach ($combination->tableIds as $tableId) {
+                    ReservationTableAssignment::create([
+                        'reservation_request_id' => $reservation->id,
+                        'table_id' => $tableId,
+                        'assigned_at' => now(),
+                        'assigned_by_user_id' => null,
+                    ]);
+                }
+
+                // Persist every DB side-effect (outbound message, reply -> sent,
+                // request -> confirmed) FIRST, then physically send as the very
+                // last step. forceFill bypasses the manual new->… state machine,
+                // exactly as SendReservationReplyJob does for the auto pipeline.
+                $mail = $this->recordSentReply($reply, $reservation);
+                $reservation->forceFill(['status' => ReservationStatus::Confirmed])->save();
+
+                // Non-queued send LAST so an SMTP failure rolls back the whole
+                // confirmation and the request stays `new` for V1 (PRD-014). The
+                // only residual window is a commit failure after a successful
+                // send — the irreducible DB+mail dual-write, and vanishingly rare.
+                Mail::to((string) $reservation->guest_email)->send($mail);
+
+                return true;
+            });
+        } catch (Throwable $e) {
+            // Class only — never guest data or mail content (PRD-014).
+            $this->logger->warning('web sync confirm failed, falling back to v1 path', [
+                'reservation_request_id' => $reservation->id,
+                'reason' => $e::class,
+            ]);
+
+            return null;
+        }
+
+        if (! $confirmed) {
+            return null;
+        }
+
+        // Rendered AFTER the committed transaction and outside the try, so a
+        // formatting error here surfaces as an error rather than silently
+        // falling through to V1 and double-confirming an already-mailed guest.
+        return $this->renderConfirmation($reservation, $restaurant);
+    }
+
+    /**
+     * Record the outbound message and flag the reply as sent, then return the
+     * Mailable for the caller to dispatch. The outbound-message bookkeeping
+     * mirrors {@see SendReservationReplyJob} so threading (PRD-006) and the
+     * drawer history stay consistent; the parent request transition differs
+     * (sync-confirm -> confirmed, not replied) and is the caller's job.
+     */
+    private function recordSentReply(ReservationReply $reply, ReservationRequest $reservation): ReservationReplyMail
+    {
+        $email = (string) $reservation->guest_email;
+        $mail = new ReservationReplyMail($reply);
+
+        $fromAddress = (string) (config('mail.from.address') ?: 'noreply@localhost');
+        $subject = (string) $mail->envelope()->subject;
+
+        ReservationMessage::create([
+            'reservation_request_id' => $reply->reservation_request_id,
+            'direction' => MessageDirection::Out,
+            'message_id' => $mail->messageId,
+            'subject' => $subject,
+            'from_address' => $fromAddress,
+            'to_address' => $email,
+            'body_plain' => $reply->body,
+            'raw_headers' => "Message-ID: <{$mail->messageId}>\nFrom: {$fromAddress}\nTo: {$email}\nSubject: {$subject}",
+            'sent_at' => now(),
+        ]);
+
+        $reply->forceFill([
+            'status' => ReservationReplyStatus::Sent,
+            'sent_at' => now(),
+            'outbound_message_id' => $mail->messageId,
+        ])->save();
+
+        return $mail;
+    }
+
+    private function renderConfirmation(ReservationRequest $reservation, Restaurant $restaurant): Response
+    {
+        $localDesiredAt = CarbonImmutable::instance($reservation->desired_at)
+            ->setTimezone($restaurant->timezone);
+
+        return Inertia::render('Public/ConfirmedSync', [
+            'restaurant' => [
+                'name' => $restaurant->name,
+            ],
+            'reservation' => [
+                'date' => $localDesiredAt->format('Y-m-d'),
+                'time' => $localDesiredAt->format('H:i'),
+                'party_size' => $reservation->party_size,
+                'guest_email_masked' => $this->maskEmail((string) $reservation->guest_email),
+            ],
+        ]);
+    }
+
+    /**
+     * Mask a guest email for the public confirmation page: first character of
+     * the local part, then the full domain (e.g. `a…@gmail.com`).
+     */
+    private function maskEmail(string $email): string
+    {
+        $at = strpos($email, '@');
+
+        if ($at === false || $at === 0) {
+            return $email;
+        }
+
+        return $email[0].'…@'.substr($email, $at + 1);
     }
 }

--- a/app/Http/Controllers/QuickReservationController.php
+++ b/app/Http/Controllers/QuickReservationController.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Http\Requests\QuickReservationCreateRequest;
+use App\Http\Resources\TableResource;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use App\Services\Availability\SlotAvailability;
+use Carbon\CarbonImmutable;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Quick phone/walk-in reservation entry (PRD-012). This controller serves the
+ * read path: it renders the keyboard-first form and, on every date/time/party
+ * change, recomputes a deterministic availability verdict via
+ * {@see SlotAvailability::forSlot}. The store path lives in #343.
+ *
+ * The operator works in the restaurant's local time, so smart defaults and the
+ * `defaults` prop are local, while `forSlot` receives the UTC instant it expects
+ * (matching how reservations store `desired_at`). The controller stays a thin
+ * Inertia adapter — availability is the service's job, authorization is the
+ * route's `can:viewAny,Table` gate (TablePolicy, which also rejects a user
+ * without a restaurant, like the tables.availability endpoint), and tenant scope
+ * comes from the Table model's global RestaurantScope.
+ */
+final class QuickReservationController extends Controller
+{
+    private const int DEFAULT_PARTY_SIZE = 2;
+
+    public function __construct(
+        private readonly SlotAvailability $availability,
+    ) {}
+
+    public function create(QuickReservationCreateRequest $request): Response
+    {
+        $user = $request->user();
+        $restaurant = $user->restaurant;
+        $validated = $request->validated();
+
+        // The operator types local time; default to "now, rounded up to the next
+        // 30 minutes, plus an hour" so the form opens on a plausible near slot.
+        // date and time default independently so a partially supplied query never
+        // silently drops the field that was given (the live preview sends both).
+        $base = CarbonImmutable::now($restaurant->timezone)->ceilMinutes(30)->addHour();
+        $local = CarbonImmutable::parse(
+            ($validated['date'] ?? $base->format('Y-m-d')).' '.($validated['time'] ?? $base->format('H:i')),
+            $restaurant->timezone,
+        );
+
+        $partySize = (int) ($validated['party_size'] ?? self::DEFAULT_PARTY_SIZE);
+
+        $availability = $this->availability->forSlot(
+            $user->restaurant_id,
+            $local->utc(),
+            $partySize,
+        );
+
+        $tables = Table::query()
+            ->where('active', true)
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+
+        return Inertia::render('Reservations/Quick', [
+            'tables' => TableResource::collection($tables),
+            'defaults' => [
+                'date' => $local->format('Y-m-d'),
+                'time' => $local->format('H:i'),
+                'party_size' => $partySize,
+            ],
+            'availability' => $this->presentAvailability($availability, $restaurant),
+        ]);
+    }
+
+    /**
+     * Shape the availability verdict for the status banner. The suggested table
+     * (or two-table combination) is referenced by id so the page can resolve the
+     * label from the `tables` prop; alternative slots are rendered in the
+     * restaurant timezone as date+time so a click can refill both fields.
+     *
+     * @return array<string, mixed>
+     */
+    private function presentAvailability(SlotAvailabilityResult $result, Restaurant $restaurant): array
+    {
+        return [
+            'state' => $result->state->value,
+            'suggested_table_id' => $result->suggestedTableId,
+            'combination' => $result->combination === null ? null : [
+                'primary_table_id' => $result->combination->primaryTableId,
+                'table_ids' => $result->combination->tableIds,
+                'total_seats' => $result->combination->totalSeats,
+            ],
+            'alternative_slots' => $result->alternativeSlots
+                ->map(fn (CarbonImmutable $candidate): array => [
+                    'date' => $candidate->setTimezone($restaurant->timezone)->format('Y-m-d'),
+                    'time' => $candidate->setTimezone($restaurant->timezone)->format('H:i'),
+                ])
+                ->values()
+                ->all(),
+        ];
+    }
+}

--- a/app/Http/Controllers/QuickReservationController.php
+++ b/app/Http/Controllers/QuickReservationController.php
@@ -4,29 +4,40 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers;
 
+use App\Enums\ReservationStatus;
 use App\Http\Requests\QuickReservationCreateRequest;
+use App\Http\Requests\QuickReservationStoreRequest;
 use App\Http\Resources\TableResource;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
 use App\Models\Restaurant;
 use App\Models\Table;
 use App\Services\Availability\DTOs\SlotAvailabilityResult;
 use App\Services\Availability\SlotAvailability;
+use App\Support\Timezone;
 use Carbon\CarbonImmutable;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
 /**
- * Quick phone/walk-in reservation entry (PRD-012). This controller serves the
- * read path: it renders the keyboard-first form and, on every date/time/party
- * change, recomputes a deterministic availability verdict via
- * {@see SlotAvailability::forSlot}. The store path lives in #343.
+ * Quick phone/walk-in reservation entry (PRD-012).
+ *
+ * `create` is the read path: it renders the keyboard-first form and, on every
+ * date/time/party change, recomputes a deterministic availability verdict via
+ * {@see SlotAvailability::forSlot}. `store` persists the reservation directly as
+ * `confirmed` (the owner has already confirmed verbally) with an auto-assigned
+ * table — no AI reply, no mail.
  *
  * The operator works in the restaurant's local time, so smart defaults and the
- * `defaults` prop are local, while `forSlot` receives the UTC instant it expects
- * (matching how reservations store `desired_at`). The controller stays a thin
- * Inertia adapter — availability is the service's job, authorization is the
- * route's `can:viewAny,Table` gate (TablePolicy, which also rejects a user
- * without a restaurant, like the tables.availability endpoint), and tenant scope
- * comes from the Table model's global RestaurantScope.
+ * `defaults` prop are local, while the availability service receives the UTC
+ * instant it expects (matching how reservations store `desired_at`). The
+ * controller stays a thin Inertia adapter — availability is the service's job,
+ * authorization is the route's `can:viewAny,Table` gate (TablePolicy, which also
+ * rejects a user without a restaurant, like the tables.availability endpoint),
+ * and tenant scope comes from the Table model's global RestaurantScope.
  */
 final class QuickReservationController extends Controller
 {
@@ -75,6 +86,103 @@ final class QuickReservationController extends Controller
             ],
             'availability' => $this->presentAvailability($availability, $restaurant),
         ]);
+    }
+
+    public function store(QuickReservationStoreRequest $request): RedirectResponse
+    {
+        $user = $request->user();
+        $restaurant = $user->restaurant;
+        $validated = $request->validated();
+
+        // Shared helper (used by the public reservation path too) parses the
+        // operator's local input and returns the UTC instant reservations store.
+        $datetime = Timezone::localToUtc(
+            "{$validated['date']} {$validated['time']}",
+            $restaurant->timezone,
+        )->toImmutable();
+
+        DB::transaction(function () use ($user, $validated, $datetime): void {
+            // Serialize concurrent bookings for this slot: a SELECT ... FOR UPDATE
+            // on the restaurant's active tables makes a second request block until
+            // this one commits, after which its in-lock availability re-check sees
+            // the assignment just written. (lockForUpdate is a no-op on SQLite but
+            // protects the production MySQL/Postgres path.) Tenant scope is the
+            // Table model's global RestaurantScope.
+            Table::query()
+                ->where('active', true)
+                ->lockForUpdate()
+                ->get();
+
+            $tableIds = $this->resolveTableIds($user->restaurant_id, $datetime, $validated);
+
+            $reservation = ReservationRequest::create([
+                'restaurant_id' => $user->restaurant_id,
+                'source' => $validated['source'],
+                'status' => ReservationStatus::Confirmed,
+                'guest_name' => $validated['guest_name'],
+                'guest_phone' => $validated['guest_phone'] ?? null,
+                'guest_email' => $validated['guest_email'] ?? null,
+                'party_size' => $validated['party_size'],
+                'desired_at' => $datetime,
+                'note' => $validated['note'] ?? null,
+                'created_by_user_id' => $user->id,
+            ]);
+
+            foreach ($tableIds as $tableId) {
+                ReservationTableAssignment::create([
+                    'reservation_request_id' => $reservation->id,
+                    'table_id' => $tableId,
+                    'assigned_at' => now(),
+                    'assigned_by_user_id' => $user->id,
+                ]);
+            }
+        });
+
+        return redirect()->route('dashboard')->with('success', 'Reservierung gespeichert.');
+    }
+
+    /**
+     * Resolve the table(s) to assign. A manual `table_id` is honoured — yielding
+     * exactly that one table — as long as it is actually free in the slot (the
+     * operator may deliberately seat a regular at a specific table). Otherwise
+     * the smallest fitting single table or two-table combination is auto-assigned;
+     * a combination returns one id per table so both are marked occupied (the M:N
+     * schema, PRD-011) — assigning only the primary would leave the second table
+     * double-bookable. Throws when the chosen table is busy or no table fits,
+     * surfacing a clear message instead of a silent failure.
+     *
+     * @param  array<string, mixed>  $validated
+     * @return list<int>
+     */
+    private function resolveTableIds(int $restaurantId, CarbonImmutable $datetime, array $validated): array
+    {
+        if (isset($validated['table_id'])) {
+            $tableId = (int) $validated['table_id'];
+
+            $isFree = $this->availability
+                ->freeTablesAt($restaurantId, $datetime)
+                ->pluck('id')
+                ->contains($tableId);
+
+            if (! $isFree) {
+                throw ValidationException::withMessages([
+                    'table_id' => 'Dieser Tisch ist im gewählten Zeitfenster bereits belegt.',
+                ]);
+            }
+
+            return [$tableId];
+        }
+
+        $combination = $this->availability
+            ->suggestTableCombination($restaurantId, $datetime, (int) $validated['party_size']);
+
+        if ($combination === null) {
+            throw ValidationException::withMessages([
+                'table_id' => 'Kein passender Tisch verfügbar. Bitte anderen Slot wählen.',
+            ]);
+        }
+
+        return $combination->tableIds;
     }
 
     /**

--- a/app/Http/Controllers/ReservationRequestController.php
+++ b/app/Http/Controllers/ReservationRequestController.php
@@ -5,9 +5,13 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Enums\ReservationStatus;
+use App\Http\Requests\BulkGdprDeleteRequest;
 use App\Http\Requests\BulkStatusRequest;
+use App\Models\GdprAudit;
 use App\Models\ReservationRequest;
+use App\Models\User;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 
 final class ReservationRequestController extends Controller
@@ -75,5 +79,42 @@ final class ReservationRequestController extends Controller
             'updated' => $updated,
             'skipped' => array_values($skipped),
         ]);
+    }
+
+    /**
+     * GDPR Art. 17 owner bulk-delete (PRD-015): hard-delete every reservation
+     * with the given guest email — plus its messages, replies and table
+     * assignments — in one transaction, and write a single PII-free
+     * `owner_bulk_delete` audit row.
+     *
+     * Matching is on the EXACT email (not the dashboard's name-or-email LIKE
+     * search) so an erasure request never sweeps up an unrelated guest. Tenant
+     * scope is the global RestaurantScope (authenticated owner), so only the
+     * owner's own restaurant is touched; authorization is the `manage` policy
+     * enforced in {@see BulkGdprDeleteRequest}.
+     */
+    public function bulkGdprDelete(BulkGdprDeleteRequest $request): RedirectResponse
+    {
+        /** @var User $user */
+        $user = $request->user();
+        $restaurantId = $user->restaurant_id;
+        $email = $request->validated('email');
+
+        $reservations = ReservationRequest::query()
+            ->where('guest_email', $email)
+            ->get();
+
+        DB::transaction(function () use ($reservations): void {
+            foreach ($reservations as $reservation) {
+                $reservation->messages()->delete();
+                $reservation->replies()->delete();
+                $reservation->tableAssignments()->delete();
+                $reservation->delete();
+            }
+        });
+
+        GdprAudit::record(GdprAudit::ACTION_OWNER_BULK_DELETE, $restaurantId);
+
+        return back()->with('success', $reservations->count().' Reservierung(en) DSGVO-konform gelöscht.');
     }
 }

--- a/app/Http/Controllers/Settings/SendModeSettingsController.php
+++ b/app/Http/Controllers/Settings/SendModeSettingsController.php
@@ -55,6 +55,7 @@ class SendModeSettingsController extends Controller
             'partySizeMax' => $restaurant->auto_send_party_size_max,
             'minLeadTimeMinutes' => $restaurant->auto_send_min_lead_time_minutes,
             'sendModeChangedAt' => $restaurant->send_mode_changed_at?->toIso8601String(),
+            'webSyncConfirmEnabled' => $restaurant->web_sync_confirm_enabled,
             'shadowStats' => $this->shadowStats($restaurant),
         ]);
     }
@@ -70,18 +71,25 @@ class SendModeSettingsController extends Controller
 
         Gate::authorize('manageSendMode', $restaurant);
 
-        $newMode = SendMode::from($request->validated('send_mode'));
+        $validated = $request->validated();
+        $newMode = SendMode::from($validated['send_mode']);
         $modeChanged = $restaurant->send_mode !== $newMode;
 
         $payload = [
             'send_mode' => $newMode,
-            'auto_send_party_size_max' => $request->validated('auto_send_party_size_max'),
-            'auto_send_min_lead_time_minutes' => $request->validated('auto_send_min_lead_time_minutes'),
+            'auto_send_party_size_max' => $validated['auto_send_party_size_max'],
+            'auto_send_min_lead_time_minutes' => $validated['auto_send_min_lead_time_minutes'],
         ];
 
         if ($modeChanged) {
             $payload['send_mode_changed_at'] = now();
             $payload['send_mode_changed_by'] = $user->id;
+        }
+
+        // PRD-014 toggle: only touch the flag when the form sends it (the rule
+        // is `sometimes`), so other callers of this endpoint leave it untouched.
+        if (array_key_exists('web_sync_confirm_enabled', $validated)) {
+            $payload['web_sync_confirm_enabled'] = $validated['web_sync_confirm_enabled'];
         }
 
         $restaurant->update($payload);

--- a/app/Http/Requests/BulkGdprDeleteRequest.php
+++ b/app/Http/Requests/BulkGdprDeleteRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Gate;
+
+/**
+ * Owner-only dashboard GDPR bulk-delete by email (PRD-015 § Dashboard-Bulk-Delete).
+ * Authorization is the `manage` policy on the user's own restaurant — owners
+ * only, staff get a 403 (deletion is destructive and Art. 17 is owner-driven
+ * here). Tenant scope on the actual delete comes from the global RestaurantScope.
+ */
+class BulkGdprDeleteRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $restaurant = $this->user()?->restaurant;
+
+        return $restaurant !== null && Gate::allows('manage', $restaurant);
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'string', 'max:190'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'email.required' => 'Bitte eine E-Mail-Adresse angeben.',
+        ];
+    }
+}

--- a/app/Http/Requests/GdprDeleteRequest.php
+++ b/app/Http/Requests/GdprDeleteRequest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the GDPR self-service delete confirmation (PRD-015). Authorization
+ * is the route's `signed` middleware; the anti-bot check (the typed date must
+ * equal the reservation date) lives in the controller, which has the
+ * reservation in scope.
+ */
+class GdprDeleteRequest extends FormRequest
+{
+    /**
+     * @return array<string, ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'confirm_date' => ['required', 'string'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'confirm_date.required' => 'Bitte bestätige durch Eingabe des Reservierungs-Datums.',
+        ];
+    }
+}

--- a/app/Http/Requests/QuickReservationCreateRequest.php
+++ b/app/Http/Requests/QuickReservationCreateRequest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\ReservationRequest;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the optional date/time/party_size query parameters that drive the
+ * live availability preview on the quick-entry form (PRD-012). All three are
+ * nullable: opening the page with no parameters falls back to the controller's
+ * smart defaults. Authorization is the route's `auth`/`verified` middleware; the
+ * tenant scope comes from the authenticated user's restaurant, so there is no
+ * model binding to guard here. Past-date rejection is enforced authoritatively
+ * on the store path (#343), not on this read path.
+ */
+class QuickReservationCreateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'date' => ['nullable', 'date_format:Y-m-d'],
+            'time' => ['nullable', 'date_format:H:i'],
+            'party_size' => ['nullable', 'integer', 'min:1', 'max:'.ReservationRequest::MAX_PARTY_SIZE],
+        ];
+    }
+}

--- a/app/Http/Requests/QuickReservationStoreRequest.php
+++ b/app/Http/Requests/QuickReservationStoreRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests;
+
+use App\Models\ReservationRequest;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Validates a manual phone/walk-in reservation submission (PRD-012).
+ * Authorization is the route's `can:viewAny,Table` gate (same operator
+ * capability as the create form). `table_id` is constrained to an active table
+ * of the acting user's own restaurant, so a client-supplied id can never point
+ * at a foreign or inactive table.
+ */
+class QuickReservationStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'source' => ['required', 'in:phone,walk_in'],
+            'date' => ['required', 'date_format:Y-m-d', 'after_or_equal:today'],
+            'time' => ['required', 'date_format:H:i'],
+            'party_size' => ['required', 'integer', 'min:1', 'max:'.ReservationRequest::MAX_PARTY_SIZE],
+            'guest_name' => ['required', 'string', 'max:200'],
+            'guest_phone' => ['nullable', 'string', 'max:50', 'regex:/^[+0-9 ()\/-]+$/'],
+            'guest_email' => ['nullable', 'email'],
+            'note' => ['nullable', 'string', 'max:500'],
+            'table_id' => [
+                'nullable',
+                'integer',
+                Rule::exists('tables', 'id')
+                    ->where('restaurant_id', $this->user()->restaurant_id)
+                    ->where('active', true),
+            ],
+        ];
+    }
+}

--- a/app/Http/Requests/Settings/SendModeSettingsUpdateRequest.php
+++ b/app/Http/Requests/Settings/SendModeSettingsUpdateRequest.php
@@ -25,6 +25,10 @@ class SendModeSettingsUpdateRequest extends FormRequest
             'send_mode' => ['required', 'string', Rule::enum(SendMode::class)],
             'auto_send_party_size_max' => ['required', 'integer', 'min:1', 'max:50'],
             'auto_send_min_lead_time_minutes' => ['required', 'integer', 'min:0', 'max:1440'],
+            // PRD-014 web sync-confirm opt-in. Optional so the field can be
+            // added to the shared form without forcing every caller to send it;
+            // the controller only persists it when present.
+            'web_sync_confirm_enabled' => ['sometimes', 'boolean'],
         ];
     }
 }

--- a/app/Mail/Concerns/HasGdprLink.php
+++ b/app/Mail/Concerns/HasGdprLink.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail\Concerns;
+
+use Illuminate\Support\Facades\URL;
+
+/**
+ * Central generator for the GDPR self-service link (PRD-015) so no outbound
+ * mailable forgets the Art. 15/17 footer. Every mailable that reaches a guest
+ * (PRD-005 manual reply, PRD-007 auto-send, PRD-014 sync-confirm) uses this.
+ *
+ * The link is produced at render time, so each send carries a fresh 30-day
+ * signature — a guest replying within an active thread always gets a live
+ * link rather than an expired one.
+ */
+trait HasGdprLink
+{
+    private const int GDPR_LINK_TTL_DAYS = 30;
+
+    /**
+     * A 30-day signed `gdpr.self-service` URL for the given reservation request.
+     */
+    protected function gdprLink(int $reservationId): string
+    {
+        return URL::temporarySignedRoute(
+            'gdpr.self-service',
+            now()->addDays(self::GDPR_LINK_TTL_DAYS),
+            ['reservation' => $reservationId],
+        );
+    }
+}

--- a/app/Mail/ReservationReplyMail.php
+++ b/app/Mail/ReservationReplyMail.php
@@ -34,8 +34,16 @@ final class ReservationReplyMail extends Mailable
 
     public readonly string $messageId;
 
-    public function __construct(public readonly ReservationReply $reply)
-    {
+    /**
+     * @param  bool  $syncConfirm  true when sent through the PRD-014 web
+     *                             sync-confirm path; surfaces a transparency
+     *                             line in the template (same intent as the
+     *                             PRD-007 auto-send notice).
+     */
+    public function __construct(
+        public readonly ReservationReply $reply,
+        public readonly bool $syncConfirm = false,
+    ) {
         $this->messageId = self::generateMessageId($reply->id);
     }
 
@@ -100,6 +108,7 @@ final class ReservationReplyMail extends Mailable
                 // escaping does not apply — and HTML-escaping inside a
                 // plaintext mail is incorrect by definition.
                 'body' => $this->reply->body,
+                'syncConfirm' => $this->syncConfirm,
             ],
         );
     }

--- a/app/Mail/ReservationReplyMail.php
+++ b/app/Mail/ReservationReplyMail.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Mail;
 
 use App\Enums\MessageDirection;
+use App\Mail\Concerns\HasGdprLink;
 use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use Illuminate\Bus\Queueable;
@@ -29,6 +30,7 @@ use Illuminate\Queue\SerializesModels;
  */
 final class ReservationReplyMail extends Mailable
 {
+    use HasGdprLink;
     use Queueable;
     use SerializesModels;
 
@@ -109,6 +111,8 @@ final class ReservationReplyMail extends Mailable
                 // plaintext mail is incorrect by definition.
                 'body' => $this->reply->body,
                 'syncConfirm' => $this->syncConfirm,
+                // Generated per send so each mail carries a live 30-day link.
+                'gdprLink' => $this->gdprLink($this->reply->reservation_request_id),
             ],
         );
     }

--- a/app/Models/GdprAudit.php
+++ b/app/Models/GdprAudit.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Append-only, PII-FREE audit row for GDPR self-service actions (PRD-015).
+ *
+ * Records only that an access/erasure action happened in a restaurant and
+ * when — `action` (`view` | `delete` | `owner_bulk_delete`) plus
+ * `restaurant_id` and `created_at`. It deliberately stores no guest email,
+ * reservation id, IP or user-agent: the table proves the *volume* of
+ * requests per restaurant, not *who* did *what*. That separation is what
+ * keeps the audit data itself outside the erasure claim it records.
+ *
+ * Writer pattern mirrors {@see AutoSendAudit}: a single static `record()`,
+ * `$timestamps = false`, no soft-deletes.
+ */
+class GdprAudit extends Model
+{
+    public const string ACTION_VIEW = 'view';
+
+    public const string ACTION_DELETE = 'delete';
+
+    public const string ACTION_OWNER_BULK_DELETE = 'owner_bulk_delete';
+
+    public $timestamps = false;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'action',
+        'restaurant_id',
+        'created_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'created_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
+    }
+
+    /**
+     * Single writer for GDPR audit rows. Call sites pass only the action and
+     * the tenant — never any guest-identifying data, by design.
+     */
+    public static function record(string $action, int $restaurantId): self
+    {
+        return self::create([
+            'action' => $action,
+            'restaurant_id' => $restaurantId,
+            'created_at' => now(),
+        ]);
+    }
+}

--- a/app/Models/ReservationReply.php
+++ b/app/Models/ReservationReply.php
@@ -38,6 +38,7 @@ class ReservationReply extends Model
         'shadow_was_modified',
         'auto_send_decision',
         'auto_send_scheduled_for',
+        'sync_confirm',
     ];
 
     /**
@@ -58,6 +59,7 @@ class ReservationReply extends Model
             'shadow_was_modified' => 'boolean',
             'auto_send_decision' => 'array',
             'auto_send_scheduled_for' => 'datetime',
+            'sync_confirm' => 'boolean',
         ];
     }
 

--- a/app/Models/ReservationRequest.php
+++ b/app/Models/ReservationRequest.php
@@ -37,9 +37,11 @@ class ReservationRequest extends Model
         'party_size',
         'desired_at',
         'message',
+        'note',
         'raw_payload',
         'needs_manual_review',
         'email_message_id',
+        'created_by_user_id',
     ];
 
     /**
@@ -56,6 +58,7 @@ class ReservationRequest extends Model
             'desired_at' => 'datetime',
             'raw_payload' => 'encrypted:array',
             'needs_manual_review' => 'boolean',
+            'created_by_user_id' => 'integer',
         ];
     }
 
@@ -65,6 +68,17 @@ class ReservationRequest extends Model
     public function restaurant(): BelongsTo
     {
         return $this->belongsTo(Restaurant::class);
+    }
+
+    /**
+     * The user who captured this request manually (phone/walk-in); null for
+     * web-form and email sources.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function createdBy(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by_user_id');
     }
 
     /**

--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -44,6 +44,7 @@ class Restaurant extends Model
         'send_mode_changed_at',
         'send_mode_changed_by',
         'slot_buffer_minutes',
+        'web_sync_confirm_enabled',
     ];
 
     /**
@@ -72,6 +73,7 @@ class Restaurant extends Model
             'auto_send_min_lead_time_minutes' => 'integer',
             'send_mode_changed_at' => 'datetime',
             'slot_buffer_minutes' => 'integer',
+            'web_sync_confirm_enabled' => 'boolean',
         ];
     }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,7 +8,11 @@ use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\WebklexImapMailboxFactory;
 use App\Services\Exports\Contracts\ExportGenerator;
 use App\Services\Exports\FormatRoutingExportGenerator;
+use GuzzleHttp\Client as GuzzleClient;
 use Illuminate\Support\ServiceProvider;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
+use Psr\Log\LoggerInterface;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -18,8 +22,50 @@ class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         $this->app->bind(ImapMailboxFactory::class, WebklexImapMailboxFactory::class);
-        $this->app->bind(ReplyGenerator::class, OpenAiReplyGenerator::class);
         $this->app->bind(ExportGenerator::class, FormatRoutingExportGenerator::class);
+
+        // The generator needs two timeout regimes: the default 30 s client
+        // for the async job (`generate`), and a short-budget client for the
+        // PRD-014 sync-confirm path (`generateSync`). The factory builds the
+        // latter on demand with the requested timeout.
+        $this->app->bind(OpenAiReplyGenerator::class, fn ($app): OpenAiReplyGenerator => new OpenAiReplyGenerator(
+            $app->make(ClientContract::class),
+            $app->make(LoggerInterface::class),
+            fn (int $timeout): ClientContract => $this->buildTimeoutBoundOpenAiClient($timeout),
+        ));
+        $this->app->bind(ReplyGenerator::class, OpenAiReplyGenerator::class);
+    }
+
+    /**
+     * Build an OpenAI client whose HTTP timeout is `$timeout` seconds,
+     * mirroring the openai-php Laravel ServiceProvider construction but with
+     * the sync hard-limit instead of the global `openai.request_timeout`.
+     */
+    private function buildTimeoutBoundOpenAiClient(int $timeout): ClientContract
+    {
+        $apiKey = config('openai.api_key');
+        $organization = config('openai.organization');
+        $project = config('openai.project');
+        $baseUri = config('openai.base_uri');
+
+        if (! is_string($apiKey) || ($organization !== null && ! is_string($organization))) {
+            throw ApiKeyIsMissing::create();
+        }
+
+        $factory = \OpenAI::factory()
+            ->withApiKey($apiKey)
+            ->withOrganization($organization)
+            ->withHttpClient(new GuzzleClient(['timeout' => $timeout]));
+
+        if (is_string($project)) {
+            $factory->withProject($project);
+        }
+
+        if (is_string($baseUri)) {
+            $factory->withBaseUri($baseUri);
+        }
+
+        return $factory->make();
     }
 
     /**

--- a/app/Services/AI/Contracts/ReplyGenerator.php
+++ b/app/Services/AI/Contracts/ReplyGenerator.php
@@ -7,10 +7,15 @@ namespace App\Services\AI\Contracts;
 /**
  * Producer of a German reply text from a deterministic Context-JSON.
  *
- * Implementations MUST never throw; on every error path they return the
- * neutral fallback string. This contract is the seam used by the job
- * layer (and tests) to substitute in a real OpenAI client, a stub, or a
+ * Implementations of `generate` MUST never throw; on every error path they
+ * return the neutral fallback string. This contract is the seam used by the
+ * job layer (and tests) to substitute in a real OpenAI client, a stub, or a
  * future provider (Azure / Anthropic) without changing call sites.
+ *
+ * Concrete classes may expose additional, non-interface methods with their
+ * own contracts — e.g. `OpenAiReplyGenerator::generateSync` (PRD-014), which
+ * deliberately throws on every failure. Such methods are outside this
+ * never-throw guarantee and are not part of the provider-swap seam.
  */
 interface ReplyGenerator
 {

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -6,12 +6,16 @@ namespace App\Services\AI;
 
 use App\Exceptions\AI\OpenAiAuthenticationException;
 use App\Exceptions\AI\OpenAiRateLimitException;
+use App\Exceptions\AI\OpenAiTimeoutException;
 use App\Services\AI\Contracts\ReplyGenerator;
 use App\Support\OpenAiKeyHealth;
+use Closure;
 use OpenAI\Contracts\ClientContract;
 use OpenAI\Exceptions\ErrorException;
 use OpenAI\Exceptions\RateLimitException;
+use OpenAI\Exceptions\TransporterException;
 use Psr\Log\LoggerInterface;
+use RuntimeException;
 use Throwable;
 
 /**
@@ -19,7 +23,7 @@ use Throwable;
  * `ReservationContextBuilder`) into a German reply text via OpenAI Chat
  * Completions.
  *
- * Error matrix (PRD-005 / #71):
+ * Async `generate` error matrix (PRD-005 / #71):
  *   - HTTP 401 or RateLimit/Server errors are classified as
  *     `OpenAiAuthenticationException` / `OpenAiRateLimitException` and
  *     RETHROWN so the job layer can drive the admin notification (#76)
@@ -28,7 +32,13 @@ use Throwable;
  *     timeout, malformed payload — returns the neutral fallback so the
  *     caller never raises.
  *
- * Logging hygiene: only `$e->getMessage()` is logged. No API key, no
+ * The sync `generateSync` (PRD-014) has the OPPOSITE error contract: a
+ * web sync-confirm must carry a real AI reply, so it NEVER returns the
+ * fallback and instead throws on every failure, letting the caller fall
+ * back to the V1 path. See its docblock for the per-error mapping.
+ *
+ * Logging hygiene: only the exception message (and, for classified HTTP
+ * errors, the numeric status code) is logged. No API key, no
  * Authorization header, no full context payload, no guest data.
  */
 final class OpenAiReplyGenerator implements ReplyGenerator
@@ -37,9 +47,18 @@ final class OpenAiReplyGenerator implements ReplyGenerator
 
     private const float TEMPERATURE = 0.4;
 
+    /**
+     * @param  (Closure(int): ClientContract)|null  $syncClientFactory
+     *                                                                  Builds a client whose HTTP timeout equals the sync hard-limit
+     *                                                                  (PRD-014). Bound in production so `generateSync` can run a
+     *                                                                  5 s-bounded call; left null in unit tests, where the injected
+     *                                                                  client (a fake) is used directly so `OpenAI::fake()` applies.
+     *                                                                  The async `generate` always uses the default 30 s `$client`.
+     */
     public function __construct(
         private readonly ClientContract $client,
         private readonly LoggerInterface $logger,
+        private readonly ?Closure $syncClientFactory = null,
     ) {}
 
     /**
@@ -49,16 +68,7 @@ final class OpenAiReplyGenerator implements ReplyGenerator
     public function generate(array $context): string
     {
         try {
-            $tonality = $this->extractTonality($context);
-
-            $response = $this->client->chat()->create([
-                'model' => config('reservations.ai.openai_model', 'gpt-4o-mini'),
-                'temperature' => self::TEMPERATURE,
-                'messages' => [
-                    ['role' => 'system', 'content' => $this->systemPrompt($tonality)],
-                    ['role' => 'user', 'content' => json_encode($context, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)],
-                ],
-            ]);
+            $response = $this->client->chat()->create($this->chatCreatePayload($context));
 
             $content = trim((string) ($response->choices[0]->message->content ?? ''));
 
@@ -92,6 +102,114 @@ final class OpenAiReplyGenerator implements ReplyGenerator
 
             return self::FALLBACK_TEXT;
         }
+    }
+
+    /**
+     * Synchronous reply generation for the PRD-014 web sync-confirm path.
+     *
+     * Runs inside the public submit latency with a hard `$timeout`-second
+     * budget enforced by the `syncClientFactory` client. Unlike `generate`,
+     * it NEVER returns the neutral fallback: a confirmation must carry a
+     * real AI reply, so every failure throws and the caller falls back to
+     * the V1 path.
+     *
+     *   - transport failure / 5 s timeout → `OpenAiTimeoutException`
+     *   - empty completion → `RuntimeException`
+     *   - 401 / 429 / 5xx → the underlying OpenAI exception propagates
+     *
+     * Error mapping (every branch is logged and then thrown — the sync path
+     * never returns the fallback):
+     *   - 401 → `OpenAiAuthenticationException` (classified like `generate`,
+     *     so the caller can surface the admin key-check notification)
+     *   - 429 → `OpenAiRateLimitException`
+     *   - transport failure / 5 s timeout → `OpenAiTimeoutException`
+     *   - 5xx, empty completion, malformed payload → the originating
+     *     exception propagates
+     *
+     * Logging hygiene matches `generate`: only the exception message (and,
+     * for classified HTTP errors, the numeric status) is logged — never the
+     * API key, headers, context payload, or guest data.
+     *
+     * @param  array<string, mixed>  $context  the JSON produced by
+     *                                         ReservationContextBuilder::build()
+     */
+    public function generateSync(array $context, int $timeout = 5): string
+    {
+        $client = $this->syncClientFactory !== null
+            ? ($this->syncClientFactory)($timeout)
+            : $this->client;
+
+        try {
+            $response = $client->chat()->create($this->chatCreatePayload($context));
+
+            $content = trim((string) ($response->choices[0]->message->content ?? ''));
+
+            if ($content === '') {
+                throw new RuntimeException('OpenAI returned an empty completion for the sync reply.');
+            }
+
+            // Successful authenticated call — clear the admin "OpenAI key
+            // check" banner (#76), mirroring `generate`.
+            OpenAiKeyHealth::clear();
+
+            return $content;
+        } catch (ErrorException $e) {
+            $this->logger->warning('openai sync reply generation failed', [
+                'status' => $e->getStatusCode(),
+                'error' => $e->getErrorMessage(),
+            ]);
+
+            if ($e->getStatusCode() === 401) {
+                throw new OpenAiAuthenticationException;
+            }
+
+            throw $e;
+        } catch (RateLimitException $e) {
+            $this->logger->warning('openai sync reply generation rate-limited', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new OpenAiRateLimitException;
+        } catch (TransporterException $e) {
+            // Guzzle connection timeout / network failure within the 5 s
+            // budget surfaces here (openai-php wraps it).
+            $this->logger->warning('openai sync reply generation timed out', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw new OpenAiTimeoutException(previous: $e);
+        } catch (Throwable $e) {
+            // 5xx, empty completion, malformed payload — log for parity with
+            // `generate`, then propagate so the caller falls back to V1
+            // (never the neutral fallback text).
+            $this->logger->warning('openai sync reply generation failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * The Chat Completions request body shared by the async `generate` and
+     * the sync `generateSync`: same model, temperature, system prompt and
+     * the deterministic context JSON as the user message.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array<string, mixed>
+     */
+    private function chatCreatePayload(array $context): array
+    {
+        $tonality = $this->extractTonality($context);
+
+        return [
+            'model' => config('reservations.ai.openai_model', 'gpt-4o-mini'),
+            'temperature' => self::TEMPERATURE,
+            'messages' => [
+                ['role' => 'system', 'content' => $this->systemPrompt($tonality)],
+                ['role' => 'user', 'content' => json_encode($context, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)],
+            ],
+        ];
     }
 
     /**

--- a/app/Services/AutoSend/WebSyncConfirmDecider.php
+++ b/app/Services/AutoSend/WebSyncConfirmDecider.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AutoSend;
+
+use App\Enums\SlotState;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use App\Services\Availability\SlotAvailability;
+use Carbon\CarbonImmutable;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Decides whether a web reservation may be confirmed synchronously in the
+ * submit path (PRD-014), or must fall back to the normal owner-approval flow.
+ *
+ * The gate cascade is hard-coded and order-significant — the first tripped gate
+ * wins. Unlike the PRD-007 auto-send path, `first_time_guest` and
+ * `needs_manual_review` are deliberately NOT gates here: web-form input is
+ * structured (no parse risk) and a first-time filter would punish the very
+ * online first-timers the channel exists to win (see PRD-014 risks). The
+ * PRD-007 restaurant limits (`auto_send_party_size_max`,
+ * `auto_send_min_lead_time_minutes`) are reused.
+ *
+ * `final`, stateless: availability is delegated to {@see SlotAvailability}.
+ */
+final class WebSyncConfirmDecider
+{
+    public const string REASON_GLOBAL_KILL = 'global_kill';
+
+    public const string REASON_DISABLED = 'web_sync_confirm_disabled';
+
+    public const string REASON_SLOT_NOT_FREE = 'slot_not_deterministic_free';
+
+    public const string REASON_PARTY_SIZE_OVER_LIMIT = 'party_size_over_limit';
+
+    public const string REASON_SHORT_NOTICE = 'short_notice';
+
+    public function __construct(
+        private readonly SlotAvailability $availability,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function decide(ReservationRequest $request): WebSyncConfirmDecision
+    {
+        // 1. Global incident killswitch — stops every sync-confirm at once.
+        if ((bool) config('reservations.web_sync_confirm.kill', false)) {
+            return WebSyncConfirmDecision::skip(self::REASON_GLOBAL_KILL);
+        }
+
+        // 2. Per-restaurant opt-in.
+        $restaurant = $request->restaurant;
+        if ($restaurant === null) {
+            $this->logger->warning('web sync confirm: reservation has no restaurant, skipping', [
+                'reservation_request_id' => $request->id,
+            ]);
+
+            return WebSyncConfirmDecision::skip(self::REASON_DISABLED);
+        }
+
+        if (! $restaurant->web_sync_confirm_enabled) {
+            return WebSyncConfirmDecision::skip(self::REASON_DISABLED);
+        }
+
+        // 3. Slot must be deterministically free (a missing time can never be).
+        if ($request->desired_at === null) {
+            return WebSyncConfirmDecision::skip(self::REASON_SLOT_NOT_FREE);
+        }
+
+        $slot = $this->availability->forSlot(
+            $request->restaurant_id,
+            CarbonImmutable::instance($request->desired_at),
+            $request->party_size,
+        );
+
+        // Only a Free slot proceeds — Tight (≤25% capacity left) is bookable from
+        // the dashboard but too close to full for an unattended confirmation.
+        if ($slot->state !== SlotState::Free) {
+            return WebSyncConfirmDecision::skip(self::REASON_SLOT_NOT_FREE);
+        }
+
+        // 4. Reused PRD-007 hard limits.
+        if ($request->party_size > $restaurant->auto_send_party_size_max) {
+            return WebSyncConfirmDecision::skip(self::REASON_PARTY_SIZE_OVER_LIMIT);
+        }
+
+        if ($this->isShortNotice($request, $restaurant)) {
+            return WebSyncConfirmDecision::skip(self::REASON_SHORT_NOTICE);
+        }
+
+        return WebSyncConfirmDecision::proceed($slot);
+    }
+
+    private function isShortNotice(ReservationRequest $request, Restaurant $restaurant): bool
+    {
+        // Defensive: the cascade already returns on a null desired_at, but guard
+        // here too (matching AutoSendDecider) so the method is safe in isolation.
+        if ($request->desired_at === null) {
+            return false;
+        }
+
+        $minutesUntilDesired = now()->diffInMinutes($request->desired_at, false);
+
+        return $minutesUntilDesired < $restaurant->auto_send_min_lead_time_minutes;
+    }
+}

--- a/app/Services/AutoSend/WebSyncConfirmDecision.php
+++ b/app/Services/AutoSend/WebSyncConfirmDecision.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AutoSend;
+
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use InvalidArgumentException;
+
+/**
+ * Outcome of {@see WebSyncConfirmDecider} for a web reservation (PRD-014).
+ *
+ * `proceed` carries the deterministic slot verdict the controller needs to
+ * assign a table; `skip` carries the gate reason that sent the request back to
+ * the normal owner-approval path. Exactly one of the two is populated.
+ */
+final readonly class WebSyncConfirmDecision
+{
+    public const string STATE_PROCEED = 'proceed';
+
+    public const string STATE_SKIP = 'skip';
+
+    private function __construct(
+        public string $state,
+        public ?string $reason,
+        public ?SlotAvailabilityResult $slot,
+    ) {}
+
+    public static function proceed(SlotAvailabilityResult $slot): self
+    {
+        return new self(self::STATE_PROCEED, null, $slot);
+    }
+
+    public static function skip(string $reason): self
+    {
+        if (trim($reason) === '') {
+            throw new InvalidArgumentException('A skip decision must carry a non-empty reason.');
+        }
+
+        return new self(self::STATE_SKIP, $reason, null);
+    }
+
+    public function shouldProceed(): bool
+    {
+        return $this->state === self::STATE_PROCEED;
+    }
+}

--- a/app/Services/Waitlist/WaitlistBanner.php
+++ b/app/Services/Waitlist/WaitlistBanner.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Waitlist;
+
+use App\Enums\ReservationStatus;
+use App\Enums\SlotState;
+use App\Models\ReservationRequest;
+use App\Services\Availability\SlotAvailability;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Collection;
+
+/**
+ * Surfaces waitlisted reservations whose desired slot is currently available
+ * (PRD-013), so the dashboard can prompt the owner to pull a waiting guest in
+ * when a cancellation frees a table.
+ *
+ * Read-only and stateless: the availability verdict is delegated to
+ * {@see SlotAvailability}, and tenant scope comes from the explicit
+ * `$restaurantId` with the global RestaurantScope bypassed, so the service
+ * behaves identically from HTTP, a job, or the console.
+ */
+final class WaitlistBanner
+{
+    /** Performance cap: never evaluate more than this many waitlist entries. */
+    private const int MAX_RESULTS = 20;
+
+    public function __construct(
+        private readonly SlotAvailability $availability,
+    ) {}
+
+    /**
+     * Future-dated waitlisted reservations whose slot is not full, oldest wish
+     * first. The query is capped before the availability filter runs, so the
+     * result holds at most {@see self::MAX_RESULTS} entries.
+     *
+     * @return Collection<int, ReservationRequest>
+     */
+    public function eligibleNow(int $restaurantId): Collection
+    {
+        return ReservationRequest::query()
+            ->withoutGlobalScopes()
+            ->where('restaurant_id', $restaurantId)
+            ->where('status', ReservationStatus::Waitlisted)
+            ->where('desired_at', '>=', now())
+            ->orderBy('desired_at')
+            ->limit(self::MAX_RESULTS)
+            ->get()
+            ->filter(fn (ReservationRequest $request): bool => $this->slotHasRoom($request))
+            ->values();
+    }
+
+    private function slotHasRoom(ReservationRequest $request): bool
+    {
+        // The query already excludes null desired_at; the guard keeps the method
+        // safe and explicit if it is ever called from another path.
+        if ($request->desired_at === null) {
+            return false;
+        }
+
+        $result = $this->availability->forSlot(
+            $request->restaurant_id,
+            CarbonImmutable::instance($request->desired_at),
+            $request->party_size,
+        );
+
+        return $result->state !== SlotState::Full;
+    }
+}

--- a/config/reservations.php
+++ b/config/reservations.php
@@ -63,4 +63,19 @@ return [
             'Beginne mit Anrede („Guten Tag [Name],"), ende mit Grußformel und Restaurant-Name.',
         ],
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Synchronous web confirmation (PRD-014)
+    |--------------------------------------------------------------------------
+    |
+    | Global incident killswitch for the sync-confirm path. Setting
+    | WEB_SYNC_CONFIRM_GLOBAL_KILL=true stops every synchronous confirmation
+    | immediately, regardless of per-restaurant opt-in — e.g. during an OpenAI
+    | outage that would otherwise make each web submit wait out the 5s timeout.
+    |
+    */
+    'web_sync_confirm' => [
+        'kill' => (bool) env('WEB_SYNC_CONFIRM_GLOBAL_KILL', false),
+    ],
 ];

--- a/database/migrations/2026_05_22_000001_add_created_by_user_id_to_reservation_requests_table.php
+++ b/database/migrations/2026_05_22_000001_add_created_by_user_id_to_reservation_requests_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->foreignId('created_by_user_id')
+                ->nullable()
+                ->after('needs_manual_review')
+                ->constrained('users')
+                ->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('created_by_user_id');
+        });
+    }
+};

--- a/database/migrations/2026_05_22_000002_add_note_to_reservation_requests_table.php
+++ b/database/migrations/2026_05_22_000002_add_note_to_reservation_requests_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->text('note')->nullable()->after('message');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_requests', function (Blueprint $table) {
+            $table->dropColumn('note');
+        });
+    }
+};

--- a/database/migrations/2026_05_23_000001_add_web_sync_confirm_enabled_to_restaurants_table.php
+++ b/database/migrations/2026_05_23_000001_add_web_sync_confirm_enabled_to_restaurants_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->boolean('web_sync_confirm_enabled')
+                ->default(false)
+                ->after('auto_send_min_lead_time_minutes');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->dropColumn('web_sync_confirm_enabled');
+        });
+    }
+};

--- a/database/migrations/2026_05_23_000002_add_sync_confirm_to_reservation_replies_table.php
+++ b/database/migrations/2026_05_23_000002_add_sync_confirm_to_reservation_replies_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->boolean('sync_confirm')->default(false)->after('is_fallback');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('reservation_replies', function (Blueprint $table) {
+            $table->dropColumn('sync_confirm');
+        });
+    }
+};

--- a/database/migrations/2026_05_23_000003_create_gdpr_audits_table.php
+++ b/database/migrations/2026_05_23_000003_create_gdpr_audits_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('gdpr_audits', function (Blueprint $table) {
+            $table->id();
+            // view | delete | owner_bulk_delete
+            $table->string('action');
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            // Append-only and deliberately PII-FREE (PRD-015 § Datenmodell):
+            // no guest_email, reservation_id, IP or user-agent — the table
+            // answers "how many access/erasure requests in restaurant X", not
+            // "who did what", so it never falls under the same erasure claim.
+            $table->dateTime('created_at')->useCurrent();
+
+            $table->index(['restaurant_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('gdpr_audits');
+    }
+};

--- a/docs/HANDOFF-2026-05-23.md
+++ b/docs/HANDOFF-2026-05-23.md
@@ -1,0 +1,149 @@
+# Handoff — Stand 2026-05-23
+
+Übergabe-Dokument für die nächste Session. Snapshot zum Datum oben; nicht evergreen.
+Maßgeblich bleiben die PRDs in `docs/`, `CLAUDE.md` und die GitHub-Issues.
+
+---
+
+## TL;DR
+
+- **PRD-012** (Telefon/Walk-in-Erfassung) und **PRD-013** (passive Warteliste) sind **vollständig** auf `dev`, beide Epics geschlossen.
+- **PRD-014** (Sync-Web-Confirm) ist **angefangen**: `#352` (Schema) + `#353` (Decider) gemerged. Verbleibend: `#354`–`#358`.
+- **PRD-015** (DSGVO-Self-Service) ist **gescoped, noch nicht begonnen**: `#359`–`#364`.
+- `dev` ist **13 Commits vor `main`**. `main` ist unangetastet — der `dev → main`-Release ist ein **expliziter Owner-Freigabe-Schritt** (noch nicht erfolgt).
+- Tests grün: **956 PHPUnit** (3095 Assertions) + **112 Vitest** (14 Dateien). CI (Backend PHP 8.4 / Frontend Node 20 / Ziggy-Drift) durchgehend grün.
+
+---
+
+## Branch- & Release-Stand
+
+- Aktueller Arbeits-Branch: `dev` (sauber, in sync mit `origin/dev`).
+- `origin/main..origin/dev` = **13 Commits** (die 13 gemergten PRs dieser Session, #341→#353 als Squash-Commits #365→#377).
+- **`main` bleibt unangetastet.** `dev → main` wird als eigener Release-PR (`Release: <bezeichnung>`) erst nach expliziter Owner-Freigabe erstellt — siehe `CLAUDE.md` § Branch-Strategie. Aktuell **keine** Freigabe erteilt.
+
+---
+
+## Was in dieser Session gebaut wurde
+
+### PRD-012 — Manuelle Erfassung Telefon/Walk-in ✅ komplett (Epic #337 zu)
+
+| Issue | Inhalt |
+|---|---|
+| #341 | `ReservationSource::Phone/WalkIn`, `reservation_requests.created_by_user_id` + `note`, Model-Fillable/Cast, `createdBy()`-Relation |
+| #342 | `QuickReservationController@create` + Request + Route + Live-Verfügbarkeits-Prop (`forSlot`) |
+| #343 | `@store` + Transaktion + `lockForUpdate` + Auto-Tisch (alle Tische einer Kombination) + `confirmed`, kein KI/Mail |
+| #344 | `resources/js/pages/Reservations/Quick.vue` — Keyboard-First, debounced Live-Verfügbarkeit, Banner, Tisch-Override |
+| #345 | Dashboard-Header-Button „Telefon-Reservierung" |
+| #346 | Vitest für `Quick.vue` |
+
+### PRD-013 — Warteliste passiv ✅ komplett (Epic #338 zu)
+
+| Issue | Inhalt |
+|---|---|
+| #347 | `ReservationStatus::Waitlisted` + Übergänge (`new`/`in_review` → `waitlisted`, `waitlisted` → `confirmed`/`declined`); Waitlist ist **non-occupying** (Test gepinnt) |
+| #348 | `app/Services/Waitlist/WaitlistBanner::eligibleNow` (free-slot Wartende, ≤20, oldest-first) |
+| #349 | Dashboard-Prop `waitlistBanner` (im Poll-`only`-Set) + waitlisted-Filter (lief schon via `Rule::enum`) |
+| #350 | `WaitlistBanner.vue` + „Warteliste"-Filter-Chip + Badge + Drawer-Übergangs-Buttons (→ `bulk-status`); `'waitlisted'` im TS-Typ |
+| #351 | Vitest für `WaitlistBanner.vue` |
+
+### PRD-014 — Sync-Web-Confirm 🚧 angefangen (Epic #339 offen)
+
+| Issue | Status |
+|---|---|
+| #352 | ✅ Schema: `restaurants.web_sync_confirm_enabled` + `reservation_replies.sync_confirm` (beide bool default false) |
+| #353 | ✅ `app/Services/AutoSend/WebSyncConfirmDecider` + `WebSyncConfirmDecision` DTO + `WEB_SYNC_CONFIRM_GLOBAL_KILL` config |
+
+---
+
+## Offene Issues (Stand 2026-05-23)
+
+Alle sofort baubar (PRD-007 **ist** implementiert — der frühere „blockiert"-Vermerk war falsch und wurde korrigiert).
+
+### PRD-014 (Epic #339) — Reihenfolge & Abhängigkeiten
+
+```
+#354 generateSync  ─┐ (unabhängig, PRD-005 vorhanden)
+#352 schema ✅ ─────┤
+#353 decider ✅ ────┘
+                    ▼
+#355 store-sync-path (braucht #353 + #354)
+   ├─► #356 ReservationReplyMail syncConfirm-Flag
+   └─► #357 PublicForm/ConfirmedSync.vue
+#358 Settings-Toggle (Settings/SendMode.vue, unabhängig)
+```
+
+- **#354** `OpenAiReplyGenerator::generateSync` — 5 s Hard-Timeout am OpenAI-Client, wirft `OpenAiTimeoutException`; bestehendes async `generate` unverändert. Kein API-Key in Strings/Logs.
+- **#355** `StoreReservationRequest` Sync-Pfad: `WebSyncConfirmDecider::decide` → bei `proceed` sync `generateSync` + `ReservationTableAssignment` + sync Mail + `confirmed` + `sync_confirm=true` + render `ConfirmedSync`; bei jedem Fehler/Timeout Fallthrough zum V1-Pfad (`new` + `Submitted`). `lockForUpdate` auf den vorgeschlagenen Tisch (Race vs. #343). Nur `web_form`-Source.
+- **#356** `ReservationReplyMail` optionales `syncConfirm: bool` + Template-Zeile „automatisch erstellt".
+- **#357** `resources/js/pages/PublicForm/ConfirmedSync.vue` (öffentlich, kein Layout).
+- **#358** Toggle in `resources/js/pages/Settings/SendMode.vue` (⚠️ **nicht** `AutoSend.vue` — so heißt die PRD-007-Seite real) + policy-guarded Update.
+
+### PRD-015 (Epic #340) — DSGVO Self-Service, noch nicht begonnen
+
+```
+#359 gdpr_audits (PII-frei) + Model + Service
+   ├─► #360 HasGdprLink-Trait + ReservationReplyMail-Footer
+   ├─► #361 GdprSelfServiceController@show (signed) + view-audit + Page
+   │      └─► #362 @delete + confirm_date + Hard-Delete + audit
+   │      └─► #363 Public GdprSelfService.vue + GdprDeleted.vue
+   └─► #364 Dashboard Bulk-Delete (E-Mail) + Owner-Policy + audit
+```
+
+### Altlasten (PRD-010, V2/V3-Sound-Assets — kein Code-Blocker)
+
+- **#200** `[Epic] PRD-010: Push & Sound-Alerts` (Tracking)
+- **#244** CC0-Sound-Assets in `public/sounds/` + LICENSE.txt (braucht echte Binärdateien)
+
+---
+
+## Nächster Schritt
+
+**#354** (`OpenAiReplyGenerator::generateSync`) ziehen — kleinstes unblockiertes PRD-014-Issue, Voraussetzung für #355. Danach #355 → #356/#357 → #358; dann PRD-015 ab #359.
+
+Epic #339 schließt nach #354–358; Epic #340 nach PRD-015.
+
+---
+
+## Arbeits-Workflow (verbindlich, pro Issue eine Schleife)
+
+1. `git checkout dev && git pull --ff-only origin dev && git checkout -b feature/<nr>-<slug>`
+2. Umsetzen **streng nach den Acceptance Criteria** des Issues; bestehende Patterns fortführen.
+3. Tests schreiben (Pest/PHPUnit + ggf. Vitest) — **jedes** Szenario (happy/edge/error).
+4. Grün machen: `php artisan test`, `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check`; bei Vue-Änderung zusätzlich `npm run build` (vue-tsc) und `npm run test` (Vitest).
+5. Atomare Commits (Imperativ-Englisch, `Refs #<nr>`). **Keine** KI-Attribution/Co-Authored-By in Commits/PRs/Kommentaren.
+6. Push, **PR gegen `dev`** (`gh pr create --base dev`), englischer Body (Summary/Why/Test plan, `Closes #<nr>`).
+7. **Self-Review (Pflicht):** Skill `code-review:code-review <PR#>` bzw. 5 Lenses (CLAUDE.md / Bug-Scan / Git-History / Prior-Comments / Comments-vs-Impl). Findings ≥80 als PR-Kommentar; reale Findings fixen, schwache/CLAUDE-widersprechende **begründet ablehnen**.
+8. **CI grün prüfen** (`gh pr checks <PR#>` — alle 3 Jobs), dann **Squash-Merge** nach `dev` (`gh pr merge --squash --delete-branch`).
+9. Issue **manuell schließen** (+ Abschlusskommentar) — Auto-Close greift bei `dev`-Merges nicht.
+10. Erst dann das nächste Issue.
+
+`dev → main` ist separat und braucht **Owner-Freigabe**.
+
+---
+
+## Gotchas aus dieser Session (Zeit-Sparer)
+
+- **Tests sind PHPUnit**, kein Pest (trotz Doku); Lauf via `php artisan test` (kein `composer test`-Script).
+- **Ziggy:** nach neuen **oder umsortierten** Routes `php artisan ziggy:generate --types-only resources/js/ziggy.d.ts` und die getrackte `ziggy.d.ts` committen — der CI-`ziggy-drift`-Job vergleicht. (Eine Route nur zu **verschieben** ändert die Reihenfolge in `ziggy.d.ts`.)
+- **Tenant-Scope:** in HTTP-Controllern auf den globalen `RestaurantScope` verlassen — **niemals** `where('restaurant_id', auth()->user()->…)` im Controller (CLAUDE.md-Verbot). In **Services** dagegen `withoutGlobalScopes()->where('restaurant_id', $id)` (Determinismus, laufen auch aus Jobs/Console).
+- **Inertia-Tests** für noch nicht existierende Vue-Seiten: `->component('Name', false)` (zweiter Param überspringt die Datei-Existenzprüfung).
+- **Vue native `<select :value="x">`**: liefert via `_value` den echten Typ (auch `null`/number), nicht den String — kein Bug.
+- **`v-model.number` am Wrapper-`<Input>` ist ein No-op** → numerische Felder explizit `Number()`-coercen (Submit **und** Reload-Pfad).
+- **`lockForUpdate` ist auf SQLite ein No-op** — Locking-Logik via in-Transaktion-Recheck testen (sequenzielle Doppel-Buchung), nicht via echter Parallelität.
+- **`SlotAvailability::forSlot`** erwartet UTC-`CarbonImmutable`; lokale Operator-Eingaben via `App\Support\Timezone::localToUtc(...)->toImmutable()` umwandeln; Cast-`Carbon` → `CarbonImmutable::instance()` (kein `parse()`-String-Roundtrip).
+- **Status/Source-Enums** werden in `AnalyticsAggregator` über `::cases()` iteriert → neue Werte tauchen automatisch als Zähl-Buckets auf (Frontend ignoriert Extra-Keys; TS-Typ/Anzeige separat nachziehen).
+- **PRD-007 (Auto-Send) ist gebaut** (V2-Welle): `AutoSendDecider`, `restaurants.auto_send_party_size_max`/`auto_send_min_lead_time_minutes`, Settings-Seite **`SendMode.vue`**. Aus nur-V1-Milestones **nicht** auf „ungebaut" schließen — V2/V3 sind über `v2`/`v3`-Labels getrackt.
+
+## Bekannte Follow-ups / Tech-Debt
+
+- **WaitlistBanner / WebSyncConfirmDecider N+1:** `forSlot` löst Restaurant+Tische pro Eintrag/Aufruf neu auf. Bei der Dashboard-Banner-Schleife (≤20) akzeptabel; falls das PRD-013-`<50 ms`-Ziel in Prod kippt, eine Batch-Methode auf `SlotAvailability` einführen.
+- **`bulk-status` `skipped`-Flash** wird nirgends im Dashboard angezeigt (betrifft auch die bestehende Bulk-Toolbar). Drawer-Übergangs-Buttons sind auf gültige Übergänge gegated, daher unkritisch — aber ein echtes Feedback-Loch, falls gewünscht.
+- **V4-PRDs (PRD-016/021/022 etc.) bewusst NICHT geschrieben** — Roadmap-Politik (`docs/superpowers/specs/2026-04-29-v3-plus-roadmap-design.md` §9/§10): V4 bleibt auf Bullet-Niveau bis V3 live + Pilot. „Keine V4-Issues" ist gewollt, kein Loch.
+
+---
+
+## Schnell-Referenz
+
+- PRDs: `docs/PRD-012`…`PRD-015`. Roadmap/Politik: `docs/README.md` + `docs/superpowers/specs/`.
+- Entscheidungen: `docs/decisions/`. Bekannte Fehler: `docs/TROUBLESHOOTING.md`.
+- Verhaltensregeln: `/Users/private/CLAUDE.md` + projektspezifische `CLAUDE.md`.

--- a/resources/js/components/WaitlistBanner.test.ts
+++ b/resources/js/components/WaitlistBanner.test.ts
@@ -1,0 +1,92 @@
+import type { ReservationRequestRow } from '@/types';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import WaitlistBanner from './WaitlistBanner.vue';
+
+const { formatSpy } = vi.hoisted(() => ({
+    formatSpy: vi.fn((iso: string | null) => `FMT(${iso})`),
+}));
+
+vi.mock('@/lib/format-datetime', () => ({
+    formatDateTime: formatSpy,
+}));
+
+beforeEach(() => {
+    formatSpy.mockReset();
+    formatSpy.mockImplementation((iso: string | null) => `FMT(${iso})`);
+});
+
+function makeEntry(overrides: Partial<ReservationRequestRow> = {}): ReservationRequestRow {
+    return {
+        id: 1,
+        status: 'waitlisted',
+        source: 'web_form',
+        guest_name: 'Müller',
+        guest_email: null,
+        guest_phone: null,
+        party_size: 4,
+        desired_at: '2026-06-15T19:00:00+00:00',
+        needs_manual_review: false,
+        created_at: null,
+        has_raw_email: false,
+        ...overrides,
+    };
+}
+
+function makeEntries(count: number): ReservationRequestRow[] {
+    return Array.from({ length: count }, (_, i) => makeEntry({ id: i + 1, guest_name: `Gast ${i + 1}` }));
+}
+
+describe('WaitlistBanner.vue', () => {
+    it('renders nothing when the banner is empty', () => {
+        const wrapper = mount(WaitlistBanner, { props: { banner: [] } });
+
+        expect(wrapper.find('[data-testid="waitlist-banner"]').exists()).toBe(false);
+    });
+
+    it('renders one entry per waitlisted item with name and party size', () => {
+        const wrapper = mount(WaitlistBanner, { props: { banner: makeEntries(3) } });
+
+        const entries = wrapper.findAll('[data-testid^="waitlist-entry-"]');
+        expect(entries).toHaveLength(3);
+        expect(entries[0].text()).toContain('Gast 1');
+        expect(entries[0].text()).toContain('(4 P.)');
+    });
+
+    it('emits open with the clicked entry id, not just the first', async () => {
+        const wrapper = mount(WaitlistBanner, { props: { banner: [makeEntry({ id: 7 }), makeEntry({ id: 42 })] } });
+
+        await wrapper.get('[data-testid="waitlist-entry-42"]').trigger('click');
+
+        expect(wrapper.emitted('open')).toEqual([[42]]);
+    });
+
+    it('shows at most five entries and an overflow note for the rest', () => {
+        const wrapper = mount(WaitlistBanner, { props: { banner: makeEntries(7) } });
+
+        expect(wrapper.findAll('[data-testid^="waitlist-entry-"]')).toHaveLength(5);
+        expect(wrapper.get('[data-testid="waitlist-overflow"]').text()).toContain('2 weitere');
+    });
+
+    it('has no overflow note at five or fewer entries', () => {
+        const wrapper = mount(WaitlistBanner, { props: { banner: makeEntries(5) } });
+
+        expect(wrapper.find('[data-testid="waitlist-overflow"]').exists()).toBe(false);
+    });
+
+    it('uses singular and plural headlines', () => {
+        const one = mount(WaitlistBanner, { props: { banner: makeEntries(1) } });
+        expect(one.get('[data-testid="waitlist-banner"]').text()).toContain('1 Wartender könnte');
+
+        const many = mount(WaitlistBanner, { props: { banner: makeEntries(3) } });
+        expect(many.get('[data-testid="waitlist-banner"]').text()).toContain('3 Wartende könnten');
+    });
+
+    it('formats the wished time in the restaurant timezone', () => {
+        mount(WaitlistBanner, {
+            props: { banner: [makeEntry({ desired_at: '2026-06-15T19:00:00+00:00' })], timezone: 'Europe/Berlin' },
+        });
+
+        expect(formatSpy).toHaveBeenCalledWith('2026-06-15T19:00:00+00:00', { timeZone: 'Europe/Berlin' });
+    });
+});

--- a/resources/js/components/WaitlistBanner.vue
+++ b/resources/js/components/WaitlistBanner.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { formatDateTime } from '@/lib/format-datetime';
+import { type ReservationRequestRow } from '@/types';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    /** Waitlisted reservations whose slot is currently free (PRD-013). */
+    banner: ReservationRequestRow[];
+    /** Restaurant timezone, so wished times read in local time. */
+    timezone?: string | null;
+}>();
+
+const emit = defineEmits<{
+    (e: 'open', id: number): void;
+}>();
+
+const MAX_VISIBLE = 5;
+
+const visible = computed(() => props.banner.slice(0, MAX_VISIBLE));
+const overflow = computed(() => Math.max(0, props.banner.length - MAX_VISIBLE));
+
+const headline = computed(() =>
+    props.banner.length === 1
+        ? '1 Wartender könnte jetzt einen Slot bekommen.'
+        : `${props.banner.length} Wartende könnten jetzt einen Slot bekommen.`,
+);
+
+function when(iso: string | null): string {
+    return formatDateTime(iso, { timeZone: props.timezone });
+}
+</script>
+
+<template>
+    <div
+        v-if="banner.length > 0"
+        class="rounded-lg border border-amber-300 bg-amber-50 p-4 dark:border-amber-900/40 dark:bg-amber-950/40"
+        role="status"
+        aria-live="polite"
+        data-testid="waitlist-banner"
+    >
+        <p class="text-sm font-medium text-amber-900 dark:text-amber-200">{{ headline }}</p>
+        <ul class="mt-2 space-y-1 text-sm">
+            <li v-for="entry in visible" :key="entry.id">
+                <button
+                    type="button"
+                    class="text-amber-900 underline underline-offset-2 hover:no-underline dark:text-amber-200"
+                    :data-testid="`waitlist-entry-${entry.id}`"
+                    @click="emit('open', entry.id)"
+                >
+                    {{ entry.guest_name }} – {{ when(entry.desired_at) }} ({{ entry.party_size }} P.)
+                </button>
+            </li>
+        </ul>
+        <p v-if="overflow > 0" class="mt-1 text-xs text-amber-800 dark:text-amber-300" data-testid="waitlist-overflow">
+            … und {{ overflow }} weitere
+        </p>
+    </div>
+</template>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
 import DashboardExportDropdown from '@/components/DashboardExportDropdown.vue';
+import InputError from '@/components/InputError.vue';
 import ReservationThreadHistory from '@/components/ReservationThreadHistory.vue';
 import WaitlistBanner from '@/components/WaitlistBanner.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Sheet, SheetContent, SheetDescription, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
@@ -29,7 +31,7 @@ import {
     type SharedData,
     type ThreadMessage,
 } from '@/types';
-import { Head, Link, router, usePage } from '@inertiajs/vue3';
+import { Head, Link, router, useForm, usePage } from '@inertiajs/vue3';
 import { ChevronDown, Info, Phone } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 
@@ -53,6 +55,7 @@ const breadcrumbs: BreadcrumbItem[] = [{ title: 'Dashboard', href: '/dashboard' 
 const page = usePage<SharedData>();
 const restaurantName = computed(() => page.props.restaurant?.name ?? '');
 const restaurantTimezone = computed(() => page.props.restaurant?.timezone);
+const isOwner = computed(() => page.props.auth.user.role === 'owner');
 
 // PRD-007 mode banner. Shows yellow for shadow (test mode, no risk to
 // guests yet) and red for auto (mail flows without operator approval),
@@ -167,6 +170,27 @@ function toggleSource(value: ReservationSource) {
 
 function submitSearch() {
     applyFilter({ q: search.value });
+}
+
+// GDPR Art. 17 owner bulk-delete by exact email (PRD-015).
+const gdprDeleteOpen = ref(false);
+const gdprDeleteForm = useForm({ email: '' });
+
+function openGdprDelete() {
+    gdprDeleteForm.clearErrors();
+    // Prefill from the current search term when it looks like an email.
+    gdprDeleteForm.email = search.value.includes('@') ? search.value.trim() : '';
+    gdprDeleteOpen.value = true;
+}
+
+function submitGdprDelete() {
+    gdprDeleteForm.post(route('reservations.bulk-delete'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            gdprDeleteOpen.value = false;
+            gdprDeleteForm.reset();
+        },
+    });
 }
 
 function commitDateRange() {
@@ -641,6 +665,17 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                     <Button v-if="hasActiveFilters" type="button" variant="ghost" class="h-9" data-testid="filter-clear" @click="clearAllFilters">
                         Filter zurücksetzen
                     </Button>
+
+                    <Button
+                        v-if="isOwner"
+                        type="button"
+                        variant="ghost"
+                        class="h-9 text-destructive hover:text-destructive"
+                        data-testid="gdpr-bulk-delete-open"
+                        @click="openGdprDelete"
+                    >
+                        DSGVO-Löschung
+                    </Button>
                 </div>
             </section>
 
@@ -1027,5 +1062,41 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                 </template>
             </SheetContent>
         </Sheet>
+
+        <Dialog v-model:open="gdprDeleteOpen">
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Daten DSGVO-konform löschen</DialogTitle>
+                    <DialogDescription>
+                        Alle Reservierungen mit dieser E-Mail-Adresse – samt Nachrichten, Antworten und Tisch-Zuordnungen – werden unwiderruflich
+                        gelöscht. Diese Aktion kann nicht rückgängig gemacht werden.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <form class="grid gap-2" @submit.prevent="submitGdprDelete">
+                    <Input
+                        v-model="gdprDeleteForm.email"
+                        type="email"
+                        placeholder="gast@example.com"
+                        autocomplete="off"
+                        data-testid="gdpr-bulk-delete-email"
+                    />
+                    <InputError :message="gdprDeleteForm.errors.email" />
+                </form>
+
+                <DialogFooter>
+                    <Button type="button" variant="ghost" @click="gdprDeleteOpen = false">Abbrechen</Button>
+                    <Button
+                        type="button"
+                        variant="destructive"
+                        data-testid="gdpr-bulk-delete-confirm"
+                        :disabled="gdprDeleteForm.processing || gdprDeleteForm.email.length === 0"
+                        @click="submitGdprDelete"
+                    >
+                        Endgültig löschen
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
     </AppLayout>
 </template>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import DashboardExportDropdown from '@/components/DashboardExportDropdown.vue';
 import ReservationThreadHistory from '@/components/ReservationThreadHistory.vue';
+import WaitlistBanner from '@/components/WaitlistBanner.vue';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
@@ -22,6 +23,7 @@ import {
     type NotificationSettings,
     type PaginatedReservationRequests,
     type ReservationRequestDetail,
+    type ReservationRequestRow,
     type ReservationSource,
     type ReservationStatus,
     type SharedData,
@@ -39,6 +41,7 @@ interface DashboardProps {
     stats: DashboardStats;
     selectedRequest?: ReservationRequestDetail | null;
     threadMessages?: ThreadMessage[] | null;
+    waitlistBanner: ReservationRequestRow[];
     openaiKeyRejectedAt?: string | null;
     sendMode?: 'manual' | 'shadow' | 'auto' | null;
 }
@@ -80,6 +83,7 @@ const STATUS_OPTIONS: { value: ReservationStatus; label: string }[] = [
     { value: 'confirmed', label: 'Bestätigt' },
     { value: 'declined', label: 'Abgelehnt' },
     { value: 'cancelled', label: 'Storniert' },
+    { value: 'waitlisted', label: 'Warteliste' },
 ];
 
 const SOURCE_OPTIONS: { value: ReservationSource; label: string }[] = [
@@ -94,6 +98,7 @@ const STATUS_BADGE_CLASS: Record<ReservationStatus, string> = {
     confirmed: 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200',
     declined: 'bg-rose-100 text-rose-900 dark:bg-rose-900/40 dark:text-rose-200',
     cancelled: 'bg-zinc-200 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-300',
+    waitlisted: 'bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200',
 };
 
 const STATUS_LABEL: Record<ReservationStatus, string> = Object.fromEntries(STATUS_OPTIONS.map((s) => [s.value, s.label])) as Record<
@@ -224,6 +229,25 @@ const drawerOpen = computed({
         });
     },
 });
+
+function openReservation(id: number): void {
+    router.visit(detailHref(id), {
+        only: ['selectedRequest'],
+        preserveScroll: true,
+        preserveState: true,
+    });
+}
+
+// PRD-013 waitlist transitions from the drawer. bulk-status validates the
+// transition server-side (canTransitionTo) and the redirect refreshes the
+// dashboard, so the drawer reflects the new status.
+function setReservationStatus(status: ReservationStatus): void {
+    const id = props.selectedRequest?.id;
+    if (id == null) {
+        return;
+    }
+    router.post(route('reservations.bulk-status'), { ids: [id], status }, { preserveScroll: true, preserveState: true });
+}
 
 const rawEmailOpen = ref(false);
 
@@ -544,6 +568,8 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                 </div>
             </header>
 
+            <WaitlistBanner :banner="props.waitlistBanner" :timezone="restaurantTimezone" @open="openReservation" />
+
             <section
                 class="flex flex-col gap-4 rounded-lg border border-border p-4"
                 data-testid="dashboard-filter-bar"
@@ -777,6 +803,30 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                         {{ STATUS_LABEL[props.selectedRequest.status] }}
                     </SheetDescription>
                 </SheetHeader>
+
+                <!-- PRD-013 waitlist transitions: park a new/in-review request, or
+                     resolve a waitlisted one. bulk-status enforces the allowed moves. -->
+                <div
+                    v-if="['new', 'in_review', 'waitlisted'].includes(props.selectedRequest.status)"
+                    class="flex flex-wrap gap-2"
+                    data-testid="waitlist-actions"
+                >
+                    <Button
+                        v-if="props.selectedRequest.status === 'new' || props.selectedRequest.status === 'in_review'"
+                        type="button"
+                        variant="outline"
+                        data-testid="action-waitlist"
+                        @click="setReservationStatus('waitlisted')"
+                    >
+                        Auf Warteliste
+                    </Button>
+                    <template v-if="props.selectedRequest.status === 'waitlisted'">
+                        <Button type="button" data-testid="action-confirm" @click="setReservationStatus('confirmed')">Bestätigen</Button>
+                        <Button type="button" variant="outline" data-testid="action-decline" @click="setReservationStatus('declined')">
+                            Ablehnen
+                        </Button>
+                    </template>
+                </div>
 
                 <div class="-mx-1 inline-flex gap-1 border-b border-border" role="tablist" data-testid="drawer-tabs">
                     <button

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -451,7 +451,9 @@ watch(
 );
 
 function pollOnly(): string[] {
-    const keys = ['requests', 'stats'];
+    // waitlistBanner is refreshed by the poll so a cancellation that frees a slot
+    // surfaces a waiting guest within one tick (PRD-013), without a full reload.
+    const keys = ['requests', 'stats', 'waitlistBanner'];
     if (props.selectedRequest != null) {
         keys.push('selectedRequest');
     }

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -28,7 +28,7 @@ import {
     type ThreadMessage,
 } from '@/types';
 import { Head, Link, router, usePage } from '@inertiajs/vue3';
-import { ChevronDown, Info } from 'lucide-vue-next';
+import { ChevronDown, Info, Phone } from 'lucide-vue-next';
 import { computed, ref, watch } from 'vue';
 
 const POLL_MS = 30_000;
@@ -514,18 +514,31 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                     <p class="text-sm text-muted-foreground">Reservierungs-Dashboard</p>
                 </div>
 
-                <div class="flex flex-wrap items-center gap-3 text-sm" data-testid="dashboard-stats">
-                    <span
-                        class="rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-200"
+                <div class="flex flex-wrap items-center gap-3">
+                    <!-- The primary action for the owner-on-the-phone: log a phone/walk-in
+                         reservation. Kept a prominent button, not buried in a dropdown. -->
+                    <Link
+                        :href="route('reservations.quick.create')"
+                        class="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground shadow-sm transition-colors hover:bg-primary/90"
+                        data-testid="quick-reservation-link"
                     >
-                        Neu: <strong>{{ props.stats.new }}</strong>
-                    </span>
-                    <span
-                        class="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-indigo-900 dark:border-indigo-900/40 dark:bg-indigo-950/40 dark:text-indigo-200"
-                    >
-                        In Bearbeitung: <strong>{{ props.stats.in_review }}</strong>
-                    </span>
-                    <DashboardExportDropdown :filters="props.filters" />
+                        <Phone class="size-4" />
+                        Telefon-Reservierung
+                    </Link>
+
+                    <div class="flex flex-wrap items-center gap-3 text-sm" data-testid="dashboard-stats">
+                        <span
+                            class="rounded-md border border-blue-200 bg-blue-50 px-3 py-1 text-blue-900 dark:border-blue-900/40 dark:bg-blue-950/40 dark:text-blue-200"
+                        >
+                            Neu: <strong>{{ props.stats.new }}</strong>
+                        </span>
+                        <span
+                            class="rounded-md border border-indigo-200 bg-indigo-50 px-3 py-1 text-indigo-900 dark:border-indigo-900/40 dark:bg-indigo-950/40 dark:text-indigo-200"
+                        >
+                            In Bearbeitung: <strong>{{ props.stats.in_review }}</strong>
+                        </span>
+                        <DashboardExportDropdown :filters="props.filters" />
+                    </div>
                 </div>
             </header>
 

--- a/resources/js/pages/Public/ConfirmedSync.vue
+++ b/resources/js/pages/Public/ConfirmedSync.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { Head } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    restaurant: {
+        name: string;
+    };
+    reservation: {
+        date: string;
+        time: string;
+        party_size: number;
+        guest_email_masked: string;
+    };
+}>();
+
+// The server sends the date already localised to the restaurant timezone as
+// `YYYY-MM-DD`; reformat to German `DD.MM.YYYY` by string split rather than
+// re-parsing through Date(), which would re-introduce a timezone shift.
+const germanDate = computed(() => {
+    const [year, month, day] = props.reservation.date.split('-');
+
+    return year && month && day ? `${day}.${month}.${year}` : props.reservation.date;
+});
+</script>
+
+<template>
+    <PublicLayout :heading="`Reservierung bei ${restaurant.name} bestätigt`" description="Ihr Tisch ist reserviert.">
+        <Head :title="`Reservierung bestätigt – ${restaurant.name}`" />
+
+        <dl class="space-y-3 text-sm">
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Datum</dt>
+                <dd class="font-medium">{{ germanDate }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Uhrzeit</dt>
+                <dd class="font-medium">{{ reservation.time }} Uhr</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Personen</dt>
+                <dd class="font-medium">{{ reservation.party_size }}</dd>
+            </div>
+        </dl>
+
+        <p class="mt-6 text-sm text-muted-foreground">Eine Bestätigung haben wir an {{ reservation.guest_email_masked }} geschickt.</p>
+
+        <p class="mt-4 border-t border-border pt-4 text-xs text-muted-foreground">
+            Diese Bestätigung wurde automatisch ausgesprochen, weil Ihr Wunschtermin frei war.
+        </p>
+    </PublicLayout>
+</template>

--- a/resources/js/pages/Public/GdprDeleted.vue
+++ b/resources/js/pages/Public/GdprDeleted.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { Head } from '@inertiajs/vue3';
+
+defineProps<{
+    restaurant: {
+        name: string;
+    };
+}>();
+</script>
+
+<template>
+    <PublicLayout heading="Deine Daten wurden gelöscht" description="Die Löschung ist abgeschlossen.">
+        <Head title="Daten gelöscht" />
+
+        <p class="text-sm text-muted-foreground">Wir haben alle gespeicherten Daten zu deiner Reservierung bei {{ restaurant.name }} entfernt.</p>
+    </PublicLayout>
+</template>

--- a/resources/js/pages/Public/GdprSelfService.vue
+++ b/resources/js/pages/Public/GdprSelfService.vue
@@ -1,0 +1,113 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import PublicLayout from '@/layouts/PublicLayout.vue';
+import { formatDateTime } from '@/lib/format-datetime';
+import { Head, useForm } from '@inertiajs/vue3';
+import { computed } from 'vue';
+
+const props = defineProps<{
+    reservation: {
+        guest_name: string;
+        guest_email: string;
+        guest_phone: string | null;
+        party_size: number;
+        status: string;
+        note: string | null;
+        desired_at: string | null;
+        created_at: string | null;
+    };
+    restaurant: {
+        name: string;
+        timezone: string;
+    };
+    deleteToken: string;
+}>();
+
+const STATUS_LABELS: Record<string, string> = {
+    new: 'Neu',
+    in_review: 'In Prüfung',
+    replied: 'Beantwortet',
+    confirmed: 'Bestätigt',
+    declined: 'Abgelehnt',
+    waitlisted: 'Warteliste',
+};
+
+const statusLabel = computed(() => STATUS_LABELS[props.reservation.status] ?? props.reservation.status);
+
+const localDateTime = (iso: string | null): string => (iso ? formatDateTime(iso, { timeZone: props.restaurant.timezone }) : '–');
+
+const desiredAt = computed(() => localDateTime(props.reservation.desired_at));
+const createdAt = computed(() => localDateTime(props.reservation.created_at));
+
+const form = useForm({ confirm_date: '' });
+
+const submitDelete = () => {
+    // Posts to the short-lived signed delete URL issued by the show endpoint.
+    form.post(props.deleteToken, { preserveScroll: true });
+};
+</script>
+
+<template>
+    <PublicLayout
+        :heading="`Deine Daten beim Restaurant ${restaurant.name}`"
+        description="Hier siehst du alle Daten, die wir zu deiner Reservierung gespeichert haben."
+    >
+        <Head title="Datenschutz – Deine Daten" />
+
+        <dl class="space-y-3 text-sm">
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Reservierung am</dt>
+                <dd class="font-medium">{{ desiredAt }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Personen</dt>
+                <dd class="font-medium">{{ reservation.party_size }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Status</dt>
+                <dd class="font-medium">{{ statusLabel }}</dd>
+            </div>
+        </dl>
+
+        <h2 class="mb-3 mt-6 text-sm font-semibold">Persönliche Daten</h2>
+        <dl class="space-y-3 text-sm">
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Name</dt>
+                <dd class="font-medium">{{ reservation.guest_name }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">E-Mail</dt>
+                <dd class="font-medium">{{ reservation.guest_email }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Telefon</dt>
+                <dd class="font-medium">{{ reservation.guest_phone ?? '–' }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Anmerkung</dt>
+                <dd class="font-medium">{{ reservation.note ?? '–' }}</dd>
+            </div>
+            <div class="flex justify-between gap-4">
+                <dt class="text-muted-foreground">Eingegangen am</dt>
+                <dd class="font-medium">{{ createdAt }}</dd>
+            </div>
+        </dl>
+
+        <form class="mt-8 rounded-lg border border-destructive/40 p-4" @submit.prevent="submitDelete">
+            <h2 class="text-sm font-semibold text-destructive">Daten löschen</h2>
+            <p class="mt-1 text-sm text-muted-foreground">
+                Bitte bestätige durch Eingabe des Reservierungs-Datums (TT.MM.JJJJ). Anschließend werden alle gespeicherten Daten zu dieser
+                Reservierung unwiderruflich gelöscht.
+            </p>
+            <div class="mt-3 grid gap-2">
+                <Label for="confirm-date" class="sr-only">Reservierungs-Datum</Label>
+                <Input id="confirm-date" v-model="form.confirm_date" placeholder="TT.MM.JJJJ" autocomplete="off" class="max-w-40" />
+                <InputError :message="form.errors.confirm_date" />
+            </div>
+            <Button type="submit" variant="destructive" class="mt-3" :disabled="form.processing"> Löschen bestätigen </Button>
+        </form>
+    </PublicLayout>
+</template>

--- a/resources/js/pages/Reservations/Quick.test.ts
+++ b/resources/js/pages/Reservations/Quick.test.ts
@@ -1,0 +1,213 @@
+import type { QuickAvailability, TableModel } from '@/types';
+import { mount, type VueWrapper } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import Quick from './Quick.vue';
+
+const { postSpy, visitSpy, reloadSpy } = vi.hoisted(() => ({
+    postSpy: vi.fn(),
+    visitSpy: vi.fn(),
+    reloadSpy: vi.fn(),
+}));
+
+vi.mock('@inertiajs/vue3', () => ({
+    Head: { name: 'Head', render: () => null },
+    router: {
+        post: (...args: unknown[]) => postSpy(...args),
+        visit: (...args: unknown[]) => visitSpy(...args),
+        reload: (...args: unknown[]) => reloadSpy(...args),
+    },
+}));
+
+vi.mock('@/layouts/AppLayout.vue', () => ({
+    default: { name: 'AppLayout', template: '<div data-testid="layout"><slot /></div>' },
+}));
+
+function makeTable(overrides: Partial<TableModel> = {}): TableModel {
+    return {
+        id: 1,
+        label: '1',
+        seats: 4,
+        room_tag: null,
+        sort_order: 1,
+        active: true,
+        combinable_with: [],
+        created_at: null,
+        ...overrides,
+    };
+}
+
+function makeAvailability(overrides: Partial<QuickAvailability> = {}): QuickAvailability {
+    return {
+        state: 'free',
+        suggested_table_id: 1,
+        combination: null,
+        alternative_slots: [],
+        ...overrides,
+    };
+}
+
+let wrapper: VueWrapper;
+let confirmSpy: ReturnType<typeof vi.fn>;
+
+function mountQuick(opts: { tables?: TableModel[]; availability?: QuickAvailability } = {}): VueWrapper {
+    wrapper = mount(Quick, {
+        props: {
+            tables: { data: opts.tables ?? [makeTable()] },
+            defaults: { date: '2026-06-15', time: '19:00', party_size: 2 },
+            availability: opts.availability ?? makeAvailability(),
+        },
+    });
+    return wrapper;
+}
+
+beforeEach(() => {
+    vi.useFakeTimers();
+    postSpy.mockReset();
+    visitSpy.mockReset();
+    reloadSpy.mockReset();
+    confirmSpy = vi.fn(() => true);
+    vi.stubGlobal('confirm', confirmSpy);
+    vi.stubGlobal('route', (name: string, params?: Record<string, unknown>) => (params ? `${name}/${Object.values(params).join('/')}` : name));
+});
+
+afterEach(() => {
+    // Unmount so the window keydown listener is removed before the next test.
+    wrapper?.unmount();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+});
+
+describe('Reservations/Quick.vue', () => {
+    it('reloads only the availability prop, debounced, when the date changes', async () => {
+        mountQuick();
+
+        await wrapper.get('[data-testid="field-date"]').setValue('2026-06-20');
+
+        await vi.advanceTimersByTimeAsync(249);
+        expect(reloadSpy).not.toHaveBeenCalled(); // still inside the 250ms debounce window
+
+        await vi.advanceTimersByTimeAsync(1);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+        expect(reloadSpy.mock.calls[0][0]).toMatchObject({
+            only: ['availability'],
+            data: { date: '2026-06-20', time: '19:00', party_size: 2 },
+        });
+    });
+
+    it('coerces party_size to a number in the availability reload and skips it while cleared', async () => {
+        mountQuick();
+
+        // The wrapper <Input>'s v-model.number is a no-op, so the form holds a
+        // string; the reload must coerce it back to a number.
+        await wrapper.get('[data-testid="field-party-size"]').setValue('5');
+        await vi.advanceTimersByTimeAsync(250);
+        expect(reloadSpy).toHaveBeenCalledTimes(1);
+        expect(reloadSpy.mock.calls[0][0].data.party_size).toBe(5);
+
+        // Clearing the field must not fire a reload with an empty/zero party size.
+        reloadSpy.mockClear();
+        await wrapper.get('[data-testid="field-party-size"]').setValue('');
+        await vi.advanceTimersByTimeAsync(250);
+        expect(reloadSpy).not.toHaveBeenCalled();
+    });
+
+    it('submits via router.post on Ctrl+Enter', async () => {
+        mountQuick();
+        await wrapper.get('[data-testid="field-name"]').setValue('Müller');
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true }));
+
+        expect(postSpy).toHaveBeenCalledTimes(1);
+        expect(postSpy.mock.calls[0][0]).toBe('reservations.quick.store');
+        expect(postSpy.mock.calls[0][1]).toMatchObject({
+            source: 'phone',
+            date: '2026-06-15',
+            time: '19:00',
+            party_size: 2,
+            guest_name: 'Müller',
+            // Empty optional fields are coerced to null, not '' .
+            guest_phone: null,
+            guest_email: null,
+            note: null,
+            table_id: null,
+        });
+    });
+
+    it('ignores a second Ctrl+Enter while a submit is in flight', async () => {
+        mountQuick();
+        await wrapper.get('[data-testid="field-name"]').setValue('Müller');
+
+        // The mocked router.post never resolves onFinish, so processing stays true.
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true }));
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true }));
+
+        expect(postSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('submits a manually chosen table override as a numeric id', async () => {
+        mountQuick({ tables: [makeTable({ id: 7, label: '7' }), makeTable({ id: 9, label: '9' })] });
+        await wrapper.get('[data-testid="field-name"]').setValue('Müller');
+
+        // Native <select> with :value="table.id": Vue returns the bound number,
+        // not the string "9" — this is the path the #344 review flagged.
+        await wrapper.get('[data-testid="field-table"]').setValue('9');
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', ctrlKey: true }));
+
+        expect(postSpy.mock.calls[0][1].table_id).toBe(9);
+    });
+
+    it('cancels without confirmation when the form is pristine', () => {
+        mountQuick();
+
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+
+        expect(confirmSpy).not.toHaveBeenCalled();
+        expect(visitSpy).toHaveBeenCalledWith('dashboard');
+    });
+
+    it('confirms before cancelling on Esc when the form is dirty', async () => {
+        mountQuick();
+        await wrapper.get('[data-testid="field-name"]').setValue('Müller');
+
+        confirmSpy.mockReturnValue(false);
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(confirmSpy).toHaveBeenCalledTimes(1);
+        expect(visitSpy).not.toHaveBeenCalled();
+
+        confirmSpy.mockReturnValue(true);
+        window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+        expect(visitSpy).toHaveBeenCalledWith('dashboard');
+    });
+
+    it('renders the suggested table in the banner when the slot is free', () => {
+        mountQuick({
+            tables: [makeTable({ id: 7, label: '7', seats: 4 })],
+            availability: makeAvailability({ suggested_table_id: 7 }),
+        });
+
+        const banner = wrapper.get('[data-testid="availability-banner"]');
+        expect(banner.text()).toContain('Slot frei');
+        expect(banner.text()).toContain('Tisch 7 (4 Plätze)');
+    });
+
+    it('lists clickable alternative slots when the slot is full and applies one on click', async () => {
+        mountQuick({
+            availability: makeAvailability({
+                state: 'full',
+                suggested_table_id: null,
+                alternative_slots: [
+                    { date: '2026-06-15', time: '18:30' },
+                    { date: '2026-06-15', time: '20:00' },
+                ],
+            }),
+        });
+
+        const alternatives = wrapper.findAll('[data-testid="alt-slot"]');
+        expect(alternatives).toHaveLength(2);
+        expect(alternatives[0].text()).toBe('18:30');
+
+        await alternatives[1].trigger('click');
+
+        expect((wrapper.get('[data-testid="field-time"]').element as HTMLInputElement).value).toBe('20:00');
+    });
+});

--- a/resources/js/pages/Reservations/Quick.vue
+++ b/resources/js/pages/Reservations/Quick.vue
@@ -1,0 +1,265 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/AppLayout.vue';
+import { type BreadcrumbItem, type QuickAvailability, type TableModel } from '@/types';
+import { Head, router } from '@inertiajs/vue3';
+import { useDebounceFn } from '@vueuse/core';
+import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
+
+const props = defineProps<{
+    tables: { data: TableModel[] };
+    defaults: { date: string; time: string; party_size: number };
+    availability: QuickAvailability;
+}>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'Telefon-Reservierung', href: '/reservations/quick' }];
+
+// Matches the native-select styling used by the public ReservationForm so the
+// dropdowns line up with the adjacent Input fields.
+const selectClass =
+    'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 md:text-sm';
+
+const form = reactive({
+    source: 'phone' as 'phone' | 'walk_in',
+    date: props.defaults.date,
+    time: props.defaults.time,
+    party_size: props.defaults.party_size,
+    guest_name: '',
+    guest_phone: '',
+    guest_email: '',
+    note: '',
+    table_id: null as number | null,
+});
+
+const errors = ref<Record<string, string>>({});
+const processing = ref(false);
+
+const tableById = computed(() => new Map(props.tables.data.map((table) => [table.id, table])));
+
+// Human-readable proposal for the banner: a single suggested table, or the
+// labels of a two-table combination, resolved from the `tables` prop.
+const proposedTables = computed<string | null>(() => {
+    const { suggested_table_id, combination } = props.availability;
+    if (suggested_table_id !== null) {
+        const table = tableById.value.get(suggested_table_id);
+        return table ? `Tisch ${table.label} (${table.seats} Plätze)` : null;
+    }
+    if (combination !== null) {
+        return combination.table_ids.map((id) => `Tisch ${tableById.value.get(id)?.label ?? `#${id}`}`).join(' + ');
+    }
+    return null;
+});
+
+const bannerClass = computed(
+    () =>
+        ({
+            free: 'border-green-300 bg-green-50 text-green-900',
+            tight: 'border-amber-300 bg-amber-50 text-amber-900',
+            full: 'border-red-300 bg-red-50 text-red-900',
+        })[props.availability.state],
+);
+
+// Dirty = the operator has typed something worth losing. Date/time/party always
+// carry the smart defaults, so they do not count; only the entered guest details
+// and note do.
+const isDirty = computed(() => form.guest_name !== '' || form.guest_phone !== '' || form.guest_email !== '' || form.note !== '');
+
+// Live availability: re-fetch only the `availability` prop on every slot change,
+// debounced so typing a date/time does not fire a request per keystroke. `form`
+// is a detached reactive object (not bound to props), so it survives the reload;
+// `preserveState` keeps the page from remounting. party_size is coerced because
+// the wrapper <Input>'s v-model.number is a no-op, and the reload is skipped
+// while the slot is incompletely entered so the server never sees an empty value.
+const refreshAvailability = useDebounceFn(() => {
+    const partySize = Number(form.party_size);
+    if (form.date === '' || form.time === '' || !Number.isFinite(partySize) || partySize < 1) {
+        return;
+    }
+    router.reload({
+        only: ['availability'],
+        data: { date: form.date, time: form.time, party_size: partySize },
+        preserveState: true,
+        preserveScroll: true,
+    });
+}, 250);
+
+watch(() => [form.date, form.time, form.party_size], refreshAvailability);
+
+function applySlot(slot: { date: string; time: string }): void {
+    form.date = slot.date;
+    form.time = slot.time;
+}
+
+function payload(): Record<string, unknown> {
+    return {
+        source: form.source,
+        date: form.date,
+        time: form.time,
+        party_size: Number(form.party_size),
+        guest_name: form.guest_name,
+        guest_phone: form.guest_phone === '' ? null : form.guest_phone,
+        guest_email: form.guest_email === '' ? null : form.guest_email,
+        note: form.note === '' ? null : form.note,
+        table_id: form.table_id,
+    };
+}
+
+function submit(): void {
+    if (processing.value) {
+        return;
+    }
+    processing.value = true;
+    errors.value = {};
+    // On success the controller redirects to the dashboard, so the page does not
+    // handle onSuccess itself.
+    router.post(route('reservations.quick.store'), payload(), {
+        preserveScroll: true,
+        onError: (received: Record<string, string>) => {
+            errors.value = received;
+        },
+        onFinish: () => {
+            processing.value = false;
+        },
+    });
+}
+
+function cancel(): void {
+    if (isDirty.value && !window.confirm('Eingaben verwerfen?')) {
+        return;
+    }
+    router.visit(route('dashboard'));
+}
+
+// Keyboard-first: Ctrl/Cmd+Enter submits from anywhere on the form, Esc cancels.
+// isComposing guards against firing mid-IME-composition.
+function onKeydown(event: KeyboardEvent): void {
+    if (event.isComposing) {
+        return;
+    }
+    if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+        event.preventDefault();
+        submit();
+    } else if (event.key === 'Escape') {
+        event.preventDefault();
+        cancel();
+    }
+}
+
+onMounted(() => window.addEventListener('keydown', onKeydown));
+onUnmounted(() => window.removeEventListener('keydown', onKeydown));
+</script>
+
+<template>
+    <Head title="Telefon-Reservierung" />
+
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <div class="mx-auto flex w-full max-w-2xl flex-col gap-6 p-4">
+            <h1 class="text-2xl font-semibold tracking-tight">Telefon-Reservierung</h1>
+
+            <form class="flex flex-col gap-4" @submit.prevent="submit">
+                <div class="grid gap-2">
+                    <Label for="quick-source">Art</Label>
+                    <select id="quick-source" v-model="form.source" data-testid="field-source" :class="selectClass">
+                        <option value="phone">Telefon</option>
+                        <option value="walk_in">Walk-in</option>
+                    </select>
+                </div>
+
+                <div class="grid grid-cols-3 gap-3">
+                    <div class="grid gap-2">
+                        <Label for="quick-date">Datum</Label>
+                        <Input id="quick-date" v-model="form.date" type="date" data-testid="field-date" required />
+                        <InputError :message="errors.date" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="quick-time">Zeit</Label>
+                        <Input id="quick-time" v-model="form.time" type="time" data-testid="field-time" required />
+                        <InputError :message="errors.time" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="quick-party">Personen</Label>
+                        <Input
+                            id="quick-party"
+                            v-model.number="form.party_size"
+                            type="number"
+                            min="1"
+                            max="20"
+                            data-testid="field-party-size"
+                            required
+                        />
+                        <InputError :message="errors.party_size" />
+                    </div>
+                </div>
+
+                <div class="rounded-lg border p-3 text-sm" :class="bannerClass" data-testid="availability-banner">
+                    <p v-if="availability.state === 'free'">
+                        Slot frei<span v-if="proposedTables"> – {{ proposedTables }} wird vorgeschlagen</span>
+                    </p>
+                    <p v-else-if="availability.state === 'tight'">
+                        Slot knapp<span v-if="proposedTables"> – {{ proposedTables }} passt noch</span>, andere Slots sind sicherer
+                    </p>
+                    <template v-else>
+                        <p>Slot belegt.</p>
+                        <div v-if="availability.alternative_slots.length > 0" class="mt-2 flex flex-wrap items-center gap-2">
+                            <span>Vorschläge:</span>
+                            <button
+                                v-for="slot in availability.alternative_slots"
+                                :key="`${slot.date} ${slot.time}`"
+                                type="button"
+                                class="rounded border border-current px-2 py-0.5 underline"
+                                data-testid="alt-slot"
+                                @click="applySlot(slot)"
+                            >
+                                {{ slot.time }}
+                            </button>
+                        </div>
+                    </template>
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="quick-name">Name</Label>
+                    <Input id="quick-name" v-model="form.guest_name" data-testid="field-name" required />
+                    <InputError :message="errors.guest_name" />
+                </div>
+
+                <div class="grid grid-cols-2 gap-3">
+                    <div class="grid gap-2">
+                        <Label for="quick-phone">Telefon</Label>
+                        <Input id="quick-phone" v-model="form.guest_phone" data-testid="field-phone" placeholder="+49 …" />
+                        <InputError :message="errors.guest_phone" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="quick-email">E-Mail</Label>
+                        <Input id="quick-email" v-model="form.guest_email" type="email" data-testid="field-email" placeholder="optional" />
+                        <InputError :message="errors.guest_email" />
+                    </div>
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="quick-note">Anmerkung</Label>
+                    <Input id="quick-note" v-model="form.note" data-testid="field-note" placeholder="optional, z. B. Geburtstag" />
+                    <InputError :message="errors.note" />
+                </div>
+
+                <div class="grid gap-2">
+                    <Label for="quick-table">Tisch</Label>
+                    <select id="quick-table" v-model="form.table_id" data-testid="field-table" :class="selectClass">
+                        <option :value="null">Automatisch zuweisen</option>
+                        <option v-for="table in tables.data" :key="table.id" :value="table.id">
+                            Tisch {{ table.label }} ({{ table.seats }} Plätze)
+                        </option>
+                    </select>
+                    <InputError :message="errors.table_id" />
+                </div>
+
+                <div class="mt-2 flex justify-end gap-2">
+                    <Button type="button" variant="outline" data-testid="cancel" @click="cancel">Abbrechen (Esc)</Button>
+                    <Button type="submit" :disabled="processing" data-testid="submit">Speichern (Strg+Enter)</Button>
+                </div>
+            </form>
+        </div>
+    </AppLayout>
+</template>

--- a/resources/js/pages/settings/SendMode.vue
+++ b/resources/js/pages/settings/SendMode.vue
@@ -5,6 +5,7 @@ import { computed, ref } from 'vue';
 import HeadingSmall from '@/components/HeadingSmall.vue';
 import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -27,6 +28,7 @@ interface Props {
     partySizeMax: number;
     minLeadTimeMinutes: number;
     sendModeChangedAt: string | null;
+    webSyncConfirmEnabled: boolean;
     shadowStats: ShadowStats;
 }
 
@@ -38,6 +40,7 @@ const form = useForm({
     send_mode: props.sendMode,
     auto_send_party_size_max: props.partySizeMax,
     auto_send_min_lead_time_minutes: props.minLeadTimeMinutes,
+    web_sync_confirm_enabled: props.webSyncConfirmEnabled,
 });
 
 const pendingMode = ref<SendMode | null>(null);
@@ -177,6 +180,24 @@ const triggerKillswitch = () => {
                         <Label for="min-lead-time"> Mindest-Vorlauf in Minuten </Label>
                         <Input id="min-lead-time" type="number" min="0" max="1440" v-model="form.auto_send_min_lead_time_minutes" />
                         <InputError :message="form.errors.auto_send_min_lead_time_minutes" />
+                    </div>
+
+                    <div class="rounded-lg border border-border p-4 md:col-span-2">
+                        <div class="flex items-center gap-3">
+                            <Checkbox
+                                id="web-sync-confirm-toggle"
+                                :checked="form.web_sync_confirm_enabled"
+                                :disabled="form.processing"
+                                data-testid="web-sync-confirm-toggle"
+                                @update:checked="(value) => (form.web_sync_confirm_enabled = Boolean(value))"
+                            />
+                            <Label for="web-sync-confirm-toggle">Online-Sofort-Bestätigung aktivieren</Label>
+                        </div>
+                        <p class="mt-2 text-sm text-muted-foreground">
+                            Wenn Web-Anfragen einen eindeutig freien Slot treffen, wird die Bestätigung direkt nach dem Absenden versandt. Greift
+                            NICHT bei knappem oder belegtem Slot, bei Gruppen über der Auto-Versand-Grenze oder bei zu kurzem Vorlauf.
+                        </p>
+                        <InputError :message="form.errors.web_sync_confirm_enabled" />
                     </div>
 
                     <div class="md:col-span-2">

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -127,6 +127,19 @@ export interface DayAvailability {
     reserved_seats: number;
 }
 
+export interface TableCombination {
+    primary_table_id: number;
+    table_ids: number[];
+    total_seats: number;
+}
+
+export interface QuickAvailability {
+    state: SlotState;
+    suggested_table_id: number | null;
+    combination: TableCombination | null;
+    alternative_slots: Array<{ date: string; time: string }>;
+}
+
 export interface DashboardFilters {
     status?: ReservationStatus[];
     source?: ReservationSource[];

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -54,7 +54,7 @@ export interface User {
 
 export type BreadcrumbItemType = BreadcrumbItem;
 
-export type ReservationStatus = 'new' | 'in_review' | 'replied' | 'confirmed' | 'declined' | 'cancelled';
+export type ReservationStatus = 'new' | 'in_review' | 'replied' | 'confirmed' | 'declined' | 'cancelled' | 'waitlisted';
 export type ReservationSource = 'web_form' | 'email';
 
 export interface ReservationRequestRow {

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -92,6 +92,13 @@ declare module 'ziggy-js' {
             "binding": "slug"
         }
     ],
+    "gdpr.self-service": [
+        {
+            "name": "reservation",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "profile.edit": [],
     "profile.update": [],
     "profile.destroy": [],

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -26,6 +26,7 @@ declare module 'ziggy-js' {
         }
     ],
     "reservations.bulk-status": [],
+    "reservations.bulk-delete": [],
     "reservation-replies.approve": [
         {
             "name": "reply",

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -12,6 +12,7 @@ declare module 'ziggy-js' {
         }
     ],
     "reservations.quick.create": [],
+    "reservations.quick.store": [],
     "reservations.show": [
         {
             "name": "reservation",

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -11,6 +11,7 @@ declare module 'ziggy-js' {
             "required": true
         }
     ],
+    "reservations.quick.create": [],
     "reservations.show": [
         {
             "name": "reservation",

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -99,6 +99,13 @@ declare module 'ziggy-js' {
             "binding": "id"
         }
     ],
+    "gdpr.self-service.delete": [
+        {
+            "name": "reservation",
+            "required": true,
+            "binding": "id"
+        }
+    ],
     "profile.edit": [],
     "profile.update": [],
     "profile.destroy": [],

--- a/resources/views/emails/reservation-reply.blade.php
+++ b/resources/views/emails/reservation-reply.blade.php
@@ -1,1 +1,5 @@
+@if ($syncConfirm)
+Diese Bestätigung wurde automatisch erstellt.
+
+@endif
 {!! $body !!}

--- a/resources/views/emails/reservation-reply.blade.php
+++ b/resources/views/emails/reservation-reply.blade.php
@@ -3,3 +3,8 @@ Diese Bestätigung wurde automatisch erstellt.
 
 @endif
 {!! $body !!}
+
+─────────────────────────────────────────────
+Datenschutz: Welche Daten haben wir von dir?
+Hier ansehen oder löschen → {!! $gdprLink !!}
+─────────────────────────────────────────────

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,10 @@ Route::get('reservations/quick', [QuickReservationController::class, 'create'])
     ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])
     ->name('reservations.quick.create');
 
+Route::post('reservations/quick', [QuickReservationController::class, 'store'])
+    ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])
+    ->name('reservations.quick.store');
+
 Route::get('reservations/{reservation}', [ReservationRequestController::class, 'show'])
     ->whereNumber('reservation')
     ->middleware(['auth', 'verified'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,5 +116,10 @@ Route::get('gdpr/{reservation}', [GdprSelfServiceController::class, 'show'])
     ->middleware('signed')
     ->name('gdpr.self-service');
 
+Route::post('gdpr/{reservation}/delete', [GdprSelfServiceController::class, 'delete'])
+    ->whereNumber('reservation')
+    ->middleware('signed')
+    ->name('gdpr.self-service.delete');
+
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ExportController;
 use App\Http\Controllers\PublicReservationController;
+use App\Http\Controllers\QuickReservationController;
 use App\Http\Controllers\ReservationMessagesController;
 use App\Http\Controllers\ReservationReplyController;
 use App\Http\Controllers\ReservationRequestController;
@@ -34,6 +35,12 @@ Route::get('exports/download/{token}', [ExportController::class, 'download'])
     ->whereNumber('token')
     ->middleware(['auth', 'verified', 'signed'])
     ->name('exports.download');
+
+// Static segment registered before the {reservation} wildcard (static-before-
+// wildcard convention, mirroring tables/availability vs tables/{table}).
+Route::get('reservations/quick', [QuickReservationController::class, 'create'])
+    ->middleware(['auth', 'verified', 'can:viewAny,'.Table::class])
+    ->name('reservations.quick.create');
 
 Route::get('reservations/{reservation}', [ReservationRequestController::class, 'show'])
     ->whereNumber('reservation')

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ExportController;
+use App\Http\Controllers\GdprSelfServiceController;
 use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\QuickReservationController;
 use App\Http\Controllers\ReservationMessagesController;
@@ -107,6 +108,13 @@ Route::post('r/{restaurant:slug}/reservations', [PublicReservationController::cl
 
 Route::get('r/{restaurant:slug}/reservations/thanks', [PublicReservationController::class, 'thanks'])
     ->name('public.reservations.thanks');
+
+// Public, login-less GDPR self-service (PRD-015). Signed link from the
+// confirmation mail; the signature is the only guard (no auth, scoped by id).
+Route::get('gdpr/{reservation}', [GdprSelfServiceController::class, 'show'])
+    ->whereNumber('reservation')
+    ->middleware('signed')
+    ->name('gdpr.self-service');
 
 require __DIR__.'/settings.php';
 require __DIR__.'/auth.php';

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,6 +61,11 @@ Route::post('reservations/bulk-status', [ReservationRequestController::class, 'b
     ->middleware(['auth', 'verified'])
     ->name('reservations.bulk-status');
 
+// Owner-only GDPR bulk-delete by email (PRD-015); authorization in the request.
+Route::post('reservations/bulk-delete', [ReservationRequestController::class, 'bulkGdprDelete'])
+    ->middleware(['auth', 'verified'])
+    ->name('reservations.bulk-delete');
+
 Route::post('reservation-replies/{reply}/approve', [ReservationReplyController::class, 'approve'])
     ->middleware(['auth', 'verified', 'can:approve,reply'])
     ->name('reservation-replies.approve');

--- a/tests/Feature/AutoSend/SendModeSettingsTest.php
+++ b/tests/Feature/AutoSend/SendModeSettingsTest.php
@@ -159,6 +159,95 @@ class SendModeSettingsTest extends TestCase
             ->assertSessionHasErrors('send_mode');
     }
 
+    public function test_it_exposes_web_sync_confirm_enabled_on_the_edit_page(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $restaurant->forceFill(['web_sync_confirm_enabled' => true])->save();
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->get(route('settings.send-mode.edit'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('settings/SendMode')
+                ->where('webSyncConfirmEnabled', true)
+            );
+    }
+
+    public function test_it_allows_owner_to_enable_web_sync_confirm(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $owner = $this->makeOwner($restaurant);
+        $this->assertFalse((bool) $restaurant->fresh()->web_sync_confirm_enabled);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+                'web_sync_confirm_enabled' => true,
+            ])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertTrue($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
+    public function test_it_allows_owner_to_disable_web_sync_confirm(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $restaurant->forceFill(['web_sync_confirm_enabled' => true])->save();
+        $owner = $this->makeOwner($restaurant);
+
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+                'web_sync_confirm_enabled' => false,
+            ])
+            ->assertRedirect();
+
+        $this->assertFalse($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
+    public function test_it_forbids_staff_from_enabling_web_sync_confirm(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $staff = User::factory()->create([
+            'restaurant_id' => $restaurant->id,
+            'role' => UserRole::Staff,
+        ]);
+
+        $this->actingAs($staff)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+                'web_sync_confirm_enabled' => true,
+            ])
+            ->assertForbidden();
+
+        $this->assertFalse($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
+    public function test_it_leaves_web_sync_confirm_untouched_when_the_field_is_absent(): void
+    {
+        $restaurant = $this->makeRestaurantWithMode(SendMode::Manual);
+        $restaurant->forceFill(['web_sync_confirm_enabled' => true])->save();
+        $owner = $this->makeOwner($restaurant);
+
+        // A submit without the toggle field must not silently disable it.
+        $this->actingAs($owner)
+            ->patch(route('settings.send-mode.update'), [
+                'send_mode' => SendMode::Manual->value,
+                'auto_send_party_size_max' => 10,
+                'auto_send_min_lead_time_minutes' => 90,
+            ])
+            ->assertRedirect();
+
+        $this->assertTrue($restaurant->fresh()->web_sync_confirm_enabled);
+    }
+
     private function makeRestaurantWithMode(SendMode $mode): Restaurant
     {
         $restaurant = Restaurant::factory()->create();

--- a/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
+++ b/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
@@ -1,0 +1,291 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AutoSend;
+
+use App\Enums\ReservationReplyStatus;
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Events\ReservationRequestReceived;
+use App\Jobs\GenerateReservationReplyJob;
+use App\Mail\ReservationReplyMail;
+use App\Models\ReservationMessage;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\AI\OpenAiReplyGenerator;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Mail;
+use OpenAI\Exceptions\TransporterException;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Responses\Chat\CreateResponse;
+use Psr\Log\LoggerInterface;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * End-to-end coverage of the PRD-014 web sync-confirm path on the public
+ * submit endpoint (#355): a free-slot web reservation is confirmed inside
+ * the request, with a synchronous AI reply, an auto table assignment and an
+ * immediate mail — falling back to the unchanged V1 path on any failure.
+ */
+class WebSyncConfirmFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Frozen well before the desired slot so the lead-time gate passes;
+        // UTC timezone keeps local form input equal to the stored UTC instant.
+        Carbon::setTestNow('2026-05-23 12:00:00');
+
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'slug' => 'demo',
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+            'web_sync_confirm_enabled' => true,
+            'auto_send_party_size_max' => 10,
+            'auto_send_min_lead_time_minutes' => 90,
+        ]);
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function validPayload(array $overrides = []): array
+    {
+        return array_merge([
+            'guest_name' => 'Alice Example',
+            'guest_email' => 'alice@gmail.com',
+            'guest_phone' => '+49 30 1234567',
+            'party_size' => 4,
+            'desired_at' => '2026-06-15 19:00',
+            'message' => 'Fensterplatz wäre toll.',
+        ], $overrides);
+    }
+
+    /**
+     * Bind the generator to the OpenAI fake without the production
+     * sync-client factory, so `generateSync` uses the faked client instead
+     * of building a real timeout-bounded one.
+     *
+     * @param  array<int, mixed>  $responses
+     */
+    private function fakeOpenAi(array $responses): void
+    {
+        $fake = OpenAI::fake($responses);
+
+        $this->app->bind(OpenAiReplyGenerator::class, fn ($app): OpenAiReplyGenerator => new OpenAiReplyGenerator(
+            $fake,
+            $app->make(LoggerInterface::class),
+        ));
+    }
+
+    private function replyResponse(string $body = 'Guten Tag Alice, Ihr Tisch ist bestätigt.'): CreateResponse
+    {
+        return CreateResponse::fake([
+            'choices' => [
+                ['index' => 0, 'message' => ['role' => 'assistant', 'content' => $body], 'finish_reason' => 'stop'],
+            ],
+        ]);
+    }
+
+    private function timeoutException(): TransporterException
+    {
+        return new TransporterException(
+            new ConnectException(
+                'cURL error 28: Operation timed out',
+                new Request('POST', 'https://api.openai.com/v1/chat/completions'),
+            ),
+        );
+    }
+
+    public function test_sync_confirm_succeeds_and_sends_mail(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        Mail::fake();
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $this->withHeaders(['X-Inertia' => 'true'])
+            ->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertOk();
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::Confirmed, $reservation->status);
+        $this->assertSame(ReservationSource::WebForm, $reservation->source);
+
+        $reply = ReservationReply::withoutGlobalScopes()->sole();
+        $this->assertTrue($reply->sync_confirm);
+        $this->assertSame(ReservationReplyStatus::Sent, $reply->status);
+        $this->assertNotNull($reply->sent_at);
+
+        Mail::assertSent(ReservationReplyMail::class);
+        // The sync path handled everything — the async draft pipeline must not fire.
+        Event::assertNotDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_sync_confirm_renders_the_confirmed_sync_page(): void
+    {
+        Mail::fake();
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            // Second arg false: the Vue page lands in #357; skip the file check.
+            ->assertInertia(fn ($page) => $page
+                ->component('Public/ConfirmedSync', false)
+                ->where('reservation.party_size', 4)
+                ->where('reservation.date', '2026-06-15')
+                ->where('reservation.time', '19:00')
+                ->where('reservation.guest_email_masked', 'a…@gmail.com')
+                ->where('restaurant.name', $this->restaurant->name)
+            );
+    }
+
+    public function test_sync_confirm_creates_a_table_assignment(): void
+    {
+        Mail::fake();
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $this->withHeaders(['X-Inertia' => 'true'])
+            ->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertOk();
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $table = Table::query()->withoutGlobalScopes()->sole();
+
+        $assignment = ReservationTableAssignment::withoutGlobalScopes()->sole();
+        $this->assertSame($reservation->id, $assignment->reservation_request_id);
+        $this->assertSame($table->id, $assignment->table_id);
+        $this->assertNull($assignment->assigned_by_user_id);
+    }
+
+    public function test_sync_confirm_falls_back_on_openai_timeout(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        Mail::fake();
+        $this->fakeOpenAi([$this->timeoutException()]);
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::New, $reservation->status);
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+        $this->assertSame(0, ReservationTableAssignment::withoutGlobalScopes()->count());
+
+        Mail::assertNothingSent();
+        // V1 path must take over so the request still gets an async draft.
+        Event::assertDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_sync_confirm_falls_back_on_smtp_failure(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        // Make the synchronous send throw; the transaction must roll back the
+        // reply + assignment and the controller must fall through to V1.
+        Mail::shouldReceive('to')->andReturnSelf();
+        Mail::shouldReceive('send')->andThrow(new RuntimeException('smtp down'));
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::New, $reservation->status);
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+        $this->assertSame(0, ReservationTableAssignment::withoutGlobalScopes()->count());
+        // The outbound message is written before the send, so the rollback must
+        // also drop it — no orphaned audit row for a mail that never went out.
+        $this->assertSame(0, ReservationMessage::withoutGlobalScopes()->count());
+
+        Event::assertDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_two_submits_for_the_same_slot_confirm_only_once(): void
+    {
+        Mail::fake();
+        // Both submits may attempt a sync reply; queue two responses.
+        $this->fakeOpenAi([$this->replyResponse(), $this->replyResponse()]);
+
+        // First submit takes the only table for the slot.
+        $this->withHeaders(['X-Inertia' => 'true'])
+            ->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertOk();
+
+        // Second submit for the same slot can no longer find a free table, so it
+        // falls back to the V1 path (status new). (lockForUpdate is a no-op on
+        // SQLite; the in-transaction re-check is what serialises real bookings.)
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $confirmed = ReservationRequest::withoutGlobalScopes()
+            ->where('status', ReservationStatus::Confirmed)->count();
+        $new = ReservationRequest::withoutGlobalScopes()
+            ->where('status', ReservationStatus::New)->count();
+
+        $this->assertSame(1, $confirmed);
+        $this->assertSame(1, $new);
+        Mail::assertSent(ReservationReplyMail::class, 1);
+    }
+
+    public function test_v1_path_when_sync_confirm_is_disabled_for_the_restaurant(): void
+    {
+        Event::fake([ReservationRequestReceived::class]);
+        Mail::fake();
+        $this->restaurant->update(['web_sync_confirm_enabled' => false]);
+
+        $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
+            ->assertRedirect(route('public.reservations.thanks', $this->restaurant));
+
+        $reservation = ReservationRequest::withoutGlobalScopes()->sole();
+        $this->assertSame(ReservationStatus::New, $reservation->status);
+        $this->assertSame(0, ReservationReply::withoutGlobalScopes()->count());
+        Mail::assertNothingSent();
+        Event::assertDispatched(ReservationRequestReceived::class);
+    }
+
+    public function test_email_source_request_is_never_sync_confirmed(): void
+    {
+        // An email-ingested request runs the async draft pipeline, never the
+        // sync-confirm path: the resulting reply must not be flagged sync_confirm.
+        $this->fakeOpenAi([$this->replyResponse()]);
+
+        $request = ReservationRequest::factory()->for($this->restaurant)->create([
+            'source' => ReservationSource::Email,
+            'status' => ReservationStatus::New,
+            'desired_at' => Carbon::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 4,
+        ]);
+
+        (new GenerateReservationReplyJob($request->id))->handle();
+
+        $reply = ReservationReply::withoutGlobalScopes()->sole();
+        $this->assertFalse((bool) $reply->sync_confirm);
+        $this->assertSame(0, ReservationTableAssignment::withoutGlobalScopes()->count());
+    }
+}

--- a/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
+++ b/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
@@ -155,9 +155,8 @@ class WebSyncConfirmFlowTest extends TestCase
         $this->fakeOpenAi([$this->replyResponse()]);
 
         $this->post(route('public.reservations.store', $this->restaurant), $this->validPayload())
-            // Second arg false: the Vue page lands in #357; skip the file check.
             ->assertInertia(fn ($page) => $page
-                ->component('Public/ConfirmedSync', false)
+                ->component('Public/ConfirmedSync')
                 ->where('reservation.party_size', 4)
                 ->where('reservation.date', '2026-06-15')
                 ->where('reservation.time', '19:00')

--- a/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
+++ b/tests/Feature/AutoSend/WebSyncConfirmFlowTest.php
@@ -143,7 +143,8 @@ class WebSyncConfirmFlowTest extends TestCase
         $this->assertSame(ReservationReplyStatus::Sent, $reply->status);
         $this->assertNotNull($reply->sent_at);
 
-        Mail::assertSent(ReservationReplyMail::class);
+        // Sent with the sync-confirm transparency flag (#356).
+        Mail::assertSent(ReservationReplyMail::class, fn (ReservationReplyMail $mail): bool => $mail->syncConfirm === true);
         // The sync path handled everything — the async draft pipeline must not fire.
         Event::assertNotDispatched(ReservationRequestReceived::class);
     }

--- a/tests/Feature/Dashboard/DashboardBulkDeleteTest.php
+++ b/tests/Feature/Dashboard/DashboardBulkDeleteTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Dashboard;
+
+use App\Enums\UserRole;
+use App\Models\GdprAudit;
+use App\Models\ReservationMessage;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardBulkDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->restaurant = Restaurant::factory()->create();
+    }
+
+    private function owner(): User
+    {
+        return User::factory()->create(['restaurant_id' => $this->restaurant->id, 'role' => UserRole::Owner]);
+    }
+
+    private function staff(): User
+    {
+        return User::factory()->create(['restaurant_id' => $this->restaurant->id, 'role' => UserRole::Staff]);
+    }
+
+    public function test_owner_can_bulk_delete_email_matches_with_related_records(): void
+    {
+        $match = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+        ReservationReply::factory()->create(['reservation_request_id' => $match->id]);
+        ReservationMessage::factory()->create(['reservation_request_id' => $match->id]);
+        $table = Table::factory()->for($this->restaurant)->create();
+        ReservationTableAssignment::factory()->for($match, 'reservationRequest')->for($table)->create();
+
+        $other = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'someone-else@gmail.com']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertDatabaseMissing('reservation_requests', ['id' => $match->id]);
+        $this->assertDatabaseMissing('reservation_replies', ['reservation_request_id' => $match->id]);
+        $this->assertDatabaseMissing('reservation_messages', ['reservation_request_id' => $match->id]);
+        $this->assertDatabaseMissing('reservation_table_assignments', ['reservation_request_id' => $match->id]);
+
+        // A non-matching email is untouched.
+        $this->assertDatabaseHas('reservation_requests', ['id' => $other->id]);
+    }
+
+    public function test_match_is_on_exact_email_not_a_substring(): void
+    {
+        $exact = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'anna@gmail.com']);
+        $similar = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'anna@gmail.community.org']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'anna@gmail.com'])
+            ->assertRedirect();
+
+        $this->assertDatabaseMissing('reservation_requests', ['id' => $exact->id]);
+        $this->assertDatabaseHas('reservation_requests', ['id' => $similar->id]);
+    }
+
+    public function test_service_user_cannot_bulk_delete(): void
+    {
+        $reservation = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+
+        $this->actingAs($this->staff())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('reservation_requests', ['id' => $reservation->id]);
+        $this->assertSame(0, GdprAudit::query()->count());
+    }
+
+    public function test_bulk_delete_writes_an_owner_audit_entry_without_pii(): void
+    {
+        ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertRedirect();
+
+        $audit = GdprAudit::query()->sole();
+        $this->assertSame(GdprAudit::ACTION_OWNER_BULK_DELETE, $audit->action);
+        $this->assertSame($this->restaurant->id, $audit->restaurant_id);
+        $this->assertStringNotContainsString('gast@gmail.com', json_encode($audit->getAttributes(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_bulk_delete_does_not_cross_the_tenant_boundary(): void
+    {
+        $otherRestaurant = Restaurant::factory()->create();
+        $foreign = ReservationRequest::factory()->for($otherRestaurant)->create(['guest_email' => 'gast@gmail.com']);
+        $own = ReservationRequest::factory()->for($this->restaurant)->create(['guest_email' => 'gast@gmail.com']);
+
+        $this->actingAs($this->owner())
+            ->post(route('reservations.bulk-delete'), ['email' => 'gast@gmail.com'])
+            ->assertRedirect();
+
+        // Same email in another restaurant is never touched.
+        $this->assertDatabaseHas('reservation_requests', ['id' => $foreign->id]);
+        $this->assertDatabaseMissing('reservation_requests', ['id' => $own->id]);
+
+        // The audit is scoped to the acting owner's restaurant.
+        $audit = GdprAudit::query()->sole();
+        $this->assertSame($this->restaurant->id, $audit->restaurant_id);
+    }
+
+    public function test_email_is_required(): void
+    {
+        $this->actingAs($this->owner())
+            ->from('/dashboard')
+            ->post(route('reservations.bulk-delete'), [])
+            ->assertRedirect('/dashboard')
+            ->assertSessionHasErrors('email');
+    }
+}

--- a/tests/Feature/Gdpr/GdprAuditTest.php
+++ b/tests/Feature/Gdpr/GdprAuditTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Gdpr;
+
+use App\Models\GdprAudit;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class GdprAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_record_writes_a_row_with_action_and_restaurant_only(): void
+    {
+        Carbon::setTestNow('2026-05-23 12:00:00');
+        $restaurant = Restaurant::factory()->create();
+
+        $audit = GdprAudit::record(GdprAudit::ACTION_VIEW, $restaurant->id);
+
+        $this->assertDatabaseCount('gdpr_audits', 1);
+        $this->assertSame(GdprAudit::ACTION_VIEW, $audit->action);
+        $this->assertSame($restaurant->id, $audit->restaurant_id);
+        $this->assertTrue(Carbon::parse('2026-05-23 12:00:00')->equalTo($audit->created_at));
+
+        Carbon::setTestNow();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function actionProvider(): iterable
+    {
+        yield 'view' => [GdprAudit::ACTION_VIEW];
+        yield 'delete' => [GdprAudit::ACTION_DELETE];
+        yield 'owner_bulk_delete' => [GdprAudit::ACTION_OWNER_BULK_DELETE];
+    }
+
+    #[DataProvider('actionProvider')]
+    public function test_record_persists_each_action_constant(string $action): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        GdprAudit::record($action, $restaurant->id);
+
+        $this->assertDatabaseHas('gdpr_audits', [
+            'action' => $action,
+            'restaurant_id' => $restaurant->id,
+        ]);
+    }
+
+    public function test_the_table_has_no_pii_columns(): void
+    {
+        $columns = Schema::getColumnListing('gdpr_audits');
+
+        sort($columns);
+        $this->assertSame(['action', 'created_at', 'id', 'restaurant_id'], $columns);
+
+        // Explicit guard against PII creeping in via a later migration.
+        foreach (['guest_email', 'guest_name', 'guest_phone', 'reservation_id', 'reservation_request_id', 'ip_address', 'user_agent'] as $forbidden) {
+            $this->assertNotContains($forbidden, $columns, "gdpr_audits must not carry the PII column [{$forbidden}].");
+        }
+    }
+
+    public function test_the_table_has_no_updated_at(): void
+    {
+        // Append-only: a row is either written or absent, never updated.
+        $this->assertFalse(Schema::hasColumn('gdpr_audits', 'updated_at'));
+    }
+}

--- a/tests/Feature/Gdpr/GdprDeleteTest.php
+++ b/tests/Feature/Gdpr/GdprDeleteTest.php
@@ -64,7 +64,7 @@ class GdprDeleteTest extends TestCase
         $this->get($showUrl)
             ->assertOk()
             ->assertInertia(fn ($page) => $page
-                ->component('Public/GdprSelfService', false)
+                ->component('Public/GdprSelfService')
                 ->where('deleteToken', fn (string $token): bool => str_contains($token, '/gdpr/'.$reservation->id.'/delete')
                     && str_contains($token, 'signature='))
             );
@@ -96,7 +96,12 @@ class GdprDeleteTest extends TestCase
 
         $this->post($this->signedDeleteUrl($reservation), [
             'confirm_date' => $this->expectedConfirmDate($reservation),
-        ])->assertOk();
+        ])
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Public/GdprDeleted')
+                ->where('restaurant.name', $this->restaurant->name)
+            );
 
         $this->assertDatabaseMissing('reservation_requests', ['id' => $reservation->id]);
         $this->assertDatabaseMissing('reservation_replies', ['reservation_request_id' => $reservation->id]);

--- a/tests/Feature/Gdpr/GdprDeleteTest.php
+++ b/tests/Feature/Gdpr/GdprDeleteTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Gdpr;
+
+use App\Models\GdprAudit;
+use App\Models\ReservationMessage;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class GdprDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->restaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+    }
+
+    private function reservation(array $overrides = []): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($this->restaurant)->create(array_merge([
+            'guest_name' => 'Anna Müller',
+            'guest_email' => 'anna@gmail.com',
+            // 2026-06-15 19:00 Europe/Berlin → 17:00 UTC; local date is 15.06.2026.
+            'desired_at' => CarbonImmutable::parse('2026-06-15 17:00:00', 'UTC'),
+        ], $overrides));
+    }
+
+    private function expectedConfirmDate(ReservationRequest $reservation): string
+    {
+        return CarbonImmutable::instance($reservation->desired_at)
+            ->setTimezone($this->restaurant->timezone)
+            ->format('d.m.Y');
+    }
+
+    private function signedDeleteUrl(ReservationRequest $reservation): string
+    {
+        return URL::temporarySignedRoute(
+            'gdpr.self-service.delete',
+            now()->addMinutes(15),
+            ['reservation' => $reservation->id],
+        );
+    }
+
+    public function test_show_issues_a_signed_delete_token(): void
+    {
+        $reservation = $this->reservation();
+
+        $showUrl = URL::temporarySignedRoute('gdpr.self-service', now()->addDays(30), ['reservation' => $reservation->id]);
+
+        $this->get($showUrl)
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Public/GdprSelfService', false)
+                ->where('deleteToken', fn (string $token): bool => str_contains($token, '/gdpr/'.$reservation->id.'/delete')
+                    && str_contains($token, 'signature='))
+            );
+    }
+
+    public function test_it_rejects_delete_with_a_wrong_confirm_date(): void
+    {
+        $reservation = $this->reservation();
+
+        $this->from('/previous')
+            ->post($this->signedDeleteUrl($reservation), ['confirm_date' => '01.01.2000'])
+            ->assertRedirect('/previous')
+            ->assertSessionHasErrors('confirm_date');
+
+        $this->assertDatabaseHas('reservation_requests', ['id' => $reservation->id]);
+        $this->assertSame(0, GdprAudit::query()->where('action', GdprAudit::ACTION_DELETE)->count());
+    }
+
+    public function test_it_hard_deletes_the_reservation_and_related_records(): void
+    {
+        $reservation = $this->reservation();
+        $reply = ReservationReply::factory()->create(['reservation_request_id' => $reservation->id]);
+        ReservationMessage::factory()->create(['reservation_request_id' => $reservation->id]);
+        $table = Table::factory()->for($this->restaurant)->create();
+        ReservationTableAssignment::factory()
+            ->for($reservation, 'reservationRequest')
+            ->for($table)
+            ->create();
+
+        $this->post($this->signedDeleteUrl($reservation), [
+            'confirm_date' => $this->expectedConfirmDate($reservation),
+        ])->assertOk();
+
+        $this->assertDatabaseMissing('reservation_requests', ['id' => $reservation->id]);
+        $this->assertDatabaseMissing('reservation_replies', ['reservation_request_id' => $reservation->id]);
+        $this->assertDatabaseMissing('reservation_messages', ['reservation_request_id' => $reservation->id]);
+        $this->assertDatabaseMissing('reservation_table_assignments', ['reservation_request_id' => $reservation->id]);
+    }
+
+    public function test_it_records_a_delete_audit_without_pii(): void
+    {
+        $reservation = $this->reservation();
+
+        $this->post($this->signedDeleteUrl($reservation), [
+            'confirm_date' => $this->expectedConfirmDate($reservation),
+        ])->assertOk();
+
+        $audit = GdprAudit::query()->where('action', GdprAudit::ACTION_DELETE)->sole();
+        $this->assertSame($this->restaurant->id, $audit->restaurant_id);
+        $this->assertStringNotContainsString('anna@gmail.com', json_encode($audit->getAttributes(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_a_deleted_reservation_is_gone_on_a_subsequent_visit(): void
+    {
+        $reservation = $this->reservation();
+        $id = $reservation->id;
+
+        $this->post($this->signedDeleteUrl($reservation), [
+            'confirm_date' => $this->expectedConfirmDate($reservation),
+        ])->assertOk();
+
+        // The 30-day view link now resolves nothing — model binding 404s.
+        $showUrl = URL::temporarySignedRoute('gdpr.self-service', now()->addDays(30), ['reservation' => $id]);
+        $this->get($showUrl)->assertNotFound();
+    }
+
+    public function test_it_returns_403_for_delete_without_a_signature(): void
+    {
+        $reservation = $this->reservation();
+
+        $this->post(route('gdpr.self-service.delete', ['reservation' => $reservation->id]), [
+            'confirm_date' => $this->expectedConfirmDate($reservation),
+        ])->assertForbidden();
+
+        $this->assertDatabaseHas('reservation_requests', ['id' => $reservation->id]);
+    }
+
+    public function test_a_delete_signature_for_one_reservation_does_not_delete_another(): void
+    {
+        $reservationA = $this->reservation();
+        $otherRestaurant = Restaurant::factory()->create(['timezone' => 'Europe/Berlin']);
+        $reservationB = ReservationRequest::factory()->for($otherRestaurant)->create([
+            'desired_at' => CarbonImmutable::parse('2026-06-15 17:00:00', 'UTC'),
+        ]);
+
+        // Take A's valid delete signature and swap in B's id: the signature no
+        // longer matches the URL, so the destructive action is rejected.
+        $signedForA = $this->signedDeleteUrl($reservationA);
+        $tampered = str_replace(
+            '/gdpr/'.$reservationA->id.'/delete',
+            '/gdpr/'.$reservationB->id.'/delete',
+            $signedForA,
+        );
+
+        $this->post($tampered, ['confirm_date' => $this->expectedConfirmDate($reservationB)])
+            ->assertForbidden();
+
+        $this->assertDatabaseHas('reservation_requests', ['id' => $reservationB->id]);
+    }
+
+    public function test_it_does_not_log_pii_on_delete(): void
+    {
+        $reservation = $this->reservation(['guest_email' => 'leak-check@gmail.com']);
+
+        $captured = [];
+        Log::listen(function ($message) use (&$captured): void {
+            $captured[] = json_encode([$message->message, $message->context], JSON_THROW_ON_ERROR);
+        });
+
+        $this->post($this->signedDeleteUrl($reservation), [
+            'confirm_date' => $this->expectedConfirmDate($reservation),
+        ])->assertOk();
+
+        $this->assertStringNotContainsString('leak-check@gmail.com', implode("\n", $captured));
+        $this->assertStringNotContainsString('Anna Müller', implode("\n", $captured));
+    }
+}

--- a/tests/Feature/Gdpr/GdprSelfServiceTest.php
+++ b/tests/Feature/Gdpr/GdprSelfServiceTest.php
@@ -42,7 +42,7 @@ class GdprSelfServiceTest extends TestCase
         $this->get($this->signedShowUrl($reservation))
             ->assertOk()
             ->assertInertia(fn ($page) => $page
-                ->component('Public/GdprSelfService', false)
+                ->component('Public/GdprSelfService')
                 ->where('reservation.guest_name', 'Anna Müller')
                 ->where('reservation.guest_email', 'anna@gmail.com')
                 ->where('reservation.party_size', 4)

--- a/tests/Feature/Gdpr/GdprSelfServiceTest.php
+++ b/tests/Feature/Gdpr/GdprSelfServiceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Gdpr;
+
+use App\Models\GdprAudit;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class GdprSelfServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function reservation(Restaurant $restaurant, array $overrides = []): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($restaurant)->create(array_merge([
+            'guest_name' => 'Anna Müller',
+            'guest_email' => 'anna@gmail.com',
+        ], $overrides));
+    }
+
+    private function signedShowUrl(ReservationRequest $reservation, ?Carbon $expiresAt = null): string
+    {
+        return URL::temporarySignedRoute(
+            'gdpr.self-service',
+            $expiresAt ?? now()->addDays(30),
+            ['reservation' => $reservation->id],
+        );
+    }
+
+    public function test_it_renders_self_service_page_with_a_valid_token(): void
+    {
+        $restaurant = Restaurant::factory()->create(['name' => 'La Trattoria']);
+        $reservation = $this->reservation($restaurant, ['party_size' => 4]);
+
+        $this->get($this->signedShowUrl($reservation))
+            ->assertOk()
+            ->assertInertia(fn ($page) => $page
+                ->component('Public/GdprSelfService', false)
+                ->where('reservation.guest_name', 'Anna Müller')
+                ->where('reservation.guest_email', 'anna@gmail.com')
+                ->where('reservation.party_size', 4)
+                ->where('restaurant.name', 'La Trattoria')
+            );
+    }
+
+    public function test_it_returns_403_without_a_signature(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant);
+
+        $this->get(route('gdpr.self-service', ['reservation' => $reservation->id]))
+            ->assertForbidden();
+    }
+
+    public function test_it_returns_403_with_an_expired_signature(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant);
+
+        $url = $this->signedShowUrl($reservation, now()->subMinute());
+
+        $this->get($url)->assertForbidden();
+    }
+
+    public function test_it_records_a_view_audit_without_pii(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant);
+
+        $this->get($this->signedShowUrl($reservation))->assertOk();
+
+        $this->assertDatabaseCount('gdpr_audits', 1);
+        $audit = GdprAudit::query()->sole();
+        $this->assertSame(GdprAudit::ACTION_VIEW, $audit->action);
+        $this->assertSame($restaurant->id, $audit->restaurant_id);
+        // The audit row carries no PII by schema; guard the serialized row too.
+        $this->assertStringNotContainsString('anna@gmail.com', json_encode($audit->getAttributes(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_a_signature_for_one_reservation_does_not_resolve_another(): void
+    {
+        $restaurantA = Restaurant::factory()->create();
+        $restaurantB = Restaurant::factory()->create();
+        $reservationA = $this->reservation($restaurantA);
+        $reservationB = $this->reservation($restaurantB);
+
+        // Take A's valid signature and swap in B's id: the signature no longer
+        // matches the URL, so cross-tenant access is rejected.
+        $signedForA = $this->signedShowUrl($reservationA);
+        $tampered = str_replace(
+            '/gdpr/'.$reservationA->id.'?',
+            '/gdpr/'.$reservationB->id.'?',
+            $signedForA,
+        );
+
+        $this->get($tampered)->assertForbidden();
+    }
+
+    public function test_it_does_not_log_pii_on_show(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $reservation = $this->reservation($restaurant, ['guest_email' => 'leak-check@gmail.com']);
+
+        $captured = [];
+        Log::listen(function ($message) use (&$captured): void {
+            $captured[] = json_encode([$message->message, $message->context], JSON_THROW_ON_ERROR);
+        });
+
+        $this->get($this->signedShowUrl($reservation))->assertOk();
+
+        $this->assertStringNotContainsString('leak-check@gmail.com', implode("\n", $captured));
+        $this->assertStringNotContainsString('Anna Müller', implode("\n", $captured));
+    }
+}

--- a/tests/Feature/Mail/ReservationReplyMailGdprLinkTest.php
+++ b/tests/Feature/Mail/ReservationReplyMailGdprLinkTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mail;
+
+use App\Enums\ReservationReplyStatus;
+use App\Mail\ReservationReplyMail;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReservationReplyMailGdprLinkTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function makeReply(): ReservationReply
+    {
+        $restaurant = Restaurant::factory()->create();
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create();
+
+        return ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Approved,
+            'body' => 'Guten Tag, gerne!',
+        ]);
+    }
+
+    public function test_it_includes_the_gdpr_link_in_the_body(): void
+    {
+        $reply = $this->makeReply();
+
+        $mailable = new ReservationReplyMail($reply);
+
+        $mailable->assertSeeInText('Datenschutz: Welche Daten haben wir von dir?');
+        $mailable->assertSeeInText('/gdpr/'.$reply->reservation_request_id);
+    }
+
+    public function test_the_link_is_signed_and_the_route_resolves(): void
+    {
+        $reply = $this->makeReply();
+
+        $rendered = (new ReservationReplyMail($reply))->render();
+
+        $this->assertSame(
+            1,
+            preg_match('#https?://\S+/gdpr/\d+\?[^\s<"]+#', $rendered, $matches),
+            'A signed GDPR link should appear in the rendered mail.'
+        );
+
+        // The extracted signed URL must resolve (valid signature → 200, not 403).
+        $this->get($matches[0])->assertOk();
+    }
+
+    public function test_the_link_targets_the_reservation_request(): void
+    {
+        $reply = $this->makeReply();
+
+        $rendered = (new ReservationReplyMail($reply))->render();
+        preg_match('#/gdpr/(\d+)\?#', $rendered, $matches);
+
+        $this->assertSame($reply->reservation_request_id, (int) $matches[1]);
+    }
+}

--- a/tests/Feature/Mail/ReservationReplyMailTest.php
+++ b/tests/Feature/Mail/ReservationReplyMailTest.php
@@ -66,6 +66,26 @@ class ReservationReplyMailTest extends TestCase
         $mailable->assertDontSeeInText('&amp;');
     }
 
+    public function test_it_shows_the_automated_line_when_sync_confirm_is_true(): void
+    {
+        $reply = $this->makeReply('Guten Tag, Ihr Tisch ist bestätigt.');
+
+        $mailable = new ReservationReplyMail($reply, syncConfirm: true);
+
+        $mailable->assertSeeInText('Diese Bestätigung wurde automatisch erstellt.');
+        $mailable->assertSeeInText('Guten Tag, Ihr Tisch ist bestätigt.');
+    }
+
+    public function test_it_omits_the_automated_line_by_default(): void
+    {
+        $reply = $this->makeReply('Guten Tag, Ihr Tisch ist bestätigt.');
+
+        $mailable = new ReservationReplyMail($reply);
+
+        $mailable->assertDontSeeInText('automatisch erstellt');
+        $mailable->assertSeeInText('Guten Tag, Ihr Tisch ist bestätigt.');
+    }
+
     public function test_uses_the_application_from_address(): void
     {
         config()->set('mail.from.address', 'no-reply@test.tld');

--- a/tests/Feature/Models/ReservationReplyTest.php
+++ b/tests/Feature/Models/ReservationReplyTest.php
@@ -190,4 +190,14 @@ class ReservationReplyTest extends TestCase
         $this->assertNotNull($fresh->approved_at, 'approved_at audit timestamp must remain');
         $this->assertNotNull($fresh->sent_at, 'sent_at audit timestamp must remain');
     }
+
+    public function test_sync_confirm_defaults_to_false_and_is_a_fillable_boolean(): void
+    {
+        $default = ReservationReply::factory()->create()->fresh();
+        $this->assertFalse($default->sync_confirm);
+        $this->assertIsBool($default->sync_confirm);
+
+        $synced = ReservationReply::factory()->create(['sync_confirm' => true]);
+        $this->assertTrue($synced->fresh()->sync_confirm);
+    }
 }

--- a/tests/Feature/Models/ReservationRequestTest.php
+++ b/tests/Feature/Models/ReservationRequestTest.php
@@ -7,6 +7,7 @@ use App\Enums\ReservationStatus;
 use App\Models\ReservationReply;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
+use App\Models\User;
 use Illuminate\Database\QueryException;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -227,5 +228,56 @@ class ReservationRequestTest extends TestCase
 
         $this->assertSame($newest->id, $request->latestReply->id);
         $this->assertSame('Latest revision', $request->latestReply->body);
+    }
+
+    public function test_phone_and_walk_in_sources_round_trip_through_the_cast(): void
+    {
+        $phone = ReservationRequest::factory()->create(['source' => ReservationSource::Phone]);
+        $walkIn = ReservationRequest::factory()->create(['source' => ReservationSource::WalkIn]);
+
+        $this->assertSame('phone', DB::table('reservation_requests')->where('id', $phone->id)->value('source'));
+        $this->assertSame('walk_in', DB::table('reservation_requests')->where('id', $walkIn->id)->value('source'));
+        $this->assertSame(ReservationSource::Phone, $phone->fresh()->source);
+        $this->assertSame(ReservationSource::WalkIn, $walkIn->fresh()->source);
+    }
+
+    public function test_note_is_nullable_and_fillable(): void
+    {
+        $withNote = ReservationRequest::factory()->create(['note' => 'Geburtstag, Fensterplatz']);
+        $withoutNote = ReservationRequest::factory()->create(['note' => null]);
+
+        $this->assertSame('Geburtstag, Fensterplatz', $withNote->fresh()->note);
+        $this->assertNull($withoutNote->fresh()->note);
+    }
+
+    public function test_created_by_user_id_is_nullable_fillable_and_cast_to_int(): void
+    {
+        $user = User::factory()->create();
+
+        $captured = ReservationRequest::factory()->create(['created_by_user_id' => $user->id]);
+        $external = ReservationRequest::factory()->create(['created_by_user_id' => null]);
+
+        $this->assertSame($user->id, $captured->fresh()->created_by_user_id);
+        $this->assertIsInt($captured->fresh()->created_by_user_id);
+        $this->assertNull($external->fresh()->created_by_user_id);
+    }
+
+    public function test_created_by_user_id_is_nulled_when_the_capturing_user_is_deleted(): void
+    {
+        $user = User::factory()->create();
+        $request = ReservationRequest::factory()->create(['created_by_user_id' => $user->id]);
+
+        $user->delete();
+
+        $this->assertTrue($request->fresh()->exists, 'the reservation must survive deleting its creator');
+        $this->assertNull($request->fresh()->created_by_user_id);
+    }
+
+    public function test_created_by_relation_returns_the_capturing_user(): void
+    {
+        $user = User::factory()->create();
+        $request = ReservationRequest::factory()->create(['created_by_user_id' => $user->id]);
+
+        $this->assertSame($user->id, $request->createdBy->id);
     }
 }

--- a/tests/Feature/Models/RestaurantAvailableSeatsAtTest.php
+++ b/tests/Feature/Models/RestaurantAvailableSeatsAtTest.php
@@ -133,6 +133,7 @@ class RestaurantAvailableSeatsAtTest extends TestCase
             ReservationStatus::Replied,
             ReservationStatus::Declined,
             ReservationStatus::Cancelled,
+            ReservationStatus::Waitlisted,
         ] as $status) {
             ReservationRequest::factory()
                 ->forRestaurant($restaurant)

--- a/tests/Feature/Models/RestaurantTest.php
+++ b/tests/Feature/Models/RestaurantTest.php
@@ -104,4 +104,14 @@ class RestaurantTest extends TestCase
         $this->assertNull($restaurant->fresh()->imap_password);
         $this->assertNull(DB::table('restaurants')->where('id', $restaurant->id)->value('imap_password'));
     }
+
+    public function test_web_sync_confirm_enabled_defaults_to_false_and_is_a_fillable_boolean(): void
+    {
+        $default = Restaurant::factory()->create()->fresh();
+        $this->assertFalse($default->web_sync_confirm_enabled);
+        $this->assertIsBool($default->web_sync_confirm_enabled);
+
+        $enabled = Restaurant::factory()->create(['web_sync_confirm_enabled' => true]);
+        $this->assertTrue($enabled->fresh()->web_sync_confirm_enabled);
+    }
 }

--- a/tests/Feature/Reservations/QuickReservationCreateTest.php
+++ b/tests/Feature/Reservations/QuickReservationCreateTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Reservations;
+
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class QuickReservationCreateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array{0: Restaurant, 1: User}
+     */
+    private function ownerWithRestaurant(): array
+    {
+        // Default factory: Europe/Berlin, Monday open 11:30–14:30 + 18:00–22:30.
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Owner]);
+
+        return [$restaurant, $owner];
+    }
+
+    public function test_guests_are_redirected_from_the_quick_form(): void
+    {
+        $this->get(route('reservations.quick.create'))->assertRedirect('/login');
+    }
+
+    public function test_form_renders_with_smart_defaults(): void
+    {
+        [$restaurant, $owner] = $this->ownerWithRestaurant();
+        Table::factory()->for($restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($owner)
+            ->get(route('reservations.quick.create'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                // The Vue page lands in #344; skip the component-file existence check.
+                ->component('Reservations/Quick', false)
+                ->where('defaults.party_size', 2)
+                ->has('defaults.date')
+                ->has('defaults.time')
+                ->has('availability.state')
+                ->has('availability.alternative_slots')
+                ->has('tables.data', 1)
+            );
+    }
+
+    public function test_staff_may_open_the_quick_form(): void
+    {
+        [$restaurant] = $this->ownerWithRestaurant();
+        $staff = User::factory()->forRestaurant($restaurant)->create(['role' => UserRole::Staff]);
+        Table::factory()->for($restaurant)->create();
+
+        $this->actingAs($staff)
+            ->get(route('reservations.quick.create'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Reservations/Quick', false)
+            );
+    }
+
+    public function test_availability_reflects_query_parameters(): void
+    {
+        [$restaurant, $owner] = $this->ownerWithRestaurant();
+        Table::factory()->for($restaurant)->create(['seats' => 6]);
+
+        $this->actingAs($owner)
+            ->get(route('reservations.quick.create', [
+                'date' => '2026-06-15', // Monday
+                'time' => '19:00',
+                'party_size' => 4,
+            ]))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                // The Vue page lands in #344; skip the component-file existence check.
+                ->component('Reservations/Quick', false)
+                ->where('defaults.date', '2026-06-15')
+                ->where('defaults.time', '19:00')
+                ->where('defaults.party_size', 4)
+                ->where('availability.state', 'free')
+            );
+    }
+
+    public function test_party_size_above_the_cap_is_rejected(): void
+    {
+        [, $owner] = $this->ownerWithRestaurant();
+
+        $this->actingAs($owner)
+            ->get(route('reservations.quick.create', ['party_size' => 21]))
+            ->assertSessionHasErrors('party_size');
+    }
+
+    public function test_only_active_tables_of_the_own_restaurant_are_returned(): void
+    {
+        [$restaurant, $owner] = $this->ownerWithRestaurant();
+        $foreign = Restaurant::factory()->create();
+        Table::factory()->for($restaurant)->create(['active' => true]);
+        Table::factory()->for($restaurant)->inactive()->create();
+        Table::factory()->for($foreign)->create(['active' => true]);
+
+        $this->actingAs($owner)
+            ->get(route('reservations.quick.create'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('tables.data', 1));
+    }
+
+    public function test_user_without_a_restaurant_is_forbidden(): void
+    {
+        $user = User::factory()->create(); // restaurant_id is null
+
+        $this->actingAs($user)
+            ->get(route('reservations.quick.create'))
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Reservations/QuickReservationStoreTest.php
+++ b/tests/Feature/Reservations/QuickReservationStoreTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Reservations;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Enums\UserRole;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class QuickReservationStoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    private User $owner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // UTC + a wide dinner window keeps local time == stored desired_at, so
+        // the booking logic under test is not confounded by timezone maths
+        // (the timezone path is covered by the create endpoint test).
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+        $this->owner = User::factory()->forRestaurant($this->restaurant)->create(['role' => UserRole::Owner]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function payload(array $overrides = []): array
+    {
+        return array_merge([
+            'source' => 'phone',
+            'date' => '2026-06-15', // Monday
+            'time' => '19:00',
+            'party_size' => 2,
+            'guest_name' => 'Müller',
+        ], $overrides);
+    }
+
+    private function occupy(Table $table, string $desiredAtUtc): void
+    {
+        $reservation = ReservationRequest::factory()->for($this->restaurant)->create([
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => 2,
+            'status' => ReservationStatus::Confirmed,
+        ]);
+
+        ReservationTableAssignment::factory()
+            ->for($reservation, 'reservationRequest')
+            ->for($table)
+            ->create();
+    }
+
+    public function test_guests_are_redirected(): void
+    {
+        $this->post(route('reservations.quick.store'), $this->payload())->assertRedirect('/login');
+    }
+
+    public function test_owner_can_create_a_phone_reservation(): void
+    {
+        Mail::fake();
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload([
+                'guest_phone' => '+49 157 1234',
+                'guest_email' => 'gast@example.com',
+                'note' => 'Geburtstag',
+            ]))
+            ->assertRedirect(route('dashboard'))
+            ->assertSessionHas('success');
+
+        $reservation = ReservationRequest::sole();
+        $this->assertSame(ReservationStatus::Confirmed, $reservation->status);
+        $this->assertSame(ReservationSource::Phone, $reservation->source);
+        $this->assertSame('Müller', $reservation->guest_name);
+        $this->assertSame('Geburtstag', $reservation->note);
+        $this->assertSame($this->owner->id, $reservation->created_by_user_id);
+        $this->assertSame('2026-06-15 19:00:00', $reservation->desired_at->utc()->format('Y-m-d H:i:s'));
+
+        $assignment = ReservationTableAssignment::sole();
+        $this->assertSame($table->id, $assignment->table_id);
+        $this->assertSame($this->owner->id, $assignment->assigned_by_user_id);
+
+        $this->assertSame(0, ReservationReply::count());
+        Mail::assertNothingSent();
+    }
+
+    public function test_owner_can_create_a_walk_in_reservation(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['source' => 'walk_in']))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame(ReservationSource::WalkIn, ReservationRequest::sole()->source);
+    }
+
+    public function test_staff_may_store_a_quick_reservation(): void
+    {
+        $staff = User::factory()->forRestaurant($this->restaurant)->create(['role' => UserRole::Staff]);
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($staff)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame($staff->id, ReservationRequest::sole()->created_by_user_id);
+    }
+
+    public function test_it_auto_assigns_the_smallest_fitting_table(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8, 'sort_order' => 1]);
+        $small = Table::factory()->for($this->restaurant)->create(['seats' => 4, 'sort_order' => 2]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 4]))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame($small->id, ReservationTableAssignment::sole()->table_id);
+    }
+
+    public function test_it_assigns_every_table_of_a_combination(): void
+    {
+        $a = Table::factory()->for($this->restaurant)->create(['seats' => 2, 'sort_order' => 1]);
+        $b = Table::factory()->for($this->restaurant)->create(['seats' => 2, 'sort_order' => 2]);
+        $a->update(['combinable_with' => [$b->id]]);
+        $b->update(['combinable_with' => [$a->id]]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 4]))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame(2, ReservationTableAssignment::count());
+        $this->assertEqualsCanonicalizing(
+            [$a->id, $b->id],
+            ReservationTableAssignment::pluck('table_id')->all(),
+        );
+    }
+
+    public function test_it_accepts_a_manual_table_override(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4, 'sort_order' => 1]);
+        $preferred = Table::factory()->for($this->restaurant)->create(['seats' => 8, 'sort_order' => 2]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['table_id' => $preferred->id]))
+            ->assertRedirect(route('dashboard'));
+
+        $this->assertSame($preferred->id, ReservationTableAssignment::sole()->table_id);
+    }
+
+    public function test_it_rejects_a_manual_table_that_is_busy_in_the_slot(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00');
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['table_id' => $table->id]))
+            ->assertSessionHasErrors('table_id');
+
+        $this->assertSame(1, ReservationRequest::count()); // only the pre-existing occupier
+    }
+
+    public function test_it_rejects_when_no_table_fits_the_party(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 2]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 6]))
+            ->assertSessionHasErrors('table_id');
+
+        $this->assertSame(0, ReservationRequest::count());
+        $this->assertSame(0, ReservationTableAssignment::count());
+    }
+
+    public function test_a_second_booking_for_the_only_table_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertRedirect(route('dashboard'));
+
+        // Same slot, only table now occupied: the in-transaction re-check rejects.
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertSessionHasErrors('table_id');
+
+        $this->assertSame(1, ReservationRequest::count());
+        $this->assertSame(1, ReservationTableAssignment::count());
+    }
+
+    public function test_a_foreign_restaurant_table_id_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $foreign = Restaurant::factory()->create();
+        $foreignTable = Table::factory()->for($foreign)->create(['seats' => 4]);
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['table_id' => $foreignTable->id]))
+            ->assertSessionHasErrors('table_id');
+    }
+
+    public function test_past_date_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create();
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['date' => '2020-01-01']))
+            ->assertSessionHasErrors('date');
+    }
+
+    public function test_party_size_above_the_cap_is_rejected(): void
+    {
+        Table::factory()->for($this->restaurant)->create();
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['party_size' => 21]))
+            ->assertSessionHasErrors('party_size');
+    }
+
+    public function test_source_must_be_phone_or_walk_in(): void
+    {
+        Table::factory()->for($this->restaurant)->create();
+
+        $this->actingAs($this->owner)
+            ->post(route('reservations.quick.store'), $this->payload(['source' => 'web_form']))
+            ->assertSessionHasErrors('source');
+    }
+
+    public function test_user_without_a_restaurant_is_forbidden(): void
+    {
+        $user = User::factory()->create(); // restaurant_id is null
+
+        $this->actingAs($user)
+            ->post(route('reservations.quick.store'), $this->payload())
+            ->assertForbidden();
+    }
+}

--- a/tests/Feature/Waitlist/WaitlistFlowTest.php
+++ b/tests/Feature/Waitlist/WaitlistFlowTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Waitlist;
+
+use App\Enums\ReservationStatus;
+use App\Enums\UserRole;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+class WaitlistFlowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    private User $owner;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+        $this->owner = User::factory()->forRestaurant($this->restaurant)->create(['role' => UserRole::Owner]);
+    }
+
+    private function waitlisted(string $desiredAtUtc, int $partySize = 2, ?Restaurant $restaurant = null): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($restaurant ?? $this->restaurant)->create([
+            'status' => ReservationStatus::Waitlisted,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => $partySize,
+        ]);
+    }
+
+    public function test_banner_lists_eligible_waitlisted_reservations(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->has('waitlistBanner', 1)
+                ->where('waitlistBanner.0.id', $waiting->id)
+            );
+    }
+
+    public function test_banner_excludes_a_waitlisted_request_whose_slot_is_full(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        // Confirmed + a table assignment is what makes busyTableIds see the only
+        // table as taken, so the slot is genuinely Full for the waiting party.
+        $busy = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+        ReservationTableAssignment::factory()->for($busy, 'reservationRequest')->for($table)->create();
+
+        $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+
+    public function test_banner_appears_after_a_cancellation_frees_the_slot(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $confirmed = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 4,
+        ]);
+        ReservationTableAssignment::factory()->for($confirmed, 'reservationRequest')->for($table)->create();
+        $waiting = $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        // Slot is full → the waiting guest is hidden.
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+
+        // Cancelling frees the table (Cancelled is non-occupying).
+        $confirmed->update(['status' => ReservationStatus::Cancelled]);
+
+        // Next load: the slot is free again, so the waiting guest surfaces.
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->has('waitlistBanner', 1)
+                ->where('waitlistBanner.0.id', $waiting->id)
+            );
+    }
+
+    public function test_user_without_a_restaurant_sees_an_empty_banner(): void
+    {
+        $user = User::factory()->create(); // restaurant_id is null
+
+        $this->actingAs($user)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+
+    public function test_banner_disappears_after_the_waitlisted_request_is_confirmed(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 1));
+
+        $waiting->update(['status' => ReservationStatus::Confirmed]);
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+
+    public function test_dashboard_filter_shows_only_waitlisted_requests(): void
+    {
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+        ReservationRequest::factory()->for($this->restaurant)->create(['status' => ReservationStatus::New]);
+        ReservationRequest::factory()->for($this->restaurant)->create(['status' => ReservationStatus::Confirmed]);
+
+        $this->actingAs($this->owner)
+            ->get(route('dashboard', ['status' => [ReservationStatus::Waitlisted->value]]))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->where('filters.status.0', 'waitlisted') // the value was accepted, not stripped
+                ->has('requests.data', 1)
+                ->where('requests.data.0.id', $waiting->id)
+                ->where('requests.data.0.status', 'waitlisted')
+            );
+    }
+
+    public function test_user_from_another_restaurant_does_not_see_the_banner(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->waitlisted('2026-06-15 19:00'); // belongs to $this->restaurant
+
+        $other = Restaurant::factory()->create(['timezone' => 'UTC', 'opening_hours' => $this->restaurant->opening_hours]);
+        $otherOwner = User::factory()->forRestaurant($other)->create(['role' => UserRole::Owner]);
+
+        $this->actingAs($otherOwner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->has('waitlistBanner', 0));
+    }
+}

--- a/tests/Unit/AutoSend/WebSyncConfirmDeciderTest.php
+++ b/tests/Unit/AutoSend/WebSyncConfirmDeciderTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\AutoSend;
+
+use App\Enums\ReservationSource;
+use App\Enums\ReservationStatus;
+use App\Enums\SlotState;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\AutoSend\WebSyncConfirmDecider;
+use App\Services\AutoSend\WebSyncConfirmDecision;
+use App\Services\Availability\DTOs\SlotAvailabilityResult;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class WebSyncConfirmDeciderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Freeze "now" inside the dinner window so lead-time and opening-hours
+        // checks are deterministic. 2026-05-23 is a Saturday.
+        Carbon::setTestNow('2026-05-23 18:00:00');
+
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+            'web_sync_confirm_enabled' => true,
+            'auto_send_party_size_max' => 10,
+            'auto_send_min_lead_time_minutes' => 90,
+        ]);
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    private function decider(): WebSyncConfirmDecider
+    {
+        return app(WebSyncConfirmDecider::class);
+    }
+
+    private function reservation(string $desiredAtUtc, int $partySize = 2): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($this->restaurant)->create([
+            'source' => ReservationSource::WebForm,
+            'status' => ReservationStatus::New,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => $partySize,
+        ]);
+    }
+
+    public function test_it_skips_when_global_kill_is_active(): void
+    {
+        config()->set('reservations.web_sync_confirm.kill', true);
+        $request = $this->reservation('2026-06-15 19:00');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecision::STATE_SKIP, $decision->state);
+        $this->assertSame(WebSyncConfirmDecider::REASON_GLOBAL_KILL, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_restaurant_toggle_is_off(): void
+    {
+        $this->restaurant->update(['web_sync_confirm_enabled' => false]);
+        $request = $this->reservation('2026-06-15 19:00');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_DISABLED, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_slot_is_not_deterministic_free(): void
+    {
+        // Occupy the (single) table at the slot so it is full, not free.
+        $busy = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+        ReservationTableAssignment::factory()
+            ->for($busy, 'reservationRequest')
+            ->for(Table::query()->firstOrFail())
+            ->create();
+
+        $request = $this->reservation('2026-06-15 19:00');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SLOT_NOT_FREE, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_party_size_is_over_the_limit(): void
+    {
+        // A 12-seat table keeps the slot genuinely free for 11 (so the slot gate
+        // passes), but 11 still exceeds the auto-send cap of 10.
+        Table::factory()->for($this->restaurant)->create(['seats' => 12]);
+        $request = $this->reservation('2026-06-15 19:00', partySize: 11);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_PARTY_SIZE_OVER_LIMIT, $decision->reason);
+    }
+
+    public function test_it_skips_on_short_notice(): void
+    {
+        // 30 minutes out, inside the dinner window, but under the 90-min lead.
+        $request = $this->reservation('2026-05-23 18:30');
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SHORT_NOTICE, $decision->reason);
+    }
+
+    public function test_it_proceeds_when_all_gates_pass(): void
+    {
+        $request = $this->reservation('2026-06-15 19:00', partySize: 2);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertTrue($decision->shouldProceed());
+        $this->assertNull($decision->reason);
+        $this->assertInstanceOf(SlotAvailabilityResult::class, $decision->slot);
+        $this->assertSame(SlotState::Free, $decision->slot->state);
+    }
+
+    public function test_it_skips_when_the_slot_is_only_tight(): void
+    {
+        // setUp's 8-seat table is occupied and only a free 2-seat table remains:
+        // 2/10 = 20% free (≤ 25%) → Tight, which must not proceed unattended.
+        $eight = Table::query()->firstOrFail();
+        Table::factory()->for($this->restaurant)->create(['seats' => 2]);
+        $busy = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+        ReservationTableAssignment::factory()->for($busy, 'reservationRequest')->for($eight)->create();
+
+        $decision = $this->decider()->decide($this->reservation('2026-06-15 19:00', partySize: 2));
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SLOT_NOT_FREE, $decision->reason);
+    }
+
+    public function test_it_skips_when_desired_at_is_null(): void
+    {
+        $request = ReservationRequest::factory()->for($this->restaurant)->create([
+            'source' => ReservationSource::WebForm,
+            'status' => ReservationStatus::New,
+            'desired_at' => null,
+            'party_size' => 2,
+        ]);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_SLOT_NOT_FREE, $decision->reason);
+    }
+
+    public function test_it_skips_when_the_request_has_no_restaurant(): void
+    {
+        // An (unsaved) request pointing at a non-existent restaurant: the relation
+        // resolves to null, so the decider logs and skips as disabled.
+        $request = new ReservationRequest([
+            'restaurant_id' => 999_999,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+
+        $decision = $this->decider()->decide($request);
+
+        $this->assertSame(WebSyncConfirmDecider::REASON_DISABLED, $decision->reason);
+    }
+
+    public function test_it_proceeds_at_exactly_the_minimum_lead_time(): void
+    {
+        // now is frozen at 18:00; 19:30 is exactly the 90-min lead (not < 90).
+        $decision = $this->decider()->decide($this->reservation('2026-05-23 19:30', partySize: 2));
+
+        $this->assertTrue($decision->shouldProceed());
+    }
+}

--- a/tests/Unit/Availability/SlotAvailabilityTest.php
+++ b/tests/Unit/Availability/SlotAvailabilityTest.php
@@ -125,6 +125,19 @@ class SlotAvailabilityTest extends TestCase
         $this->assertSame(SlotState::Free, $result->state);
     }
 
+    public function test_does_not_count_waitlisted_reservations_as_occupying(): void
+    {
+        // PRD-013: waitlisted requests are parked, not seated — they must never
+        // occupy a table, otherwise the slot would look full to the very waitlist
+        // entry that is waiting for it to free up.
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00', ReservationStatus::Waitlisted);
+
+        $result = $this->slot('2026-06-15 19:00', partySize: 4);
+
+        $this->assertSame(SlotState::Free, $result->state);
+    }
+
     public function test_ignores_inactive_tables(): void
     {
         Table::factory()->for($this->restaurant)->inactive()->create(['seats' => 8]);

--- a/tests/Unit/Enums/ReservationStatusTest.php
+++ b/tests/Unit/Enums/ReservationStatusTest.php
@@ -18,11 +18,15 @@ class ReservationStatusTest extends TestCase
         $allowed = [
             [ReservationStatus::New, ReservationStatus::InReview],
             [ReservationStatus::New, ReservationStatus::Declined],
+            [ReservationStatus::New, ReservationStatus::Waitlisted],
             [ReservationStatus::InReview, ReservationStatus::Replied],
             [ReservationStatus::InReview, ReservationStatus::Declined],
+            [ReservationStatus::InReview, ReservationStatus::Waitlisted],
             [ReservationStatus::Replied, ReservationStatus::Confirmed],
             [ReservationStatus::Replied, ReservationStatus::Cancelled],
             [ReservationStatus::Confirmed, ReservationStatus::Cancelled],
+            [ReservationStatus::Waitlisted, ReservationStatus::Confirmed],
+            [ReservationStatus::Waitlisted, ReservationStatus::Declined],
         ];
 
         $rows = [];
@@ -76,11 +80,24 @@ class ReservationStatusTest extends TestCase
         }
     }
 
-    public function test_allowed_next_states_for_new_are_in_review_and_declined(): void
+    public function test_allowed_next_states_for_new_are_in_review_declined_and_waitlisted(): void
     {
         $this->assertEqualsCanonicalizing(
-            [ReservationStatus::InReview, ReservationStatus::Declined],
+            [ReservationStatus::InReview, ReservationStatus::Declined, ReservationStatus::Waitlisted],
             ReservationStatus::New->allowedNextStates()
         );
+    }
+
+    public function test_waitlisted_can_only_move_to_confirmed_or_declined(): void
+    {
+        $this->assertEqualsCanonicalizing(
+            [ReservationStatus::Confirmed, ReservationStatus::Declined],
+            ReservationStatus::Waitlisted->allowedNextStates()
+        );
+
+        // A waitlisted request must not jump back to new/in_review/replied or be cancelled directly.
+        foreach ([ReservationStatus::New, ReservationStatus::InReview, ReservationStatus::Replied, ReservationStatus::Cancelled] as $target) {
+            $this->assertFalse(ReservationStatus::Waitlisted->canTransitionTo($target));
+        }
     }
 }

--- a/tests/Unit/Services/AI/OpenAiReplyGeneratorGenerateSyncTest.php
+++ b/tests/Unit/Services/AI/OpenAiReplyGeneratorGenerateSyncTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\AI;
+
+use App\Exceptions\AI\OpenAiAuthenticationException;
+use App\Exceptions\AI\OpenAiRateLimitException;
+use App\Exceptions\AI\OpenAiTimeoutException;
+use App\Services\AI\OpenAiReplyGenerator;
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Exceptions\ErrorException;
+use OpenAI\Exceptions\RateLimitException;
+use OpenAI\Exceptions\ServerException;
+use OpenAI\Exceptions\TransporterException;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Testing\ClientFake;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Tests\TestCase;
+
+/**
+ * Covers the synchronous reply path used by the PRD-014 web sync-confirm
+ * flow. The submit path can only confirm with a *real* AI reply, so
+ * `generateSync` throws on every failure (timeout, empty completion)
+ * instead of returning the neutral fallback the async `generate` uses.
+ */
+class OpenAiReplyGeneratorGenerateSyncTest extends TestCase
+{
+    private const string LEAK_SENTINEL = 'sk-test-LEAK-CHECK-12345';
+
+    private function makeContext(string $tonality = 'casual'): array
+    {
+        return [
+            'restaurant' => [
+                'name' => 'La Trattoria',
+                'tonality' => $tonality,
+            ],
+            'request' => [
+                'guest_name' => 'Anna Müller',
+                'party_size' => 4,
+                'desired_at' => '2026-05-13 19:30',
+                'message' => 'Möglichst Fensterplatz, danke.',
+            ],
+            'availability' => [
+                'is_open_at_desired_time' => true,
+                'closed_reason' => null,
+                'slot_state' => 'free',
+                'is_available' => true,
+                'alternative_slots' => [],
+            ],
+        ];
+    }
+
+    private function makeGenerator(ClientFake $fake): OpenAiReplyGenerator
+    {
+        return new OpenAiReplyGenerator($fake, new NullLogger);
+    }
+
+    private function timeoutException(): TransporterException
+    {
+        // Mirrors what openai-php raises in production: a Guzzle connection
+        // timeout (ClientExceptionInterface) wrapped into TransporterException.
+        return new TransporterException(
+            new ConnectException(
+                'cURL error 28: Operation timed out after 5000 milliseconds',
+                new Request('POST', 'https://api.openai.com/v1/chat/completions'),
+            ),
+        );
+    }
+
+    public function test_it_generates_a_reply_synchronously(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    [
+                        'index' => 0,
+                        'message' => [
+                            'role' => 'assistant',
+                            'content' => "  Guten Tag Anna,\n\nIhr Tisch um 19:30 ist bestätigt.\n\nViele Grüße  ",
+                        ],
+                        'finish_reason' => 'stop',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $reply = $this->makeGenerator($fake)->generateSync($this->makeContext());
+
+        $this->assertSame(
+            "Guten Tag Anna,\n\nIhr Tisch um 19:30 ist bestätigt.\n\nViele Grüße",
+            $reply
+        );
+    }
+
+    public function test_it_throws_openai_timeout_exception_on_timeout(): void
+    {
+        $fake = OpenAI::fake([
+            $this->timeoutException(),
+        ]);
+
+        $this->expectException(OpenAiTimeoutException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_throws_instead_of_returning_the_fallback_when_completion_is_empty(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => '   '], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        // A blank completion must never be sent as a confirmation; the caller
+        // falls back to the V1 path instead.
+        $this->expectException(RuntimeException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_classifies_a_401_as_an_authentication_exception(): void
+    {
+        $fake = OpenAI::fake([
+            new ErrorException(
+                ['message' => 'invalid api key', 'type' => 'invalid_request_error'],
+                new Response(401),
+            ),
+        ]);
+
+        $this->expectException(OpenAiAuthenticationException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_classifies_a_429_as_a_rate_limit_exception(): void
+    {
+        $fake = OpenAI::fake([
+            new RateLimitException(new Response(429)),
+        ]);
+
+        $this->expectException(OpenAiRateLimitException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_propagates_a_server_error_instead_of_returning_the_fallback(): void
+    {
+        $fake = OpenAI::fake([
+            new ServerException(new Response(500)),
+        ]);
+
+        // A 5xx must not yield a confirmation; it propagates so the caller
+        // falls back to the V1 path.
+        $this->expectException(ServerException::class);
+
+        $this->makeGenerator($fake)->generateSync($this->makeContext());
+    }
+
+    public function test_it_passes_the_timeout_to_the_sync_client_factory(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        $capturedTimeout = null;
+        $factory = function (int $timeout) use ($fake, &$capturedTimeout): ClientContract {
+            $capturedTimeout = $timeout;
+
+            return $fake;
+        };
+
+        $generator = new OpenAiReplyGenerator($fake, new NullLogger, $factory);
+
+        $generator->generateSync($this->makeContext(), timeout: 3);
+
+        $this->assertSame(3, $capturedTimeout);
+    }
+
+    public function test_it_defaults_to_a_five_second_timeout(): void
+    {
+        $fake = OpenAI::fake([
+            CreateResponse::fake([
+                'choices' => [
+                    ['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'ok'], 'finish_reason' => 'stop'],
+                ],
+            ]),
+        ]);
+
+        $capturedTimeout = null;
+        $factory = function (int $timeout) use ($fake, &$capturedTimeout): ClientContract {
+            $capturedTimeout = $timeout;
+
+            return $fake;
+        };
+
+        (new OpenAiReplyGenerator($fake, new NullLogger, $factory))->generateSync($this->makeContext());
+
+        $this->assertSame(5, $capturedTimeout);
+    }
+
+    public function test_the_api_key_never_appears_in_logs_or_the_thrown_exception(): void
+    {
+        config()->set('openai.api_key', self::LEAK_SENTINEL);
+
+        $captured = [];
+        Log::shouldReceive('warning')->andReturnUsing(function (string $message, array $context) use (&$captured): void {
+            $captured[] = ['message' => $message, 'context' => $context];
+        });
+        Log::shouldReceive('debug')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+
+        $fake = OpenAI::fake([
+            $this->timeoutException(),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, Log::getFacadeRoot());
+
+        $thrownMessage = '';
+        try {
+            $generator->generateSync($this->makeContext());
+        } catch (OpenAiTimeoutException $e) {
+            $thrownMessage = $e->getMessage();
+        }
+
+        $serialized = json_encode($captured, JSON_UNESCAPED_UNICODE);
+        $this->assertNotFalse($serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $thrownMessage);
+    }
+
+    public function test_the_api_key_never_leaks_on_the_classified_401_path(): void
+    {
+        config()->set('openai.api_key', self::LEAK_SENTINEL);
+
+        $captured = [];
+        Log::shouldReceive('warning')->andReturnUsing(function (string $message, array $context) use (&$captured): void {
+            $captured[] = ['message' => $message, 'context' => $context];
+        });
+        Log::shouldReceive('debug')->andReturnNull();
+        Log::shouldReceive('info')->andReturnNull();
+
+        $fake = OpenAI::fake([
+            new ErrorException(['message' => 'unauthorised'], new Response(401)),
+        ]);
+
+        $generator = new OpenAiReplyGenerator($fake, Log::getFacadeRoot());
+
+        $thrownMessage = '';
+        try {
+            $generator->generateSync($this->makeContext());
+        } catch (OpenAiAuthenticationException $e) {
+            $thrownMessage = $e->getMessage();
+        }
+
+        $serialized = json_encode($captured, JSON_UNESCAPED_UNICODE);
+        $this->assertNotFalse($serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $serialized);
+        $this->assertStringNotContainsString(self::LEAK_SENTINEL, $thrownMessage);
+    }
+}

--- a/tests/Unit/Waitlist/WaitlistBannerTest.php
+++ b/tests/Unit/Waitlist/WaitlistBannerTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Waitlist;
+
+use App\Enums\ReservationStatus;
+use App\Models\ReservationRequest;
+use App\Models\ReservationTableAssignment;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Services\Waitlist\WaitlistBanner;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WaitlistBannerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Restaurant $restaurant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // UTC + a wide dinner window so the slot maths is not confounded by
+        // timezone conversion (covered separately by SlotAvailability).
+        $dinner = [['from' => '17:00', 'to' => '23:00']];
+        $this->restaurant = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'slot_buffer_minutes' => 90,
+            'opening_hours' => [
+                'mon' => $dinner, 'tue' => $dinner, 'wed' => $dinner, 'thu' => $dinner,
+                'fri' => $dinner, 'sat' => $dinner, 'sun' => $dinner,
+            ],
+        ]);
+    }
+
+    private function service(): WaitlistBanner
+    {
+        return app(WaitlistBanner::class);
+    }
+
+    private function waitlisted(string $desiredAtUtc, int $partySize = 2, ?Restaurant $restaurant = null): ReservationRequest
+    {
+        return ReservationRequest::factory()->for($restaurant ?? $this->restaurant)->create([
+            'status' => ReservationStatus::Waitlisted,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => $partySize,
+        ]);
+    }
+
+    private function occupy(Table $table, string $desiredAtUtc): void
+    {
+        $reservation = ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Confirmed,
+            'desired_at' => CarbonImmutable::parse($desiredAtUtc, 'UTC'),
+            'party_size' => 2,
+        ]);
+
+        ReservationTableAssignment::factory()
+            ->for($reservation, 'reservationRequest')
+            ->for($table)
+            ->create();
+    }
+
+    public function test_lists_only_waitlisted_requests_with_a_free_slot(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $waiting = $this->waitlisted('2026-06-15 19:00');
+        // A non-waitlisted request at the same slot must be ignored.
+        ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::New,
+            'desired_at' => CarbonImmutable::parse('2026-06-15 19:00', 'UTC'),
+            'party_size' => 2,
+        ]);
+
+        $result = $this->service()->eligibleNow($this->restaurant->id);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($waiting->id, $result->first()->id);
+    }
+
+    public function test_excludes_waitlisted_requests_whose_desired_at_is_in_the_past(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->waitlisted('2020-01-01 19:00');
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_excludes_waitlisted_requests_whose_slot_is_full(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $this->occupy($table, '2026-06-15 19:00'); // the only table is now busy
+        $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_caps_results_at_twenty(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+        for ($i = 0; $i < 25; $i++) {
+            $this->waitlisted('2026-06-15 19:00', partySize: 1);
+        }
+
+        $this->assertCount(20, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_orders_by_desired_at_ascending(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 8]);
+        $later = $this->waitlisted('2026-06-15 20:00');
+        $earlier = $this->waitlisted('2026-06-15 18:00');
+
+        $ids = $this->service()->eligibleNow($this->restaurant->id)->pluck('id')->all();
+
+        $this->assertSame([$earlier->id, $later->id], $ids);
+    }
+
+    public function test_scopes_to_the_given_restaurant(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        $other = Restaurant::factory()->create([
+            'timezone' => 'UTC',
+            'opening_hours' => $this->restaurant->opening_hours,
+        ]);
+        Table::factory()->for($other)->create(['seats' => 4]);
+        $this->waitlisted('2026-06-15 19:00', restaurant: $other);
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_includes_waitlisted_requests_whose_slot_is_only_tight(): void
+    {
+        // 4 tables x 4 seats = 16; occupy 3 (12 seats) → 25% free → Tight (not Full),
+        // and one 4-seat table still fits the party, so the entry must appear.
+        $tables = Table::factory()->for($this->restaurant)->count(4)->create(['seats' => 4]);
+        for ($i = 0; $i < 3; $i++) {
+            $this->occupy($tables[$i], '2026-06-15 19:00');
+        }
+        $waiting = $this->waitlisted('2026-06-15 19:00', partySize: 4);
+
+        $result = $this->service()->eligibleNow($this->restaurant->id);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($waiting->id, $result->first()->id);
+    }
+
+    public function test_excludes_waitlisted_requests_without_a_desired_at(): void
+    {
+        Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        ReservationRequest::factory()->for($this->restaurant)->create([
+            'status' => ReservationStatus::Waitlisted,
+            'desired_at' => null,
+            'party_size' => 2,
+        ]);
+
+        $this->assertCount(0, $this->service()->eligibleNow($this->restaurant->id));
+    }
+
+    public function test_keeps_only_entries_whose_slot_is_free_across_different_slots(): void
+    {
+        $table = Table::factory()->for($this->restaurant)->create(['seats' => 4]);
+        // 18:00 is taken by a confirmed booking; 22:00 is far enough away (buffer +
+        // duration) that the single table is free there again.
+        $this->occupy($table, '2026-06-15 18:00');
+        $this->waitlisted('2026-06-15 18:00', partySize: 4); // full → excluded
+        $free = $this->waitlisted('2026-06-15 22:00', partySize: 4); // free → included
+
+        $result = $this->service()->eligibleNow($this->restaurant->id);
+
+        $this->assertCount(1, $result);
+        $this->assertSame($free->id, $result->first()->id);
+    }
+}


### PR DESCRIPTION
## Release summary

Bundles the complete V3 backlog from `dev` (25 commits ahead of `main`): four PRDs, 24 feature PRs, all individually reviewed, CI-green, and merged to `dev`. `main` is currently untouched; this PR is the explicit, owner-gated release step.

### What ships

**PRD-012 — Manual phone/walk-in entry** (epic #337, PRs #365–370)
Keyboard-first `Reservations/Quick.vue` with debounced live availability; `@create`/`@store` controller with `lockForUpdate` + auto table assignment, persisted directly as `confirmed` (no AI, no mail); dashboard header action; `ReservationSource::Phone/WalkIn`, `created_by_user_id`, `note`.

**PRD-013 — Passive waitlist** (epic #338, PRs #371–375)
`ReservationStatus::Waitlisted` + transitions (non-occupying); `WaitlistBanner` service (free-slot waiters, oldest-first); dashboard `waitlistBanner` prop + filter chip + drawer transition buttons.

**PRD-014 — Web sync-confirm** (epic #339, PRs #376–383)
Free-slot web submits confirmed inside the request: `WebSyncConfirmDecider` (opt-in + hard gates + global killswitch) → `OpenAiReplyGenerator::generateSync` (5 s, fail-closed) → locked transaction (re-resolve table, assign, mail-last) → `Public/ConfirmedSync`; falls back to the unchanged V1 path on any failure. Owner toggle on `Settings/SendMode.vue`. Default off.

**PRD-015 — GDPR self-service (Art. 15 + 17)** (epic #340, PRs #384–389)
30-day signed self-service link in every confirmation mail (`HasGdprLink`); login-less `GET /gdpr/{reservation}` data view + 15-min-token date-confirm hard delete; PII-free `gdpr_audits`; owner dashboard exact-email bulk-delete. Signatures bind links to a reservation id (no cross-tenant exposure); no guest data logged.

## Deploy checklist

- [ ] Run migrations (5 new, all reversible):
  - `add_created_by_user_id_to_reservation_requests_table`
  - `add_note_to_reservation_requests_table`
  - `add_web_sync_confirm_enabled_to_restaurants_table` (default `false`)
  - `add_sync_confirm_to_reservation_replies_table` (default `false`)
  - `create_gdpr_audits_table`
- [ ] Optional new ENV (incident killswitch, default off): `WEB_SYNC_CONFIRM_GLOBAL_KILL=false` (see `config/reservations.php`).
- [ ] No breaking changes: all new behaviour is opt-in (`web_sync_confirm_enabled` defaults `false`); the V1 reservation flow is unchanged on every fall-through.

## Verification

- All 24 sub-PRs merged to `dev` after self-review + green CI (Backend PHP 8.4 / Frontend Node 20 / Ziggy-drift).
- `dev` HEAD: `php artisan test` 1010 passed (3314 assertions) + Vitest 112 passed; `pint --test`, `npm run lint`, `npm run format:check`, `npm run build` clean.

## Approval

Per the branch strategy this `dev → main` merge requires explicit owner release approval. Prepared for review — not merged.