### PR TITLE
docs: correct CLAUDE.md stack table to Tailwind v3.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Status-Übergänge (new→replied→...)       Auf Deutsch, höflich, eindeutig
 |-----------------|------------------------------------------|
 | Backend         | PHP 8.2+, Laravel 12                     |
 | Frontend        | Inertia.js v2, Vue 3.5, TypeScript       |
-| Styling         | Tailwind CSS v4, Reka UI                 |
+| Styling         | Tailwind CSS v3.4, Reka UI               |
 | Routing (FE)    | Ziggy (`route()`-Helper in Vue)          |
 | DB              | SQLite (lokal), MySQL/Postgres (Prod)    |
 | Queue           | `database`-Driver lokal, `sync` in Tests |


### PR DESCRIPTION
## Summary
Fix the technical-stack table in `CLAUDE.md`: the project runs **Tailwind CSS v3.4** (`@tailwind` directives + HSL variables in `@layer base`, mapped via `hsl(var(--…))` in `tailwind.config.js`), not v4. The table previously said "Tailwind CSS v4".

## Why
Surfaced during the PRD-016 review: the wrong version misdirects design-token work toward v4 `@theme`, which this project does not use. Split out as its own PR because it touches the instruction file, separate from the PRD docs PR (#409).

## Test plan
- Docs-only, single-line change. No code touched.