### PR TITLE
PRD-016 #395: onboarding schema (password nullable, onboarding_completed_at, invitations)

### DIFF
--- a/database/migrations/2026_05_24_000001_make_users_password_nullable.php
+++ b/database/migrations/2026_05_24_000001_make_users_password_nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('password')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('password')->nullable(false)->change();
+        });
+    }
+};

--- a/database/migrations/2026_05_24_000002_add_onboarding_completed_at_to_restaurants.php
+++ b/database/migrations/2026_05_24_000002_add_onboarding_completed_at_to_restaurants.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->timestamp('onboarding_completed_at')->nullable()->after('tonality');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->dropColumn('onboarding_completed_at');
+        });
+    }
+};

--- a/database/migrations/2026_05_24_000003_create_invitations_table.php
+++ b/database/migrations/2026_05_24_000003_create_invitations_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('invitations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('restaurant_id')
+                ->constrained()
+                ->cascadeOnDelete();
+            $table->string('email');
+            $table->string('role')->default('staff');
+            $table->string('token')->unique();
+            $table->timestamp('expires_at');
+            $table->timestamp('accepted_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['restaurant_id', 'email']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('invitations');
+    }
+};

--- a/tests/Feature/Onboarding/OnboardingSchemaTest.php
+++ b/tests/Feature/Onboarding/OnboardingSchemaTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+final class OnboardingSchemaTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_user_can_be_persisted_without_a_password(): void
+    {
+        $user = User::factory()->create(['password' => null]);
+
+        $this->assertNull($user->fresh()->password);
+    }
+
+    public function test_restaurants_onboarding_completed_at_defaults_to_null(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $this->assertNull($restaurant->fresh()->onboarding_completed_at);
+        $this->assertTrue(Schema::hasColumn('restaurants', 'onboarding_completed_at'));
+    }
+
+    public function test_invitations_table_has_the_expected_columns(): void
+    {
+        $this->assertTrue(Schema::hasTable('invitations'));
+        $this->assertTrue(Schema::hasColumns('invitations', [
+            'id',
+            'restaurant_id',
+            'email',
+            'role',
+            'token',
+            'expires_at',
+            'accepted_at',
+            'created_at',
+            'updated_at',
+        ]));
+    }
+}


### PR DESCRIPTION
## Summary
Three additive migrations backing the PRD-016 onboarding flow, each with `up()` and `down()`; no existing migration modified:
- `users.password` made nullable (owner exists before accepting the invitation)
- `restaurants.onboarding_completed_at` nullable timestamp (the live transition)
- `invitations` table (id, restaurant_id fk cascade, email, role default staff, token unique, expires_at, accepted_at nullable, timestamps, index restaurant_id+email)

Model wiring, the Invitation model and factories follow in #396.

## Why
The data model is fully multi-tenant but there is no way to bring a restaurant into the system. This is the schema foundation for provisioning + onboarding (PRD-016 Phase 1, plan Task A1–A3).

## Test plan
- `tests/Feature/Onboarding/OnboardingSchemaTest.php`: user persists with null password; `onboarding_completed_at` defaults to null + column present; invitations table has the expected columns.
- `php artisan migrate` + `php artisan migrate:rollback` both clean.
- Full suite: 1013 passed; `pint --test` clean.

Closes #395.