### PR TITLE
PRD-016 #396: Invitation model + factories + Restaurant onboarding wiring

### DIFF
--- a/app/Models/Invitation.php
+++ b/app/Models/Invitation.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\UserRole;
+use App\Models\Scopes\RestaurantScope;
+use Database\Factories\InvitationFactory;
+use Illuminate\Database\Eloquent\Attributes\ScopedBy;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Str;
+
+/**
+ * A tokenised invitation to join a restaurant as owner or staff.
+ *
+ * The plaintext token is shown exactly once (at provision/invite time) and
+ * never stored — only its SHA-256 hash lives in the `token` column, so a
+ * leaked database row cannot be replayed against the acceptance route.
+ */
+#[ScopedBy(RestaurantScope::class)]
+final class Invitation extends Model
+{
+    /** @use HasFactory<InvitationFactory> */
+    use HasFactory;
+
+    /** @var list<string> */
+    protected $fillable = [
+        'restaurant_id',
+        'email',
+        'role',
+        'token',
+        'expires_at',
+        'accepted_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'role' => UserRole::class,
+            'expires_at' => 'datetime',
+            'accepted_at' => 'datetime',
+        ];
+    }
+
+    public static function generateToken(): string
+    {
+        return Str::random(64);
+    }
+
+    public static function hashToken(string $plain): string
+    {
+        return hash('sha256', $plain);
+    }
+
+    /**
+     * Look up an invitation by its plaintext token. Runs without the tenant
+     * scope because acceptance happens before the guest is logged in.
+     */
+    public static function findByToken(string $plain): ?self
+    {
+        return self::query()
+            ->withoutGlobalScopes()
+            ->where('token', self::hashToken($plain))
+            ->first();
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->expires_at->isPast();
+    }
+
+    public function isAccepted(): bool
+    {
+        return $this->accepted_at !== null;
+    }
+
+    public function isPending(): bool
+    {
+        return ! $this->isExpired() && ! $this->isAccepted();
+    }
+
+    /**
+     * @return BelongsTo<Restaurant, $this>
+     */
+    public function restaurant(): BelongsTo
+    {
+        return $this->belongsTo(Restaurant::class);
+    }
+}

--- a/app/Models/Invitation.php
+++ b/app/Models/Invitation.php
@@ -37,6 +37,16 @@ final class Invitation extends Model
     ];
 
     /**
+     * Never serialize the token hash — invitations may later be surfaced in
+     * Inertia props (team lists), and the hash has no place in the browser.
+     *
+     * @var list<string>
+     */
+    protected $hidden = [
+        'token',
+    ];
+
+    /**
      * @return array<string, string>
      */
     protected function casts(): array

--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -35,6 +35,7 @@ class Restaurant extends Model
         'capacity',
         'opening_hours',
         'tonality',
+        'onboarding_completed_at',
         'imap_host',
         'imap_username',
         'imap_password',
@@ -67,6 +68,7 @@ class Restaurant extends Model
             'capacity' => 'integer',
             'opening_hours' => 'array',
             'tonality' => Tonality::class,
+            'onboarding_completed_at' => 'datetime',
             'imap_password' => 'encrypted',
             'send_mode' => SendMode::class,
             'auto_send_party_size_max' => 'integer',
@@ -83,6 +85,30 @@ class Restaurant extends Model
     public function reservationRequests(): HasMany
     {
         return $this->hasMany(ReservationRequest::class);
+    }
+
+    /**
+     * @return HasMany<User, $this>
+     */
+    public function users(): HasMany
+    {
+        return $this->hasMany(User::class);
+    }
+
+    /**
+     * @return HasMany<Invitation, $this>
+     */
+    public function invitations(): HasMany
+    {
+        return $this->hasMany(Invitation::class);
+    }
+
+    /**
+     * A restaurant is "live" once the onboarding Pflicht-Kern is complete.
+     */
+    public function isLive(): bool
+    {
+        return $this->onboarding_completed_at !== null;
     }
 
     /**

--- a/database/factories/InvitationFactory.php
+++ b/database/factories/InvitationFactory.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Invitation>
+ */
+class InvitationFactory extends Factory
+{
+    protected $model = Invitation::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'restaurant_id' => Restaurant::factory(),
+            'email' => fake()->unique()->safeEmail(),
+            'role' => UserRole::Staff,
+            'token' => Invitation::hashToken(Invitation::generateToken()),
+            'expires_at' => now()->addDays(7),
+            'accepted_at' => null,
+        ];
+    }
+
+    public function owner(): static
+    {
+        return $this->state(fn () => ['role' => UserRole::Owner]);
+    }
+
+    public function expired(): static
+    {
+        return $this->state(fn () => ['expires_at' => now()->subDay()]);
+    }
+
+    public function accepted(): static
+    {
+        return $this->state(fn () => ['accepted_at' => now()]);
+    }
+}

--- a/database/factories/RestaurantFactory.php
+++ b/database/factories/RestaurantFactory.php
@@ -43,4 +43,26 @@ class RestaurantFactory extends Factory
             'imap_password' => null,
         ];
     }
+
+    /**
+     * A restaurant that has completed onboarding (is "live").
+     */
+    public function onboarded(): static
+    {
+        return $this->state(fn () => [
+            'onboarding_completed_at' => now(),
+        ]);
+    }
+
+    /**
+     * A freshly provisioned restaurant before the wizard: no opening hours,
+     * not yet live.
+     */
+    public function pendingOnboarding(): static
+    {
+        return $this->state(fn () => [
+            'onboarding_completed_at' => null,
+            'opening_hours' => [],
+        ]);
+    }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -56,4 +56,14 @@ class UserFactory extends Factory
             'restaurant_id' => $restaurant->id,
         ]);
     }
+
+    /**
+     * Indicate that the user is the restaurant owner.
+     */
+    public function owner(): static
+    {
+        return $this->state(fn () => [
+            'role' => UserRole::Owner,
+        ]);
+    }
 }

--- a/tests/Feature/Onboarding/InvitationModelTest.php
+++ b/tests/Feature/Onboarding/InvitationModelTest.php
@@ -53,6 +53,14 @@ final class InvitationModelTest extends TestCase
         $this->assertFalse($accepted->isPending());
     }
 
+    public function test_the_token_hash_is_never_serialized(): void
+    {
+        $invitation = Invitation::factory()->for(Restaurant::factory())->create();
+
+        $this->assertArrayNotHasKey('token', $invitation->toArray());
+        $this->assertArrayNotHasKey('token', json_decode((string) json_encode($invitation), true));
+    }
+
     public function test_find_by_token_ignores_the_tenant_scope(): void
     {
         // No authenticated user (acceptance happens before login), so the

--- a/tests/Feature/Onboarding/InvitationModelTest.php
+++ b/tests/Feature/Onboarding/InvitationModelTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class InvitationModelTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_hashes_a_plaintext_token_and_finds_by_it(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $plain = Invitation::generateToken();
+
+        $invitation = Invitation::create([
+            'restaurant_id' => $restaurant->id,
+            'email' => 'owner@example.test',
+            'role' => UserRole::Owner,
+            'token' => Invitation::hashToken($plain),
+            'expires_at' => now()->addDays(7),
+        ]);
+
+        $this->assertNotSame($plain, $invitation->token);
+        $this->assertSame(64, strlen(Invitation::hashToken($plain)));
+        $this->assertTrue(Invitation::findByToken($plain)?->is($invitation));
+        $this->assertNull(Invitation::findByToken('wrong-token'));
+        $this->assertSame(UserRole::Owner, $invitation->role);
+    }
+
+    public function test_pending_expired_and_accepted_states(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $pending = Invitation::factory()->for($restaurant)->create();
+        $expired = Invitation::factory()->for($restaurant)->expired()->create();
+        $accepted = Invitation::factory()->for($restaurant)->accepted()->create();
+
+        $this->assertTrue($pending->isPending());
+        $this->assertFalse($pending->isExpired());
+        $this->assertFalse($pending->isAccepted());
+
+        $this->assertTrue($expired->isExpired());
+        $this->assertFalse($expired->isPending());
+
+        $this->assertTrue($accepted->isAccepted());
+        $this->assertFalse($accepted->isPending());
+    }
+
+    public function test_find_by_token_ignores_the_tenant_scope(): void
+    {
+        // No authenticated user (acceptance happens before login), so the
+        // lookup must bypass RestaurantScope to find the invitation at all.
+        $restaurant = Restaurant::factory()->create();
+        $plain = Invitation::generateToken();
+        $invitation = Invitation::factory()->for($restaurant)->create([
+            'token' => Invitation::hashToken($plain),
+        ]);
+
+        $this->assertTrue(Invitation::findByToken($plain)?->is($invitation));
+    }
+}

--- a/tests/Feature/Onboarding/OnboardingWiringTest.php
+++ b/tests/Feature/Onboarding/OnboardingWiringTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+final class OnboardingWiringTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_restaurant_exposes_users_and_invitations_relations(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        User::factory()->forRestaurant($restaurant)->create();
+        Invitation::factory()->for($restaurant)->create();
+
+        $this->assertCount(1, $restaurant->users()->get());
+        $this->assertCount(1, $restaurant->invitations()->get());
+    }
+
+    public function test_is_live_reflects_onboarding_completed_at_with_datetime_cast(): void
+    {
+        $restaurant = Restaurant::factory()->create(['onboarding_completed_at' => null]);
+        $this->assertFalse($restaurant->isLive());
+
+        $restaurant->update(['onboarding_completed_at' => now()]);
+        $restaurant->refresh();
+
+        $this->assertInstanceOf(Carbon::class, $restaurant->onboarding_completed_at);
+        $this->assertTrue($restaurant->isLive());
+    }
+
+    public function test_factory_states(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+        $this->assertSame(UserRole::Owner, $owner->role);
+
+        $this->assertNotNull(Restaurant::factory()->onboarded()->create()->onboarding_completed_at);
+
+        $pending = Restaurant::factory()->pendingOnboarding()->create();
+        $this->assertNull($pending->onboarding_completed_at);
+        $this->assertSame([], $pending->opening_hours);
+    }
+}


### PR DESCRIPTION
## Summary
- `Invitation` model (`#[ScopedBy(RestaurantScope)]`): `generateToken()`/`hashToken()`/`findByToken()` (the lookup bypasses the tenant scope because acceptance happens pre-login), `isExpired()`/`isAccepted()`/`isPending()`, `role`→`UserRole` + datetime casts, `restaurant()` relation.
- `InvitationFactory` with `owner()` / `expired()` / `accepted()` states.
- `Restaurant`: `onboarding_completed_at` fillable + datetime cast; `users()` + `invitations()` HasMany; `isLive()`.
- Factory states: `UserFactory::owner()`, `RestaurantFactory::onboarded()` / `pendingOnboarding()`.

## Why
Builds the model layer on top of the #395 schema so provisioning, invitation acceptance and the wizard (next issues) have the Invitation behaviour, the live-state helper and the shared factory states they rely on (PRD-016 Phase 1, plan Task A2–A4).

## Test plan
- `InvitationModelTest`: token hashing + lookup (incl. tenant-scope bypass), pending/expired/accepted states.
- `OnboardingWiringTest`: users()/invitations() relations, isLive() + datetime cast, factory states.
- Full suite: 1019 passed; `pint --test` clean.

Closes #396.