### PR TITLE
PRD-016 #398: invitation acceptance controller + FormRequest + routes

### DIFF
--- a/app/Http/Controllers/Onboarding/AcceptInvitationController.php
+++ b/app/Http/Controllers/Onboarding/AcceptInvitationController.php
@@ -12,6 +12,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
 use Inertia\Inertia;
 use Inertia\Response;
 
@@ -50,17 +51,26 @@ final class AcceptInvitationController extends Controller
             return redirect()->route('onboarding.accept', ['token' => $token]);
         }
 
+        // Owner invitations already have a provisioned (password-less) user;
+        // staff invitations create the user on acceptance. firstOrNew covers
+        // both, and the role always comes from the invitation.
+        $user = User::firstOrNew([
+            'restaurant_id' => $invitation->restaurant_id,
+            'email' => $invitation->email,
+        ]);
+
+        // An invitation must never reset the credentials of an already-active
+        // account — the only legitimate targets are a provisioned password-less
+        // owner or a brand-new staff user.
+        if ($user->exists && $user->password !== null) {
+            throw ValidationException::withMessages([
+                'email' => 'Dieses Konto ist bereits aktiv. Bitte melden Sie sich an.',
+            ]);
+        }
+
         $validated = $request->validated();
 
-        $user = DB::transaction(function () use ($invitation, $validated): User {
-            // Owner invitations already have a provisioned (password-less) user;
-            // staff invitations create the user on acceptance. firstOrNew covers
-            // both, and the role always comes from the invitation.
-            $user = User::firstOrNew([
-                'restaurant_id' => $invitation->restaurant_id,
-                'email' => $invitation->email,
-            ]);
-
+        DB::transaction(function () use ($invitation, $user, $validated): void {
             $user->forceFill([
                 'name' => $validated['name'],
                 'password' => Hash::make($validated['password']),
@@ -69,11 +79,12 @@ final class AcceptInvitationController extends Controller
             ])->save();
 
             $invitation->forceFill(['accepted_at' => now()])->save();
-
-            return $user;
         });
 
         Auth::login($user);
+        // Rotate the session id on login to close the session-fixation gap,
+        // matching AuthenticatedSessionController.
+        $request->session()->regenerate();
 
         return to_route('dashboard');
     }

--- a/app/Http/Controllers/Onboarding/AcceptInvitationController.php
+++ b/app/Http/Controllers/Onboarding/AcceptInvitationController.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Onboarding;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Onboarding\AcceptInvitationRequest;
+use App\Models\Invitation;
+use App\Models\User;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Tokenised invitation acceptance. The owner (or staff) follows the link from
+ * `restaurant:provision` / a team invite, sets a name + password, and is
+ * logged in. After login we send them to the dashboard; the onboarding gate
+ * (PRD-016 §Gating) is responsible for routing a not-yet-live owner on to the
+ * setup wizard, so the acceptance flow stays decoupled from the wizard route.
+ */
+final class AcceptInvitationController extends Controller
+{
+    public function show(string $token): Response
+    {
+        $invitation = Invitation::findByToken($token);
+
+        if ($invitation === null || ! $invitation->isPending()) {
+            return Inertia::render('Onboarding/InvitationError', [
+                'reason' => $this->reason($invitation),
+            ]);
+        }
+
+        return Inertia::render('Onboarding/AcceptInvitation', [
+            'email' => $invitation->email,
+            'token' => $token,
+            'restaurantName' => $invitation->restaurant->name,
+        ]);
+    }
+
+    public function store(AcceptInvitationRequest $request, string $token): RedirectResponse
+    {
+        $invitation = Invitation::findByToken($token);
+
+        if ($invitation === null || ! $invitation->isPending()) {
+            // Re-render the error page via the GET route (idempotent on replay).
+            return redirect()->route('onboarding.accept', ['token' => $token]);
+        }
+
+        $validated = $request->validated();
+
+        $user = DB::transaction(function () use ($invitation, $validated): User {
+            // Owner invitations already have a provisioned (password-less) user;
+            // staff invitations create the user on acceptance. firstOrNew covers
+            // both, and the role always comes from the invitation.
+            $user = User::firstOrNew([
+                'restaurant_id' => $invitation->restaurant_id,
+                'email' => $invitation->email,
+            ]);
+
+            $user->forceFill([
+                'name' => $validated['name'],
+                'password' => Hash::make($validated['password']),
+                'role' => $invitation->role,
+                'email_verified_at' => now(),
+            ])->save();
+
+            $invitation->forceFill(['accepted_at' => now()])->save();
+
+            return $user;
+        });
+
+        Auth::login($user);
+
+        return to_route('dashboard');
+    }
+
+    private function reason(?Invitation $invitation): string
+    {
+        return match (true) {
+            $invitation === null => 'invalid',
+            $invitation->isAccepted() => 'accepted',
+            default => 'expired',
+        };
+    }
+}

--- a/app/Http/Requests/Onboarding/AcceptInvitationRequest.php
+++ b/app/Http/Requests/Onboarding/AcceptInvitationRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Onboarding;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+/**
+ * Validates the invitation-acceptance form. Authorization is implicit: the
+ * route is guest-only and the token itself is validated in the controller
+ * before any persistence happens.
+ */
+class AcceptInvitationRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'password' => ['required', 'confirmed', Password::defaults()],
+        ];
+    }
+}

--- a/resources/js/pages/Onboarding/AcceptInvitation.vue
+++ b/resources/js/pages/Onboarding/AcceptInvitation.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+// Minimal placeholder — the full acceptance form (OnboardingLayout, useForm)
+// is built in #399 once OnboardingLayout (#408) exists.
+defineProps<{ email: string; token: string; restaurantName: string }>();
+</script>
+
+<template>
+    <div>{{ restaurantName }} — {{ email }}</div>
+</template>

--- a/resources/js/pages/Onboarding/InvitationError.vue
+++ b/resources/js/pages/Onboarding/InvitationError.vue
@@ -1,0 +1,8 @@
+<script setup lang="ts">
+// Minimal placeholder — the styled error page is built in #399.
+defineProps<{ reason: string }>();
+</script>
+
+<template>
+    <div>{{ reason }}</div>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -2,6 +2,18 @@
 declare module 'ziggy-js' {
   interface RouteList {
     "home": [],
+    "onboarding.accept": [
+        {
+            "name": "token",
+            "required": true
+        }
+    ],
+    "onboarding.accept.store": [
+        {
+            "name": "token",
+            "required": true
+        }
+    ],
     "dashboard": [],
     "analytics.index": [],
     "exports.store": [],

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,6 +4,7 @@ use App\Http\Controllers\AnalyticsController;
 use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ExportController;
 use App\Http\Controllers\GdprSelfServiceController;
+use App\Http\Controllers\Onboarding\AcceptInvitationController;
 use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\QuickReservationController;
 use App\Http\Controllers\ReservationMessagesController;
@@ -19,6 +20,14 @@ use Inertia\Inertia;
 Route::get('/', function () {
     return Inertia::render('Welcome');
 })->name('home');
+
+// Tokenised invitation acceptance (owner + staff onboarding).
+Route::middleware('guest')->group(function () {
+    Route::get('onboarding/accept/{token}', [AcceptInvitationController::class, 'show'])
+        ->name('onboarding.accept');
+    Route::post('onboarding/accept/{token}', [AcceptInvitationController::class, 'store'])
+        ->name('onboarding.accept.store');
+});
 
 Route::get('dashboard', [DashboardController::class, 'index'])
     ->middleware(['auth', 'verified'])

--- a/tests/Feature/Onboarding/AcceptInvitationTest.php
+++ b/tests/Feature/Onboarding/AcceptInvitationTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+final class AcceptInvitationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array{0: string, 1: Invitation}
+     */
+    private function ownerInvitation(array $state = []): array
+    {
+        $restaurant = Restaurant::factory()->pendingOnboarding()->create();
+        User::factory()->owner()->forRestaurant($restaurant)->create([
+            'email' => 'owner@example.test',
+            'password' => null,
+        ]);
+        $plain = Invitation::generateToken();
+        $invitation = Invitation::factory()->for($restaurant)->owner()->create([
+            'email' => 'owner@example.test',
+            'token' => Invitation::hashToken($plain),
+            ...$state,
+        ]);
+
+        return [$plain, $invitation];
+    }
+
+    public function test_a_valid_token_renders_the_acceptance_form(): void
+    {
+        [$plain] = $this->ownerInvitation();
+
+        $this->get(route('onboarding.accept', ['token' => $plain]))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Onboarding/AcceptInvitation')
+                ->where('email', 'owner@example.test')
+                ->where('token', $plain)
+            );
+    }
+
+    public function test_unknown_expired_and_accepted_tokens_render_the_error_page(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $this->get(route('onboarding.accept', ['token' => 'nope']))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Onboarding/InvitationError')->where('reason', 'invalid'));
+
+        $expired = Invitation::generateToken();
+        Invitation::factory()->for($restaurant)->expired()->create(['token' => Invitation::hashToken($expired)]);
+        $this->get(route('onboarding.accept', ['token' => $expired]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Onboarding/InvitationError')->where('reason', 'expired'));
+
+        $accepted = Invitation::generateToken();
+        Invitation::factory()->for($restaurant)->accepted()->create(['token' => Invitation::hashToken($accepted)]);
+        $this->get(route('onboarding.accept', ['token' => $accepted]))
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Onboarding/InvitationError')->where('reason', 'accepted'));
+    }
+
+    public function test_owner_acceptance_sets_name_password_logs_in_and_redirects_to_dashboard(): void
+    {
+        [$plain] = $this->ownerInvitation();
+        $owner = User::where('email', 'owner@example.test')->sole();
+
+        $this->post(route('onboarding.accept.store', ['token' => $plain]), [
+            'name' => 'Mara Chef',
+            'password' => 'sup3r-secret-pw',
+            'password_confirmation' => 'sup3r-secret-pw',
+        ])->assertRedirect(route('dashboard'));
+
+        $this->assertAuthenticatedAs($owner->fresh());
+        $owner->refresh();
+        $this->assertSame('Mara Chef', $owner->name);
+        $this->assertSame(UserRole::Owner, $owner->role);
+        $this->assertTrue(Hash::check('sup3r-secret-pw', $owner->password));
+        $this->assertNotNull($owner->email_verified_at);
+        $this->assertNotNull(Invitation::findByToken($plain)->accepted_at);
+    }
+
+    public function test_staff_acceptance_creates_the_user_from_the_invitation(): void
+    {
+        $restaurant = Restaurant::factory()->onboarded()->create();
+        $plain = Invitation::generateToken();
+        Invitation::factory()->for($restaurant)->create([
+            'email' => 'server@example.test',
+            'role' => UserRole::Staff,
+            'token' => Invitation::hashToken($plain),
+        ]);
+
+        $this->post(route('onboarding.accept.store', ['token' => $plain]), [
+            'name' => 'Sam Server',
+            'password' => 'staff-secret-pw',
+            'password_confirmation' => 'staff-secret-pw',
+        ])->assertRedirect(route('dashboard'));
+
+        $staff = User::where('email', 'server@example.test')->sole();
+        $this->assertSame($restaurant->id, $staff->restaurant_id);
+        $this->assertSame(UserRole::Staff, $staff->role);
+        $this->assertAuthenticatedAs($staff);
+    }
+
+    public function test_a_used_token_cannot_be_replayed(): void
+    {
+        [$plain] = $this->ownerInvitation();
+
+        $this->post(route('onboarding.accept.store', ['token' => $plain]), [
+            'name' => 'Mara Chef',
+            'password' => 'sup3r-secret-pw',
+            'password_confirmation' => 'sup3r-secret-pw',
+        ])->assertRedirect(route('dashboard'));
+
+        $this->post('/logout');
+
+        $this->followingRedirects()
+            ->post(route('onboarding.accept.store', ['token' => $plain]), [
+                'name' => 'Intruder',
+                'password' => 'another-pw-1234',
+                'password_confirmation' => 'another-pw-1234',
+            ])
+            ->assertInertia(fn (AssertableInertia $page) => $page->component('Onboarding/InvitationError'));
+    }
+
+    public function test_validation_errors_are_returned(): void
+    {
+        [$plain] = $this->ownerInvitation();
+
+        $this->from(route('onboarding.accept', ['token' => $plain]))
+            ->post(route('onboarding.accept.store', ['token' => $plain]), [
+                'name' => '',
+                'password' => 'short',
+                'password_confirmation' => 'mismatch',
+            ])
+            ->assertSessionHasErrors(['name', 'password']);
+    }
+}

--- a/tests/Feature/Onboarding/AcceptInvitationTest.php
+++ b/tests/Feature/Onboarding/AcceptInvitationTest.php
@@ -134,6 +134,33 @@ final class AcceptInvitationTest extends TestCase
             ->assertInertia(fn (AssertableInertia $page) => $page->component('Onboarding/InvitationError'));
     }
 
+    public function test_acceptance_never_overwrites_an_already_active_account(): void
+    {
+        $restaurant = Restaurant::factory()->onboarded()->create();
+        $active = User::factory()->forRestaurant($restaurant)->create([
+            'email' => 'active@example.test',
+            'password' => Hash::make('original-password'),
+        ]);
+        $plain = Invitation::generateToken();
+        Invitation::factory()->for($restaurant)->create([
+            'email' => 'active@example.test',
+            'token' => Invitation::hashToken($plain),
+        ]);
+
+        $this->from(route('onboarding.accept', ['token' => $plain]))
+            ->post(route('onboarding.accept.store', ['token' => $plain]), [
+                'name' => 'Hijacker',
+                'password' => 'new-evil-password',
+                'password_confirmation' => 'new-evil-password',
+            ])
+            ->assertSessionHasErrors('email');
+
+        $active->refresh();
+        $this->assertTrue(Hash::check('original-password', $active->password));
+        $this->assertSame('active@example.test', $active->email);
+        $this->assertGuest();
+    }
+
     public function test_validation_errors_are_returned(): void
     {
         [$plain] = $this->ownerInvitation();


### PR DESCRIPTION
## Summary
Guest-only `onboarding.accept` (GET) + `onboarding.accept.store` (POST):
- GET: valid token → `Onboarding/AcceptInvitation`; invalid/expired/accepted → `Onboarding/InvitationError` with a reason.
- POST: validates name + password (`AcceptInvitationRequest`), sets name/hashed password/role/`email_verified_at`, marks the invitation accepted, logs the user in, redirects to `dashboard`.
- `firstOrNew` handles both owner invitations (user already provisioned) and staff invitations (user created on acceptance); role comes from the invitation.
- Minimal Vue stubs for both pages; the styled versions land in #399 (after OnboardingLayout #408).

## Deviations from the plan (deliberate, for issue ordering)
- Redirect target is `dashboard`, not `onboarding.wizard` (that route ships in #403). The onboarding gate (#404) is responsible for sending a not-yet-live owner to the wizard — this keeps acceptance decoupled from the wizard route.
- Plan used `firstOrFail`; switched to `firstOrNew` so staff invitations (no pre-existing user) also work.

## Test plan
- `AcceptInvitationTest`: valid render; invalid/expired/accepted error pages; owner acceptance (password/role/verified/login/redirect); staff acceptance creates the user; replay rejected; validation errors.
- Full suite 1026 passed; pint, eslint, build all clean.

Closes #398.