### PR TITLE
PRD-016 #397: RestaurantProvisioner service + restaurant:provision command

### DIFF
--- a/app/Console/Commands/ProvisionRestaurantCommand.php
+++ b/app/Console/Commands/ProvisionRestaurantCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\RestaurantProvisioner;
+use Illuminate\Console\Command;
+use Illuminate\Validation\ValidationException;
+
+final class ProvisionRestaurantCommand extends Command
+{
+    protected $signature = 'restaurant:provision
+        {--name= : Restaurant display name}
+        {--slug= : Public URL slug (unique)}
+        {--email= : Owner email address (unique)}
+        {--timezone=Europe/Berlin : IANA timezone}';
+
+    protected $description = 'Create a restaurant, its owner and an owner invitation, and print the acceptance link.';
+
+    public function handle(RestaurantProvisioner $provisioner): int
+    {
+        $name = (string) $this->option('name');
+        $slug = (string) $this->option('slug');
+        $email = (string) $this->option('email');
+        $timezone = (string) $this->option('timezone');
+
+        if ($name === '' || $slug === '' || $email === '') {
+            $this->error('--name, --slug and --email are required.');
+
+            return self::FAILURE;
+        }
+
+        try {
+            $result = $provisioner->provision($name, $slug, $email, $timezone);
+        } catch (ValidationException $e) {
+            foreach ($e->errors() as $messages) {
+                foreach ($messages as $message) {
+                    $this->error($message);
+                }
+            }
+
+            return self::FAILURE;
+        }
+
+        $link = route('onboarding.accept', ['token' => $result->plainToken]);
+
+        $this->info(sprintf('Provisioned "%s" (#%d).', $result->restaurant->name, $result->restaurant->id));
+        $this->line('Owner: '.$result->owner->email);
+        $this->newLine();
+        $this->line('Acceptance link (valid 7 days, shown once):');
+        $this->line($link);
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/RestaurantProvisioner.php
+++ b/app/Services/RestaurantProvisioner.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Enums\Tonality;
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Str;
+
+/**
+ * Carries the freshly created invitation together with its one-time plaintext
+ * token, which only exists in memory at provision time.
+ */
+final readonly class ProvisionResult
+{
+    public function __construct(
+        public Restaurant $restaurant,
+        public User $owner,
+        public Invitation $invitation,
+        public string $plainToken,
+    ) {}
+}
+
+/**
+ * Creates a restaurant, its owner (password-less until the invitation is
+ * accepted) and an owner invitation in one transaction. Reused by the
+ * `restaurant:provision` command today and the Super-Admin UI later.
+ */
+final class RestaurantProvisioner
+{
+    private const INVITE_TTL_DAYS = 7;
+
+    public function provision(string $name, string $slug, string $email, string $timezone = 'Europe/Berlin'): ProvisionResult
+    {
+        $this->validate($slug, $email, $timezone);
+
+        return DB::transaction(function () use ($name, $slug, $email, $timezone): ProvisionResult {
+            $restaurant = Restaurant::create([
+                'name' => $name,
+                'slug' => $slug,
+                'timezone' => $timezone,
+                // NOT NULL columns without DB defaults — seeded with safe
+                // placeholders the wizard overwrites (PRD-016 §Provisionierung).
+                'capacity' => 0,
+                'opening_hours' => [],
+                'tonality' => Tonality::Formal,
+            ]);
+
+            $owner = User::create([
+                'name' => $this->placeholderName($email),
+                'email' => $email,
+                'password' => null,
+                'restaurant_id' => $restaurant->id,
+                'role' => UserRole::Owner,
+            ]);
+
+            $plainToken = Invitation::generateToken();
+
+            $invitation = Invitation::create([
+                'restaurant_id' => $restaurant->id,
+                'email' => $email,
+                'role' => UserRole::Owner,
+                'token' => Invitation::hashToken($plainToken),
+                'expires_at' => now()->addDays(self::INVITE_TTL_DAYS),
+            ]);
+
+            return new ProvisionResult($restaurant, $owner, $invitation, $plainToken);
+        });
+    }
+
+    private function validate(string $slug, string $email, string $timezone): void
+    {
+        Validator::make(
+            ['slug' => $slug, 'email' => $email, 'timezone' => $timezone],
+            [
+                'slug' => ['required', 'string', 'max:255', 'unique:restaurants,slug'],
+                'email' => ['required', 'email', 'max:255', 'unique:users,email'],
+                'timezone' => ['required', 'timezone'],
+            ],
+        )->validate();
+    }
+
+    private function placeholderName(string $email): string
+    {
+        return Str::of($email)->before('@')->headline()->value();
+    }
+}

--- a/tests/Feature/Onboarding/ProvisionRestaurantCommandTest.php
+++ b/tests/Feature/Onboarding/ProvisionRestaurantCommandTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class ProvisionRestaurantCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_provisions_and_prints_the_acceptance_link(): void
+    {
+        $this->artisan('restaurant:provision', [
+            '--name' => 'Trattoria Bella',
+            '--slug' => 'trattoria-bella',
+            '--email' => 'chef@bella.test',
+        ])
+            ->expectsOutputToContain('/onboarding/accept/')
+            ->assertSuccessful();
+
+        $this->assertDatabaseHas('restaurants', ['slug' => 'trattoria-bella']);
+        $this->assertDatabaseHas('users', ['email' => 'chef@bella.test', 'role' => 'owner']);
+        $this->assertDatabaseHas('invitations', ['email' => 'chef@bella.test', 'role' => 'owner']);
+    }
+
+    public function test_it_fails_on_a_duplicate_slug(): void
+    {
+        Restaurant::factory()->create(['slug' => 'taken']);
+
+        $this->artisan('restaurant:provision', [
+            '--name' => 'X',
+            '--slug' => 'taken',
+            '--email' => 'new@bella.test',
+        ])
+            ->expectsOutputToContain('slug')
+            ->assertFailed();
+    }
+
+    public function test_it_fails_when_required_options_are_missing(): void
+    {
+        $this->artisan('restaurant:provision', ['--name' => 'Only Name'])
+            ->expectsOutputToContain('required')
+            ->assertFailed();
+    }
+}

--- a/tests/Feature/Onboarding/RestaurantProvisionerTest.php
+++ b/tests/Feature/Onboarding/RestaurantProvisionerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\Tonality;
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Services\RestaurantProvisioner;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Validation\ValidationException;
+use Tests\TestCase;
+
+final class RestaurantProvisionerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function provisioner(): RestaurantProvisioner
+    {
+        return $this->app->make(RestaurantProvisioner::class);
+    }
+
+    public function test_it_creates_restaurant_owner_and_invitation_with_safe_defaults(): void
+    {
+        $result = $this->provisioner()->provision(
+            name: 'Trattoria Bella',
+            slug: 'trattoria-bella',
+            email: 'chef@bella.test',
+            timezone: 'Europe/Berlin',
+        );
+
+        $restaurant = Restaurant::query()->where('slug', 'trattoria-bella')->sole();
+        $this->assertSame(0, $restaurant->capacity);
+        $this->assertSame([], $restaurant->opening_hours);
+        $this->assertSame(Tonality::Formal, $restaurant->tonality);
+        $this->assertNull($restaurant->onboarding_completed_at);
+
+        $owner = User::query()->where('email', 'chef@bella.test')->sole();
+        $this->assertSame(UserRole::Owner, $owner->role);
+        $this->assertSame($restaurant->id, $owner->restaurant_id);
+        $this->assertNull($owner->password);
+
+        $this->assertInstanceOf(Invitation::class, $result->invitation);
+        $this->assertSame(UserRole::Owner, $result->invitation->role);
+        $this->assertNotEmpty($result->plainToken);
+        $this->assertTrue(Invitation::findByToken($result->plainToken)?->is($result->invitation));
+    }
+
+    public function test_it_rejects_a_duplicate_slug(): void
+    {
+        Restaurant::factory()->create(['slug' => 'taken']);
+
+        $this->expectException(ValidationException::class);
+
+        $this->provisioner()->provision('X', 'taken', 'x@example.test', 'Europe/Berlin');
+    }
+
+    public function test_it_rejects_a_duplicate_email(): void
+    {
+        User::factory()->create(['email' => 'dupe@example.test']);
+
+        $this->expectException(ValidationException::class);
+
+        $this->provisioner()->provision('X', 'fresh-slug', 'dupe@example.test', 'Europe/Berlin');
+    }
+
+    public function test_it_rejects_an_invalid_timezone(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        $this->provisioner()->provision('X', 'tz-slug', 'tz@example.test', 'Mars/Phobos');
+    }
+}


### PR DESCRIPTION
## Summary
- `RestaurantProvisioner::provision(name, slug, email, timezone): ProvisionResult` — one transaction creating the restaurant (capacity 0, opening_hours [], tonality Formal), the owner (role=owner, password null, placeholder name from the email) and an owner invitation (hashed token, +7d). Rejects duplicate slug/email and invalid timezone via `ValidationException`. Reusable by the later Super-Admin UI.
- `restaurant:provision --name= --slug= --email= [--timezone=]` calls the service and prints the one-time `onboarding.accept` link; duplicates / missing options fail with a clear message + non-zero exit.

## Test plan
- `RestaurantProvisionerTest`: defaults + owner role + retrievable token; duplicate slug/email; invalid timezone.
- `ProvisionRestaurantCommandTest`: prints link + persists rows; duplicate slug fails; missing options fail.
- Full suite green; pint clean.

Closes #397.