### PR TITLE
PRD-016 #400: OnboardingProgress value object

### DIFF
--- a/app/Support/OnboardingProgress.php
+++ b/app/Support/OnboardingProgress.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+
+/**
+ * Derives onboarding step completion purely from persisted data, so progress
+ * survives logout/login and is never stored as a separate "current step".
+ */
+final readonly class OnboardingProgress
+{
+    /** Required ("Pflicht-Kern") steps, in wizard order. */
+    public const CORE_STEPS = ['restaurant', 'hours', 'tables'];
+
+    /** Optional, skippable steps. */
+    public const OPTIONAL_STEPS = ['tonality', 'team'];
+
+    private function __construct(private Restaurant $restaurant) {}
+
+    public static function for(Restaurant $restaurant): self
+    {
+        return new self($restaurant);
+    }
+
+    public function stepComplete(string $step): bool
+    {
+        return match ($step) {
+            'restaurant' => $this->restaurant->name !== ''
+                && $this->restaurant->slug !== ''
+                && $this->restaurant->timezone !== '',
+            'hours' => $this->restaurant->opening_hours !== [],
+            'tables' => $this->restaurant->tables()->where('active', true)->exists(),
+            'tonality' => true, // enum column always carries a value
+            'team' => $this->restaurant->invitations()->where('role', UserRole::Staff)->exists(),
+            default => false,
+        };
+    }
+
+    public function isCoreComplete(): bool
+    {
+        foreach (self::CORE_STEPS as $step) {
+            if (! $this->stepComplete($step)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * The first incomplete core step, or null when the core is done.
+     */
+    public function nextCoreStep(): ?string
+    {
+        foreach (self::CORE_STEPS as $step) {
+            if (! $this->stepComplete($step)) {
+                return $step;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Optional steps the owner has not yet addressed (for dashboard reminders).
+     *
+     * @return list<string>
+     */
+    public function pendingOptionalSteps(): array
+    {
+        return array_values(array_filter(
+            self::OPTIONAL_STEPS,
+            fn (string $step): bool => ! $this->stepComplete($step),
+        ));
+    }
+}

--- a/tests/Feature/Onboarding/OnboardingProgressTest.php
+++ b/tests/Feature/Onboarding/OnboardingProgressTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\Tonality;
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Support\OnboardingProgress;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class OnboardingProgressTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_core_is_incomplete_without_hours_and_tables(): void
+    {
+        $restaurant = Restaurant::factory()->pendingOnboarding()->create();
+        $progress = OnboardingProgress::for($restaurant);
+
+        $this->assertTrue($progress->stepComplete('restaurant')); // master data exists post-provision
+        $this->assertFalse($progress->stepComplete('hours'));
+        $this->assertFalse($progress->stepComplete('tables'));
+        $this->assertFalse($progress->isCoreComplete());
+        $this->assertSame('hours', $progress->nextCoreStep());
+    }
+
+    public function test_core_is_complete_with_hours_and_at_least_one_active_table(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'opening_hours' => ['mon' => [['from' => '18:00', 'to' => '22:00']]],
+        ]);
+        Table::factory()->for($restaurant)->create(['active' => true]);
+
+        $progress = OnboardingProgress::for($restaurant);
+
+        $this->assertTrue($progress->stepComplete('hours'));
+        $this->assertTrue($progress->stepComplete('tables'));
+        $this->assertTrue($progress->isCoreComplete());
+        $this->assertNull($progress->nextCoreStep());
+    }
+
+    public function test_an_inactive_table_does_not_satisfy_the_tables_step(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'opening_hours' => ['mon' => [['from' => '18:00', 'to' => '22:00']]],
+        ]);
+        Table::factory()->for($restaurant)->create(['active' => false]);
+
+        $this->assertFalse(OnboardingProgress::for($restaurant)->stepComplete('tables'));
+    }
+
+    public function test_optional_steps_tracking_and_pending_list(): void
+    {
+        $restaurant = Restaurant::factory()->create(['tonality' => Tonality::Casual]);
+        $progress = OnboardingProgress::for($restaurant);
+
+        $this->assertTrue($progress->stepComplete('tonality'));
+        $this->assertFalse($progress->stepComplete('team'));
+        $this->assertSame(['team'], $progress->pendingOptionalSteps());
+
+        Invitation::factory()->for($restaurant)->create(['role' => UserRole::Staff]);
+        $this->assertTrue(OnboardingProgress::for($restaurant)->stepComplete('team'));
+        $this->assertSame([], OnboardingProgress::for($restaurant)->pendingOptionalSteps());
+    }
+}


### PR DESCRIPTION
## Summary
`OnboardingProgress::for($restaurant)` derives step completion purely from persisted data: `restaurant` (master data present), `hours` (opening_hours non-empty), `tables` (>=1 active table), `tonality` (always set), `team` (>=1 staff invitation). Exposes `stepComplete()`, `isCoreComplete()`, `nextCoreStep()`, `pendingOptionalSteps()`. No stored 'current step', so progress survives logout.

## Test plan
- `OnboardingProgressTest`: core incomplete/complete, inactive table excluded, optional tracking + pending list.
- Full suite green; pint clean.

Closes #400.