### PR TITLE
PRD-016 #401: onboarding step FormRequests

### DIFF
--- a/app/Http/Requests/Onboarding/InviteStaffRequest.php
+++ b/app/Http/Requests/Onboarding/InviteStaffRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Onboarding;
+
+use App\Models\User;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class InviteStaffRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email', 'max:255', Rule::unique(User::class, 'email')],
+        ];
+    }
+}

--- a/app/Http/Requests/Onboarding/OpeningHoursRequest.php
+++ b/app/Http/Requests/Onboarding/OpeningHoursRequest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Onboarding;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the opening-hours schedule against the PRD-001 shape:
+ *   ['mon' => [['from' => 'HH:MM', 'to' => 'HH:MM'], ...], 'tue' => [], ...]
+ * Day keys are the seven lowercase three-letter abbreviations. At least one
+ * day must carry one open block, otherwise the restaurant is closed forever.
+ */
+class OpeningHoursRequest extends FormRequest
+{
+    private const DAYS = ['sun', 'mon', 'tue', 'wed', 'thu', 'fri', 'sat'];
+
+    private const TIME = 'regex:/^([01]\d|2[0-3]):[0-5]\d$/';
+
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string|Closure>>
+     */
+    public function rules(): array
+    {
+        return [
+            'opening_hours' => ['required', 'array:'.implode(',', self::DAYS), $this->atLeastOneOpenBlock()],
+            'opening_hours.*' => ['array'],
+            'opening_hours.*.*.from' => ['required', 'string', self::TIME],
+            'opening_hours.*.*.to' => ['required', 'string', self::TIME],
+        ];
+    }
+
+    private function atLeastOneOpenBlock(): Closure
+    {
+        return function (string $attribute, mixed $value, Closure $fail): void {
+            if (! is_array($value)) {
+                $fail('Öffnungszeiten fehlen.');
+
+                return;
+            }
+
+            foreach ($value as $blocks) {
+                if (is_array($blocks) && $blocks !== []) {
+                    return;
+                }
+            }
+
+            $fail('Mindestens ein Tag muss eine Öffnungszeit haben.');
+        };
+    }
+}

--- a/app/Http/Requests/Onboarding/RestaurantInfoRequest.php
+++ b/app/Http/Requests/Onboarding/RestaurantInfoRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Onboarding;
+
+use App\Models\Restaurant;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class RestaurantInfoRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        $restaurantId = $this->user()?->restaurant_id;
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => [
+                'required', 'string', 'max:255', 'alpha_dash',
+                Rule::unique(Restaurant::class, 'slug')->ignore($restaurantId),
+            ],
+            'timezone' => ['required', 'timezone'],
+        ];
+    }
+}

--- a/app/Http/Requests/Onboarding/TonalityRequest.php
+++ b/app/Http/Requests/Onboarding/TonalityRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Onboarding;
+
+use App\Enums\Tonality;
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TonalityRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'tonality' => ['required', Rule::enum(Tonality::class)],
+        ];
+    }
+}

--- a/tests/Feature/Onboarding/OnboardingFormRequestsTest.php
+++ b/tests/Feature/Onboarding/OnboardingFormRequestsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\Tonality;
+use App\Http\Requests\Onboarding\OpeningHoursRequest;
+use App\Http\Requests\Onboarding\TonalityRequest;
+use Illuminate\Support\Facades\Validator;
+use Tests\TestCase;
+
+final class OnboardingFormRequestsTest extends TestCase
+{
+    private function fails(array $rules, array $data): bool
+    {
+        return Validator::make($data, $rules)->fails();
+    }
+
+    public function test_opening_hours_accepts_a_valid_schedule(): void
+    {
+        $this->assertFalse($this->fails(
+            (new OpeningHoursRequest)->rules(),
+            ['opening_hours' => ['mon' => [['from' => '11:30', 'to' => '14:30']], 'tue' => []]],
+        ));
+    }
+
+    public function test_opening_hours_rejects_bad_time(): void
+    {
+        $this->assertTrue($this->fails(
+            (new OpeningHoursRequest)->rules(),
+            ['opening_hours' => ['mon' => [['from' => '25:00', 'to' => '14:30']]]],
+        ));
+    }
+
+    public function test_opening_hours_rejects_an_unknown_day(): void
+    {
+        $this->assertTrue($this->fails(
+            (new OpeningHoursRequest)->rules(),
+            ['opening_hours' => ['funday' => [['from' => '10:00', 'to' => '12:00']]]],
+        ));
+    }
+
+    public function test_opening_hours_requires_at_least_one_open_block(): void
+    {
+        $this->assertTrue($this->fails(
+            (new OpeningHoursRequest)->rules(),
+            ['opening_hours' => ['mon' => [], 'tue' => []]],
+        ));
+    }
+
+    public function test_tonality_rejects_an_invalid_value(): void
+    {
+        $rules = (new TonalityRequest)->rules();
+
+        $this->assertFalse($this->fails($rules, ['tonality' => Tonality::Casual->value]));
+        $this->assertTrue($this->fails($rules, ['tonality' => 'screaming']));
+    }
+}


### PR DESCRIPTION
## Summary
One FormRequest per wizard step, reusable by later settings pages:
- `RestaurantInfoRequest`: name, slug (alpha_dash, unique ignoring own restaurant), timezone (timezone rule).
- `OpeningHoursRequest`: `array:sun..sat` (rejects unknown days), HH:MM regex on from/to, custom rule requiring >=1 open block.
- `TonalityRequest`: `Rule::enum(Tonality)`.
- `InviteStaffRequest`: required unique email.

## Test plan
- `OnboardingFormRequestsTest`: opening-hours valid / bad time / unknown day / all-empty; tonality enum.
- Full suite green; pint clean.

Closes #401.