### PR TITLE
PRD-016 #402: InvitationPolicy (owner-only staff invites)

### DIFF
--- a/app/Policies/InvitationPolicy.php
+++ b/app/Policies/InvitationPolicy.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Policies;
+
+use App\Enums\UserRole;
+use App\Models\User;
+
+final class InvitationPolicy
+{
+    /**
+     * Only an owner of a restaurant may invite staff.
+     */
+    public function create(User $user): bool
+    {
+        return $user->restaurant_id !== null && $user->role === UserRole::Owner;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
+use App\Models\Invitation;
 use App\Models\ReservationRequest;
 use App\Models\Restaurant;
 use App\Models\Table;
+use App\Policies\InvitationPolicy;
 use App\Policies\ReservationRequestPolicy;
 use App\Policies\RestaurantPolicy;
 use App\Policies\TablePolicy;
@@ -22,6 +24,7 @@ final class AuthServiceProvider extends ServiceProvider
         Restaurant::class => RestaurantPolicy::class,
         ReservationRequest::class => ReservationRequestPolicy::class,
         Table::class => TablePolicy::class,
+        Invitation::class => InvitationPolicy::class,
     ];
 
     public function boot(): void

--- a/tests/Feature/Onboarding/InvitationPolicyTest.php
+++ b/tests/Feature/Onboarding/InvitationPolicyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+final class InvitationPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_may_invite_staff_but_staff_and_restaurantless_users_may_not(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+        $restaurantless = User::factory()->create(['restaurant_id' => null]);
+
+        $this->assertTrue(Gate::forUser($owner)->allows('create', Invitation::class));
+        $this->assertFalse(Gate::forUser($staff)->allows('create', Invitation::class));
+        $this->assertFalse(Gate::forUser($restaurantless)->allows('create', Invitation::class));
+    }
+}


### PR DESCRIPTION
## Summary
`InvitationPolicy::create` allows only an owner (role=owner with a restaurant) to issue invitations; registered in `AuthServiceProvider::$policies`.

## Test plan
- `InvitationPolicyTest`: owner allowed; staff and restaurant-less users denied.
- Full suite green (1044); pint clean.

Closes #402.