### PR TITLE
PRD-016 #408: OnboardingLayout (dark topbar) + central reservationStatus module

### DIFF
--- a/resources/js/layouts/OnboardingLayout.test.ts
+++ b/resources/js/layouts/OnboardingLayout.test.ts
@@ -1,0 +1,16 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import OnboardingLayout from './OnboardingLayout.vue';
+
+describe('OnboardingLayout', () => {
+    it('renders the title in a dark topbar and the default slot', () => {
+        const wrapper = mount(OnboardingLayout, {
+            props: { title: 'Restaurant einrichten' },
+            slots: { default: '<p>Inhalt</p>' },
+        });
+
+        expect(wrapper.find('header').classes()).toContain('bg-topbar');
+        expect(wrapper.text()).toContain('Restaurant einrichten');
+        expect(wrapper.html()).toContain('Inhalt');
+    });
+});

--- a/resources/js/layouts/OnboardingLayout.vue
+++ b/resources/js/layouts/OnboardingLayout.vue
@@ -1,0 +1,14 @@
+<script setup lang="ts">
+defineProps<{ title: string }>();
+</script>
+
+<template>
+    <div class="min-h-screen bg-background text-foreground">
+        <header class="flex h-16 items-center bg-topbar px-6 text-topbar-foreground">
+            <span class="text-lg font-semibold">{{ title }}</span>
+        </header>
+        <main class="mx-auto w-full max-w-2xl px-6 py-10">
+            <slot />
+        </main>
+    </div>
+</template>

--- a/resources/js/lib/reservationStatus.test.ts
+++ b/resources/js/lib/reservationStatus.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { RESERVATION_STATUSES, statusBadgeClass, statusLabel } from './reservationStatus';
+
+describe('reservationStatus', () => {
+    it('covers all seven statuses including cancelled', () => {
+        expect(RESERVATION_STATUSES).toEqual(['new', 'in_review', 'replied', 'confirmed', 'declined', 'cancelled', 'waitlisted']);
+    });
+
+    it('returns a token-based badge class and a non-empty label for every status', () => {
+        for (const status of RESERVATION_STATUSES) {
+            expect(statusBadgeClass(status)).toContain('status-');
+            expect(statusLabel(status).length).toBeGreaterThan(0);
+        }
+    });
+});

--- a/resources/js/lib/reservationStatus.ts
+++ b/resources/js/lib/reservationStatus.ts
@@ -1,0 +1,26 @@
+export const RESERVATION_STATUSES = ['new', 'in_review', 'replied', 'confirmed', 'declined', 'cancelled', 'waitlisted'] as const;
+
+export type ReservationStatus = (typeof RESERVATION_STATUSES)[number];
+
+const BADGE: Record<ReservationStatus, string> = {
+    new: 'bg-status-new/15 text-status-new',
+    in_review: 'bg-status-in-review/15 text-status-in-review',
+    replied: 'bg-status-replied/15 text-status-replied',
+    confirmed: 'bg-status-confirmed/15 text-status-confirmed',
+    declined: 'bg-status-declined/15 text-status-declined',
+    cancelled: 'bg-status-cancelled/15 text-status-cancelled',
+    waitlisted: 'bg-status-waitlisted/15 text-status-waitlisted',
+};
+
+const LABEL: Record<ReservationStatus, string> = {
+    new: 'Neu',
+    in_review: 'In Prüfung',
+    replied: 'Beantwortet',
+    confirmed: 'Bestätigt',
+    declined: 'Abgelehnt',
+    cancelled: 'Storniert',
+    waitlisted: 'Warteliste',
+};
+
+export const statusBadgeClass = (status: ReservationStatus): string => BADGE[status];
+export const statusLabel = (status: ReservationStatus): string => LABEL[status];


### PR DESCRIPTION
## Summary
- `OnboardingLayout.vue`: minimal dark-topbar (`bg-topbar`) shell consuming the #407 tokens; used by the acceptance/wizard/pending pages.
- `resources/js/lib/reservationStatus.ts`: single source for status -> token-based badge class + German label (all 7 statuses incl. `cancelled`), so Phase 2 can replace the hardcoded Dashboard map.
- Vitest for both.

## Test plan
- `npm run test` (115 passed incl. 2 new), `npm run build`, `npm run lint:check`, `npm run format:check` clean.

Closes #408.