### PR TITLE
PRD-016 #403: onboarding wizard controller (show + step stores + live transition)

### DIFF
--- a/app/Http/Controllers/Onboarding/OnboardingWizardController.php
+++ b/app/Http/Controllers/Onboarding/OnboardingWizardController.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Onboarding;
+
+use App\Enums\Tonality;
+use App\Enums\UserRole;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Onboarding\InviteStaffRequest;
+use App\Http\Requests\Onboarding\OpeningHoursRequest;
+use App\Http\Requests\Onboarding\RestaurantInfoRequest;
+use App\Http\Requests\Onboarding\TonalityRequest;
+use App\Http\Requests\TableRequest;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\Table;
+use App\Models\User;
+use App\Support\OnboardingProgress;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Server-driven onboarding wizard. The owner edits the freshly provisioned
+ * restaurant step by step; the restaurant flips "live" the first moment the
+ * Pflicht-Kern (master data + opening hours + >=1 table) is complete.
+ */
+final class OnboardingWizardController extends Controller
+{
+    public function show(): Response
+    {
+        $restaurant = $this->ownedRestaurant();
+
+        return Inertia::render('Onboarding/Wizard', [
+            'restaurant' => [
+                'name' => $restaurant->name,
+                'slug' => $restaurant->slug,
+                'timezone' => $restaurant->timezone,
+                'tonality' => $restaurant->tonality->value,
+                'opening_hours' => $restaurant->opening_hours,
+            ],
+            'tables' => $restaurant->tables()
+                ->where('active', true)
+                ->orderBy('sort_order')
+                ->get(['id', 'label', 'seats', 'room_tag']),
+            'tonalities' => array_map(fn (Tonality $t): string => $t->value, Tonality::cases()),
+            'progress' => $this->progressPayload($restaurant),
+        ]);
+    }
+
+    public function updateRestaurant(RestaurantInfoRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+        $restaurant->update($request->validated());
+
+        return $this->backToWizard($restaurant);
+    }
+
+    public function updateHours(OpeningHoursRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+        $restaurant->update(['opening_hours' => $request->validated()['opening_hours']]);
+
+        return $this->backToWizard($restaurant);
+    }
+
+    public function storeTable(TableRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+
+        Table::create([
+            ...$request->validated(),
+            'restaurant_id' => $restaurant->id,
+        ]);
+
+        // Keep capacity in step with the table layout so availability works the
+        // moment the restaurant goes live (the provisioner seeds capacity = 0).
+        $restaurant->update([
+            'capacity' => (int) $restaurant->tables()->where('active', true)->sum('seats'),
+        ]);
+
+        return $this->backToWizard($restaurant);
+    }
+
+    public function updateTonality(TonalityRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+        $restaurant->update(['tonality' => Tonality::from($request->validated()['tonality'])]);
+
+        return $this->backToWizard($restaurant);
+    }
+
+    public function storeStaffInvite(InviteStaffRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+        Gate::authorize('create', Invitation::class);
+
+        Invitation::create([
+            'restaurant_id' => $restaurant->id,
+            'email' => $request->validated()['email'],
+            'role' => UserRole::Staff,
+            'token' => Invitation::hashToken(Invitation::generateToken()),
+            'expires_at' => now()->addDays(7),
+        ]);
+
+        return $this->backToWizard($restaurant);
+    }
+
+    /**
+     * The acting owner's restaurant, or 403 for staff / restaurant-less users.
+     */
+    private function ownedRestaurant(): Restaurant
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $restaurant = $user->restaurant;
+
+        if ($restaurant === null) {
+            abort(403);
+        }
+
+        Gate::authorize('manage', $restaurant); // RestaurantPolicy::manage = owner-only
+
+        return $restaurant;
+    }
+
+    /**
+     * @return array{coreComplete: bool, nextCoreStep: string|null, steps: array<string, bool>}
+     */
+    private function progressPayload(Restaurant $restaurant): array
+    {
+        $progress = OnboardingProgress::for($restaurant);
+
+        $steps = [];
+        foreach ([...OnboardingProgress::CORE_STEPS, ...OnboardingProgress::OPTIONAL_STEPS] as $step) {
+            $steps[$step] = $progress->stepComplete($step);
+        }
+
+        return [
+            'coreComplete' => $progress->isCoreComplete(),
+            'nextCoreStep' => $progress->nextCoreStep(),
+            'steps' => $steps,
+        ];
+    }
+
+    /**
+     * Persist "live" the first time the Pflicht-Kern is complete, then redirect.
+     */
+    private function backToWizard(Restaurant $restaurant): RedirectResponse
+    {
+        $restaurant->refresh();
+
+        if ($restaurant->onboarding_completed_at === null
+            && OnboardingProgress::for($restaurant)->isCoreComplete()) {
+            $restaurant->update(['onboarding_completed_at' => now()]);
+        }
+
+        return to_route('onboarding.wizard');
+    }
+}

--- a/resources/js/pages/Onboarding/Wizard.vue
+++ b/resources/js/pages/Onboarding/Wizard.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+// Minimal placeholder — the full step UI is built in #406.
+defineProps<{
+    restaurant: Record<string, unknown>;
+    tables: unknown[];
+    tonalities: string[];
+    progress: Record<string, unknown>;
+}>();
+</script>
+
+<template>
+    <div>{{ restaurant.name }}</div>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -14,6 +14,12 @@ declare module 'ziggy-js' {
             "required": true
         }
     ],
+    "onboarding.wizard": [],
+    "onboarding.restaurant.update": [],
+    "onboarding.hours.update": [],
+    "onboarding.tables.store": [],
+    "onboarding.tonality.update": [],
+    "onboarding.team.store": [],
     "dashboard": [],
     "analytics.index": [],
     "exports.store": [],

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\DashboardController;
 use App\Http\Controllers\ExportController;
 use App\Http\Controllers\GdprSelfServiceController;
 use App\Http\Controllers\Onboarding\AcceptInvitationController;
+use App\Http\Controllers\Onboarding\OnboardingWizardController;
 use App\Http\Controllers\PublicReservationController;
 use App\Http\Controllers\QuickReservationController;
 use App\Http\Controllers\ReservationMessagesController;
@@ -27,6 +28,16 @@ Route::middleware('guest')->group(function () {
         ->name('onboarding.accept');
     Route::post('onboarding/accept/{token}', [AcceptInvitationController::class, 'store'])
         ->name('onboarding.accept.store');
+});
+
+// Owner onboarding wizard (server-driven, one action per step).
+Route::middleware(['auth', 'verified'])->group(function () {
+    Route::get('onboarding', [OnboardingWizardController::class, 'show'])->name('onboarding.wizard');
+    Route::patch('onboarding/restaurant', [OnboardingWizardController::class, 'updateRestaurant'])->name('onboarding.restaurant.update');
+    Route::patch('onboarding/hours', [OnboardingWizardController::class, 'updateHours'])->name('onboarding.hours.update');
+    Route::post('onboarding/tables', [OnboardingWizardController::class, 'storeTable'])->name('onboarding.tables.store');
+    Route::patch('onboarding/tonality', [OnboardingWizardController::class, 'updateTonality'])->name('onboarding.tonality.update');
+    Route::post('onboarding/team', [OnboardingWizardController::class, 'storeStaffInvite'])->name('onboarding.team.store');
 });
 
 Route::get('dashboard', [DashboardController::class, 'index'])

--- a/tests/Feature/Onboarding/OnboardingWizardTest.php
+++ b/tests/Feature/Onboarding/OnboardingWizardTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\Tonality;
+use App\Enums\UserRole;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+final class OnboardingWizardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array{0: User, 1: Restaurant}
+     */
+    private function owner(): array
+    {
+        $restaurant = Restaurant::factory()->pendingOnboarding()->create(['name' => 'Bella']);
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        return [$owner, $restaurant];
+    }
+
+    public function test_owner_sees_the_wizard_with_progress_and_restaurant_data(): void
+    {
+        [$owner] = $this->owner();
+
+        $this->actingAs($owner)
+            ->get(route('onboarding.wizard'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page
+                ->component('Onboarding/Wizard')
+                ->where('restaurant.name', 'Bella')
+                ->where('progress.nextCoreStep', 'hours')
+                ->where('progress.coreComplete', false)
+                ->has('progress.steps')
+                ->has('tonalities')
+            );
+    }
+
+    public function test_staff_cannot_open_the_wizard(): void
+    {
+        [, $restaurant] = $this->owner();
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($staff)->get(route('onboarding.wizard'))->assertForbidden();
+    }
+
+    public function test_owner_updates_restaurant_info(): void
+    {
+        [$owner, $restaurant] = $this->owner();
+
+        $this->actingAs($owner)
+            ->patch(route('onboarding.restaurant.update'), [
+                'name' => 'Neue Bella',
+                'slug' => 'neue-bella',
+                'timezone' => 'Europe/Vienna',
+            ])
+            ->assertRedirect(route('onboarding.wizard'));
+
+        $restaurant->refresh();
+        $this->assertSame('Neue Bella', $restaurant->name);
+        $this->assertSame('neue-bella', $restaurant->slug);
+        $this->assertSame('Europe/Vienna', $restaurant->timezone);
+    }
+
+    public function test_owner_saves_opening_hours(): void
+    {
+        [$owner, $restaurant] = $this->owner();
+
+        $this->actingAs($owner)
+            ->patch(route('onboarding.hours.update'), [
+                'opening_hours' => ['mon' => [['from' => '18:00', 'to' => '22:00']], 'tue' => []],
+            ])
+            ->assertRedirect(route('onboarding.wizard'));
+
+        $this->assertSame(
+            ['mon' => [['from' => '18:00', 'to' => '22:00']], 'tue' => []],
+            $restaurant->fresh()->opening_hours,
+        );
+    }
+
+    public function test_adding_a_table_recomputes_capacity(): void
+    {
+        [$owner, $restaurant] = $this->owner();
+
+        $this->actingAs($owner)
+            ->post(route('onboarding.tables.store'), ['label' => 'Tisch 1', 'seats' => 4])
+            ->assertRedirect(route('onboarding.wizard'));
+        $this->actingAs($owner)
+            ->post(route('onboarding.tables.store'), ['label' => 'Tisch 2', 'seats' => 2]);
+
+        $restaurant->refresh();
+        $this->assertSame(2, $restaurant->tables()->count());
+        $this->assertSame(6, $restaurant->capacity);
+    }
+
+    public function test_completing_the_core_marks_the_restaurant_live(): void
+    {
+        [$owner, $restaurant] = $this->owner();
+
+        $this->actingAs($owner)->patch(route('onboarding.hours.update'), [
+            'opening_hours' => ['mon' => [['from' => '18:00', 'to' => '22:00']]],
+        ]);
+        $this->assertNull($restaurant->fresh()->onboarding_completed_at);
+
+        $this->actingAs($owner)->post(route('onboarding.tables.store'), ['label' => 'T1', 'seats' => 4]);
+
+        $this->assertNotNull($restaurant->fresh()->onboarding_completed_at);
+    }
+
+    public function test_owner_sets_tonality(): void
+    {
+        [$owner, $restaurant] = $this->owner();
+
+        $this->actingAs($owner)->patch(route('onboarding.tonality.update'), [
+            'tonality' => Tonality::Casual->value,
+        ])->assertRedirect(route('onboarding.wizard'));
+
+        $this->assertSame(Tonality::Casual, $restaurant->fresh()->tonality);
+    }
+
+    public function test_owner_invites_staff_but_staff_cannot(): void
+    {
+        [$owner, $restaurant] = $this->owner();
+
+        $this->actingAs($owner)->post(route('onboarding.team.store'), [
+            'email' => 'server@bella.test',
+        ])->assertRedirect(route('onboarding.wizard'));
+
+        $this->assertDatabaseHas('invitations', [
+            'restaurant_id' => $restaurant->id,
+            'email' => 'server@bella.test',
+            'role' => UserRole::Staff->value,
+        ]);
+
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+        $this->actingAs($staff)->post(route('onboarding.team.store'), [
+            'email' => 'other@bella.test',
+        ])->assertForbidden();
+    }
+}

--- a/tests/Feature/Onboarding/OnboardingWizardTest.php
+++ b/tests/Feature/Onboarding/OnboardingWizardTest.php
@@ -52,6 +52,13 @@ final class OnboardingWizardTest extends TestCase
         $this->actingAs($staff)->get(route('onboarding.wizard'))->assertForbidden();
     }
 
+    public function test_a_user_without_a_restaurant_is_forbidden(): void
+    {
+        $orphan = User::factory()->create(['restaurant_id' => null]);
+
+        $this->actingAs($orphan)->get(route('onboarding.wizard'))->assertForbidden();
+    }
+
     public function test_owner_updates_restaurant_info(): void
     {
         [$owner, $restaurant] = $this->owner();


### PR DESCRIPTION
## Summary
- `GET /onboarding` (`onboarding.wizard`, owner-only via `RestaurantPolicy::manage`) renders `Onboarding/Wizard` with restaurant data, active tables, tonality options and derived `OnboardingProgress`.
- Per-step actions: `restaurant.update`, `hours.update`, `tables.store` (reuses `TableRequest`, recomputes `capacity` = sum of active seats), `tonality.update`, `team.store` (owner-only via `InvitationPolicy`).
- `backToWizard` sets `onboarding_completed_at` the first time the Pflicht-Kern is complete.
- Minimal `Wizard.vue` stub; full step UI in #406. Ziggy types regenerated.

## Test plan
- `OnboardingWizardTest` (8): owner sees wizard + progress; staff 403; each store action; capacity recompute; live transition; staff-invite owner-only.
- Full suite 1052 passed; pint, build, lint, format, ziggy all clean.

Closes #403.