### PR TITLE
PRD-016 #404: EnsureOnboardingComplete gating middleware + pending page

### DIFF
--- a/app/Http/Middleware/EnsureOnboardingComplete.php
+++ b/app/Http/Middleware/EnsureOnboardingComplete.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Enums\UserRole;
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Routes authenticated members of a not-yet-live restaurant away from the
+ * normal app: owners to the setup wizard, staff to a read-only placeholder.
+ * Guests and members of live restaurants pass straight through.
+ */
+final class EnsureOnboardingComplete
+{
+    /**
+     * Route names that must stay reachable while onboarding is incomplete.
+     *
+     * @var list<string>
+     */
+    private const EXEMPT = [
+        'onboarding.wizard',
+        'onboarding.restaurant.update',
+        'onboarding.hours.update',
+        'onboarding.tables.store',
+        'onboarding.tonality.update',
+        'onboarding.team.store',
+        'onboarding.pending',
+        'logout',
+    ];
+
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = Auth::user();
+
+        if ($user === null || $user->restaurant_id === null) {
+            return $next($request);
+        }
+
+        $restaurant = $user->restaurant;
+
+        if ($restaurant === null || $restaurant->isLive()) {
+            return $next($request);
+        }
+
+        if ($request->routeIs(self::EXEMPT)) {
+            return $next($request);
+        }
+
+        $target = $user->role === UserRole::Owner
+            ? route('onboarding.wizard')
+            : route('onboarding.pending');
+
+        return redirect()->to($target);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\EnsureOnboardingComplete;
 use App\Http\Middleware\HandleInertiaRequests;
 use App\Http\Middleware\WarnOnAppUrlMismatch;
 use Illuminate\Foundation\Application;
@@ -20,6 +21,7 @@ return Application::configure(basePath: dirname(__DIR__))
             HandleInertiaRequests::class,
             AddLinkHeadersForPreloadedAssets::class,
             WarnOnAppUrlMismatch::class,
+            EnsureOnboardingComplete::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {

--- a/database/factories/RestaurantFactory.php
+++ b/database/factories/RestaurantFactory.php
@@ -41,6 +41,9 @@ class RestaurantFactory extends Factory
             'imap_host' => null,
             'imap_username' => null,
             'imap_password' => null,
+            // Test restaurants are operational by default; onboarding tests opt
+            // into the pre-live state explicitly via pendingOnboarding().
+            'onboarding_completed_at' => now(),
         ];
     }
 

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -38,6 +38,7 @@ class DatabaseSeeder extends Seeder
                     'sun' => [['from' => '11:30', 'to' => '15:00']],
                 ],
                 'tonality' => Tonality::Casual,
+                'onboarding_completed_at' => now(),
             ]
         );
 

--- a/resources/js/pages/Onboarding/Pending.vue
+++ b/resources/js/pages/Onboarding/Pending.vue
@@ -1,0 +1,13 @@
+<script setup lang="ts">
+import OnboardingLayout from '@/layouts/OnboardingLayout.vue';
+import { Head } from '@inertiajs/vue3';
+</script>
+
+<template>
+    <OnboardingLayout title="Fast bereit">
+        <Head title="Wird eingerichtet" />
+        <p class="text-muted-foreground">
+            Dieses Restaurant wird gerade von der Inhaberin oder dem Inhaber eingerichtet. Sobald es bereit ist, können Sie hier loslegen.
+        </p>
+    </OnboardingLayout>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -20,6 +20,7 @@ declare module 'ziggy-js' {
     "onboarding.tables.store": [],
     "onboarding.tonality.update": [],
     "onboarding.team.store": [],
+    "onboarding.pending": [],
     "dashboard": [],
     "analytics.index": [],
     "exports.store": [],

--- a/routes/web.php
+++ b/routes/web.php
@@ -40,6 +40,11 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('onboarding/team', [OnboardingWizardController::class, 'storeStaffInvite'])->name('onboarding.team.store');
 });
 
+// Placeholder for staff of a restaurant whose owner has not finished onboarding.
+Route::get('onboarding/pending', fn () => Inertia::render('Onboarding/Pending'))
+    ->middleware('auth')
+    ->name('onboarding.pending');
+
 Route::get('dashboard', [DashboardController::class, 'index'])
     ->middleware(['auth', 'verified'])
     ->name('dashboard');

--- a/tests/Feature/Onboarding/OnboardingGatingTest.php
+++ b/tests/Feature/Onboarding/OnboardingGatingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class OnboardingGatingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_without_live_restaurant_is_redirected_to_the_wizard(): void
+    {
+        $restaurant = Restaurant::factory()->pendingOnboarding()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->get(route('dashboard'))->assertRedirect(route('onboarding.wizard'));
+    }
+
+    public function test_owner_on_a_wizard_route_is_not_redirected(): void
+    {
+        $restaurant = Restaurant::factory()->pendingOnboarding()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->get(route('onboarding.wizard'))->assertOk();
+    }
+
+    public function test_staff_of_a_pending_restaurant_sees_the_pending_placeholder(): void
+    {
+        $restaurant = Restaurant::factory()->pendingOnboarding()->create();
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($staff)->get(route('dashboard'))->assertRedirect(route('onboarding.pending'));
+    }
+
+    public function test_users_of_a_live_restaurant_pass_through(): void
+    {
+        $restaurant = Restaurant::factory()->onboarded()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->get(route('dashboard'))->assertOk();
+    }
+
+    public function test_a_user_without_a_restaurant_passes_through(): void
+    {
+        $orphan = User::factory()->create(['restaurant_id' => null]);
+
+        // No restaurant → gate is a no-op (other guards handle empty dashboards).
+        $this->actingAs($orphan)->get(route('dashboard'))->assertOk();
+    }
+
+    public function test_guests_are_unaffected(): void
+    {
+        $restaurant = Restaurant::factory()->create(['slug' => 'demo']);
+
+        $this->get(route('public.reservations.create', $restaurant))->assertOk();
+    }
+}

--- a/tests/Feature/Onboarding/OnboardingSchemaTest.php
+++ b/tests/Feature/Onboarding/OnboardingSchemaTest.php
@@ -21,12 +21,13 @@ final class OnboardingSchemaTest extends TestCase
         $this->assertNull($user->fresh()->password);
     }
 
-    public function test_restaurants_onboarding_completed_at_defaults_to_null(): void
+    public function test_restaurants_onboarding_completed_at_is_nullable(): void
     {
-        $restaurant = Restaurant::factory()->create();
+        $this->assertTrue(Schema::hasColumn('restaurants', 'onboarding_completed_at'));
+
+        $restaurant = Restaurant::factory()->pendingOnboarding()->create();
 
         $this->assertNull($restaurant->fresh()->onboarding_completed_at);
-        $this->assertTrue(Schema::hasColumn('restaurants', 'onboarding_completed_at'));
     }
 
     public function test_invitations_table_has_the_expected_columns(): void


### PR DESCRIPTION
## Summary
- `EnsureOnboardingComplete` appended to the web group: a non-live restaurant's **owner** is redirected to `onboarding.wizard`, **staff** to a read-only `onboarding.pending` placeholder; guests and members of live restaurants pass straight through. Wizard routes + `logout` are exempt.
- `RestaurantFactory` now defaults to **onboarded** (a test restaurant is normally operational); onboarding tests opt into `pendingOnboarding()`. This keeps the whole existing suite green with the gate in place.
- Demo seeder marks its restaurant live; the schema test now asserts nullability via `pendingOnboarding()`.

## Why
Without gating, a freshly provisioned owner lands on an empty/broken dashboard. The gate routes them into the wizard until the restaurant is live.

## Test plan
- `OnboardingGatingTest`: owner→wizard, staff→pending, live→through, restaurant-less→through, guest unaffected, wizard route not self-redirecting.
- Full suite 1059 passed; pint, build, lint, format clean.

Closes #404.