### PR TITLE
PRD-016 #405: dashboard reminders for skipped optional steps

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -12,6 +12,7 @@ use App\Http\Resources\ReservationRequestDetailResource;
 use App\Http\Resources\ReservationRequestResource;
 use App\Models\ReservationRequest;
 use App\Services\Waitlist\WaitlistBanner;
+use App\Support\OnboardingProgress;
 use App\Support\OpenAiKeyHealth;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
@@ -25,7 +26,8 @@ final class DashboardController extends Controller
     {
         $validated = $request->validated();
         $selectedId = isset($validated['selected']) ? (int) $validated['selected'] : null;
-        $restaurantId = $request->user()?->restaurant_id;
+        $restaurant = $request->user()?->restaurant;
+        $restaurantId = $restaurant?->id;
 
         $filterQuery = Arr::except($request->query(), ['selected']);
         $filters = $filterQuery === []
@@ -71,6 +73,12 @@ final class DashboardController extends Controller
             // default — so the operator always sees that auto-send is
             // armed and where to flip the killswitch.
             'sendMode' => $request->user()?->restaurant?->send_mode->value,
+            // PRD-016: optional onboarding steps the owner skipped (e.g. team),
+            // surfaced as dismissible reminder cards. Empty when none / no
+            // restaurant. Refreshed by the existing dashboard poll.
+            'onboardingReminders' => $restaurant !== null
+                ? OnboardingProgress::for($restaurant)->pendingOptionalSteps()
+                : [],
         ]);
     }
 

--- a/tests/Feature/Onboarding/DashboardOnboardingRemindersTest.php
+++ b/tests/Feature/Onboarding/DashboardOnboardingRemindersTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Onboarding;
+
+use App\Enums\UserRole;
+use App\Models\Invitation;
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+final class DashboardOnboardingRemindersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dashboard_exposes_pending_optional_steps(): void
+    {
+        // Live restaurant (passes the gate) but no staff invited yet.
+        $restaurant = Restaurant::factory()->onboarded()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)
+            ->get(route('dashboard'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $page) => $page->where('onboardingReminders', ['team']));
+    }
+
+    public function test_no_reminders_once_a_staff_invitation_exists(): void
+    {
+        $restaurant = Restaurant::factory()->onboarded()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+        Invitation::factory()->for($restaurant)->create(['role' => UserRole::Staff]);
+
+        $this->actingAs($owner)
+            ->get(route('dashboard'))
+            ->assertInertia(fn (AssertableInertia $page) => $page->where('onboardingReminders', []));
+    }
+}


### PR DESCRIPTION
## Summary
`DashboardController::index` exposes `onboardingReminders` = `OnboardingProgress::pendingOptionalSteps()` for the user's restaurant (empty when none or no restaurant), refreshed by the existing dashboard poll. This is the data surface; the dismissible reminder cards are part of the Phase-2 dashboard restyle.

## Test plan
- `DashboardOnboardingRemindersTest`: live restaurant without staff exposes `['team']`; empty once a staff invitation exists.
- Full suite 1061 passed; pint clean.

Closes #405.