### PR TITLE
PRD-016 #399: invitation acceptance + error Vue pages

### DIFF
--- a/resources/js/pages/Onboarding/AcceptInvitation.vue
+++ b/resources/js/pages/Onboarding/AcceptInvitation.vue
@@ -1,9 +1,54 @@
 <script setup lang="ts">
-// Minimal placeholder — the full acceptance form (OnboardingLayout, useForm)
-// is built in #399 once OnboardingLayout (#408) exists.
-defineProps<{ email: string; token: string; restaurantName: string }>();
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import OnboardingLayout from '@/layouts/OnboardingLayout.vue';
+import { Head, useForm } from '@inertiajs/vue3';
+
+const props = defineProps<{ email: string; token: string; restaurantName: string }>();
+
+const form = useForm({
+    name: '',
+    password: '',
+    password_confirmation: '',
+});
+
+const submit = () => {
+    form.post(route('onboarding.accept.store', { token: props.token }), {
+        onFinish: () => form.reset('password', 'password_confirmation'),
+    });
+};
 </script>
 
 <template>
-    <div>{{ restaurantName }} — {{ email }}</div>
+    <OnboardingLayout :title="`Willkommen bei ${restaurantName}`">
+        <Head title="Einladung annehmen" />
+
+        <form class="grid gap-6" @submit.prevent="submit">
+            <div class="grid gap-2">
+                <Label for="email">E-Mail</Label>
+                <Input id="email" :model-value="email" type="email" disabled />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="name">Ihr Name</Label>
+                <Input id="name" v-model="form.name" required autofocus autocomplete="name" />
+                <InputError :message="form.errors.name" />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="password">Passwort</Label>
+                <Input id="password" v-model="form.password" type="password" required autocomplete="new-password" />
+                <InputError :message="form.errors.password" />
+            </div>
+
+            <div class="grid gap-2">
+                <Label for="password_confirmation">Passwort bestätigen</Label>
+                <Input id="password_confirmation" v-model="form.password_confirmation" type="password" required autocomplete="new-password" />
+            </div>
+
+            <Button type="submit" :disabled="form.processing">Konto aktivieren</Button>
+        </form>
+    </OnboardingLayout>
 </template>

--- a/resources/js/pages/Onboarding/InvitationError.vue
+++ b/resources/js/pages/Onboarding/InvitationError.vue
@@ -1,8 +1,22 @@
 <script setup lang="ts">
-// Minimal placeholder — the styled error page is built in #399.
+import OnboardingLayout from '@/layouts/OnboardingLayout.vue';
+import { Head, Link } from '@inertiajs/vue3';
+
 defineProps<{ reason: string }>();
+
+const MESSAGE: Record<string, string> = {
+    invalid: 'Dieser Einladungs-Link ist ungültig.',
+    expired: 'Dieser Einladungs-Link ist abgelaufen. Bitte fordern Sie einen neuen an.',
+    accepted: 'Diese Einladung wurde bereits angenommen. Bitte melden Sie sich an.',
+};
 </script>
 
 <template>
-    <div>{{ reason }}</div>
+    <OnboardingLayout title="Einladung">
+        <Head title="Einladung" />
+
+        <p class="text-muted-foreground">{{ MESSAGE[reason] ?? MESSAGE.invalid }}</p>
+
+        <Link :href="route('login')" class="mt-6 inline-block text-sm font-medium underline">Zur Anmeldung</Link>
+    </OnboardingLayout>
 </template>


### PR DESCRIPTION
## Summary
Replace the minimal #398 stubs with the real pages on `OnboardingLayout` (dark topbar, #408):
- `AcceptInvitation.vue`: disabled email, name + password + confirmation via `useForm`, posts to `onboarding.accept.store`, inline `InputError`, resets password on finish.
- `InvitationError.vue`: maps `reason` (invalid/expired/accepted) to a German message + link to login.

## Test plan
- Existing `AcceptInvitationTest` (7) still green (asserts both component names + props render).
- `npm run build`, `lint:check`, `format:check` clean.

Closes #399.