### PR TITLE
PRD-016 #406: onboarding wizard UI + step components + Vitest

### DIFF
--- a/resources/js/pages/Onboarding/Wizard.vue
+++ b/resources/js/pages/Onboarding/Wizard.vue
@@ -1,13 +1,71 @@
 <script setup lang="ts">
-// Minimal placeholder — the full step UI is built in #406.
-defineProps<{
-    restaurant: Record<string, unknown>;
-    tables: unknown[];
+import OnboardingLayout from '@/layouts/OnboardingLayout.vue';
+import type { OnboardingProgress, OnboardingStep } from '@/types';
+import { Head, router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+import StepOpeningHours from './steps/StepOpeningHours.vue';
+import StepRestaurantInfo from './steps/StepRestaurantInfo.vue';
+import StepTables from './steps/StepTables.vue';
+import StepTeam from './steps/StepTeam.vue';
+import StepTonality from './steps/StepTonality.vue';
+
+interface RestaurantInfo {
+    name: string;
+    slug: string;
+    timezone: string;
+    tonality: string;
+    opening_hours: Record<string, { from: string; to: string }[]>;
+}
+
+const props = defineProps<{
+    restaurant: RestaurantInfo;
+    tables: { id: number; label: string; seats: number; room_tag: string | null }[];
     tonalities: string[];
-    progress: Record<string, unknown>;
+    progress: OnboardingProgress;
 }>();
+
+const ORDER: { key: OnboardingStep; label: string }[] = [
+    { key: 'restaurant', label: 'Stammdaten' },
+    { key: 'hours', label: 'Öffnungszeiten' },
+    { key: 'tables', label: 'Tische' },
+    { key: 'tonality', label: 'Tonalität' },
+    { key: 'team', label: 'Team' },
+];
+
+// Start at the first incomplete core step, otherwise the first optional step.
+const active = ref<OnboardingStep>(props.progress.nextCoreStep ?? 'tonality');
+
+const goTo = (step: OnboardingStep) => (active.value = step);
+
+// Re-fetch derived progress + restaurant/tables after each step save.
+const onSaved = () => router.reload({ only: ['progress', 'restaurant', 'tables'] });
 </script>
 
 <template>
-    <div>{{ restaurant.name }}</div>
+    <OnboardingLayout title="Restaurant einrichten">
+        <Head title="Einrichtung" />
+
+        <nav class="mb-6 flex flex-wrap gap-2">
+            <button
+                v-for="step in ORDER"
+                :key="step.key"
+                type="button"
+                class="rounded-md px-3 py-1 text-sm"
+                :class="active === step.key ? 'bg-primary text-primary-foreground' : 'bg-secondary text-secondary-foreground'"
+                @click="goTo(step.key)"
+            >
+                {{ step.label }}<span v-if="progress.steps[step.key]"> ✓</span>
+            </button>
+        </nav>
+
+        <p v-if="progress.coreComplete" class="mb-4 text-sm font-medium text-status-confirmed">
+            Pflichtangaben vollständig — Ihr Restaurant ist live.
+        </p>
+
+        <StepRestaurantInfo v-if="active === 'restaurant'" :restaurant="restaurant" @saved="onSaved" />
+        <StepOpeningHours v-else-if="active === 'hours'" :opening-hours="restaurant.opening_hours" @saved="onSaved" />
+        <StepTables v-else-if="active === 'tables'" :tables="tables" @saved="onSaved" />
+        <StepTonality v-else-if="active === 'tonality'" :tonality="restaurant.tonality" :tonalities="tonalities" @saved="onSaved" />
+        <StepTeam v-else @saved="onSaved" />
+    </OnboardingLayout>
 </template>

--- a/resources/js/pages/Onboarding/steps/StepOpeningHours.test.ts
+++ b/resources/js/pages/Onboarding/steps/StepOpeningHours.test.ts
@@ -1,0 +1,56 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub Inertia's useForm so the component mounts in isolation.
+vi.mock('@inertiajs/vue3', () => ({
+    useForm: (initial: Record<string, unknown>) => ({
+        ...initial,
+        errors: {},
+        processing: false,
+        patch: vi.fn(),
+    }),
+}));
+
+// Ziggy route() global.
+(globalThis as unknown as { route: () => string }).route = () => '/onboarding/hours';
+
+import StepOpeningHours from './StepOpeningHours.vue';
+
+const stubs = {
+    Button: { template: '<button @click="$emit(\'click\')"><slot /></button>' },
+    Input: { props: ['modelValue'], template: '<input :value="modelValue" />' },
+    InputError: { props: ['message'], template: '<span>{{ message }}</span>' },
+};
+
+describe('StepOpeningHours', () => {
+    it('renders a time row for a day with a block and Ruhetag for empty days', () => {
+        const wrapper = mount(StepOpeningHours, {
+            props: { openingHours: { mon: [{ from: '18:00', to: '22:00' }] } },
+            global: { stubs },
+        });
+
+        expect(wrapper.find('[data-testid="mon-from-0"]').exists()).toBe(true);
+        expect(wrapper.text()).toContain('Ruhetag'); // tue–sun default to empty
+    });
+
+    it('adds and removes a block via the exposed helpers', () => {
+        const wrapper = mount(StepOpeningHours, {
+            props: { openingHours: {} },
+            global: { stubs },
+        });
+
+        const vm = wrapper.vm as unknown as {
+            addBlock: (d: string) => void;
+            removeBlock: (d: string, i: number) => void;
+            form: { opening_hours: Record<string, unknown[]> };
+        };
+
+        expect(vm.form.opening_hours.fri).toEqual([]);
+
+        vm.addBlock('fri');
+        expect(vm.form.opening_hours.fri).toEqual([{ from: '18:00', to: '22:00' }]);
+
+        vm.removeBlock('fri', 0);
+        expect(vm.form.opening_hours.fri).toEqual([]);
+    });
+});

--- a/resources/js/pages/Onboarding/steps/StepOpeningHours.vue
+++ b/resources/js/pages/Onboarding/steps/StepOpeningHours.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useForm } from '@inertiajs/vue3';
+
+type Block = { from: string; to: string };
+type Schedule = Record<string, Block[]>;
+
+const props = defineProps<{ openingHours: Schedule }>();
+const emit = defineEmits<{ saved: [] }>();
+
+const DAYS: { key: string; label: string }[] = [
+    { key: 'mon', label: 'Montag' },
+    { key: 'tue', label: 'Dienstag' },
+    { key: 'wed', label: 'Mittwoch' },
+    { key: 'thu', label: 'Donnerstag' },
+    { key: 'fri', label: 'Freitag' },
+    { key: 'sat', label: 'Samstag' },
+    { key: 'sun', label: 'Sonntag' },
+];
+
+const form = useForm<{ opening_hours: Schedule }>({
+    opening_hours: DAYS.reduce((acc, day) => {
+        acc[day.key] = props.openingHours[day.key] ?? [];
+        return acc;
+    }, {} as Schedule),
+});
+
+const addBlock = (day: string) => form.opening_hours[day].push({ from: '18:00', to: '22:00' });
+const removeBlock = (day: string, index: number) => form.opening_hours[day].splice(index, 1);
+
+const submit = () =>
+    form.patch(route('onboarding.hours.update'), {
+        preserveScroll: true,
+        onSuccess: () => emit('saved'),
+    });
+
+defineExpose({ form, addBlock, removeBlock });
+</script>
+
+<template>
+    <form class="grid gap-4" @submit.prevent="submit">
+        <div v-for="day in DAYS" :key="day.key" class="grid gap-2 border-b border-border pb-3">
+            <div class="flex items-center justify-between">
+                <span class="font-medium">{{ day.label }}</span>
+                <Button type="button" variant="ghost" size="sm" @click="addBlock(day.key)">+ Zeit</Button>
+            </div>
+            <div v-if="form.opening_hours[day.key].length === 0" class="text-sm text-muted-foreground">Ruhetag</div>
+            <div v-for="(block, index) in form.opening_hours[day.key]" :key="index" class="flex items-center gap-2">
+                <Input v-model="block.from" type="time" :data-testid="`${day.key}-from-${index}`" />
+                <span>–</span>
+                <Input v-model="block.to" type="time" :data-testid="`${day.key}-to-${index}`" />
+                <Button type="button" variant="ghost" size="sm" @click="removeBlock(day.key, index)">Entfernen</Button>
+            </div>
+        </div>
+        <InputError :message="form.errors.opening_hours" />
+        <Button type="submit" :disabled="form.processing">Öffnungszeiten speichern</Button>
+    </form>
+</template>

--- a/resources/js/pages/Onboarding/steps/StepRestaurantInfo.vue
+++ b/resources/js/pages/Onboarding/steps/StepRestaurantInfo.vue
@@ -1,0 +1,43 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useForm } from '@inertiajs/vue3';
+
+const props = defineProps<{ restaurant: { name: string; slug: string; timezone: string } }>();
+const emit = defineEmits<{ saved: [] }>();
+
+const form = useForm({
+    name: props.restaurant.name,
+    slug: props.restaurant.slug,
+    timezone: props.restaurant.timezone,
+});
+
+const submit = () =>
+    form.patch(route('onboarding.restaurant.update'), {
+        preserveScroll: true,
+        onSuccess: () => emit('saved'),
+    });
+</script>
+
+<template>
+    <form class="grid gap-4" @submit.prevent="submit">
+        <div class="grid gap-2">
+            <Label for="name">Name des Restaurants</Label>
+            <Input id="name" v-model="form.name" required autocomplete="organization" />
+            <InputError :message="form.errors.name" />
+        </div>
+        <div class="grid gap-2">
+            <Label for="slug">Öffentliche URL (Slug)</Label>
+            <Input id="slug" v-model="form.slug" required />
+            <InputError :message="form.errors.slug" />
+        </div>
+        <div class="grid gap-2">
+            <Label for="timezone">Zeitzone</Label>
+            <Input id="timezone" v-model="form.timezone" required />
+            <InputError :message="form.errors.timezone" />
+        </div>
+        <Button type="submit" :disabled="form.processing">Stammdaten speichern</Button>
+    </form>
+</template>

--- a/resources/js/pages/Onboarding/steps/StepTables.vue
+++ b/resources/js/pages/Onboarding/steps/StepTables.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { useForm } from '@inertiajs/vue3';
+
+defineProps<{ tables: { id: number; label: string; seats: number; room_tag: string | null }[] }>();
+const emit = defineEmits<{ saved: [] }>();
+
+const form = useForm({
+    label: '',
+    seats: 2,
+});
+
+const submit = () =>
+    form.post(route('onboarding.tables.store'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            form.reset();
+            emit('saved');
+        },
+    });
+</script>
+
+<template>
+    <div class="grid gap-6">
+        <ul v-if="tables.length > 0" class="grid gap-2">
+            <li v-for="table in tables" :key="table.id" class="flex items-center justify-between rounded-md border border-border px-3 py-2 text-sm">
+                <span class="font-medium">{{ table.label }}</span>
+                <span class="text-muted-foreground">{{ table.seats }} Plätze</span>
+            </li>
+        </ul>
+        <p v-else class="text-sm text-muted-foreground">Noch keine Tische. Legen Sie mindestens einen an.</p>
+
+        <form class="flex items-end gap-2" @submit.prevent="submit">
+            <div class="grid flex-1 gap-2">
+                <Label for="label">Bezeichnung</Label>
+                <Input id="label" v-model="form.label" required placeholder="z. B. Tisch 1" />
+                <InputError :message="form.errors.label" />
+            </div>
+            <div class="grid w-28 gap-2">
+                <Label for="seats">Plätze</Label>
+                <Input id="seats" v-model="form.seats" type="number" min="1" max="20" required />
+                <InputError :message="form.errors.seats" />
+            </div>
+            <Button type="submit" :disabled="form.processing">Hinzufügen</Button>
+        </form>
+    </div>
+</template>

--- a/resources/js/pages/Onboarding/steps/StepTeam.vue
+++ b/resources/js/pages/Onboarding/steps/StepTeam.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Link, useForm } from '@inertiajs/vue3';
+
+const emit = defineEmits<{ saved: [] }>();
+
+const form = useForm({ email: '' });
+
+const submit = () =>
+    form.post(route('onboarding.team.store'), {
+        preserveScroll: true,
+        onSuccess: () => {
+            form.reset();
+            emit('saved');
+        },
+    });
+</script>
+
+<template>
+    <form class="grid gap-4" @submit.prevent="submit">
+        <p class="text-sm text-muted-foreground">Laden Sie Mitarbeitende ein (optional). Sie erhalten einen eigenen Einladungs-Link.</p>
+        <div class="grid gap-2">
+            <Label for="email">E-Mail der Mitarbeiterin / des Mitarbeiters</Label>
+            <Input id="email" v-model="form.email" type="email" required autocomplete="off" />
+            <InputError :message="form.errors.email" />
+        </div>
+        <div class="flex items-center gap-4">
+            <Button type="submit" :disabled="form.processing">Einladen</Button>
+            <Link :href="route('onboarding.wizard')" class="text-sm text-muted-foreground underline">Überspringen</Link>
+        </div>
+    </form>
+</template>

--- a/resources/js/pages/Onboarding/steps/StepTonality.vue
+++ b/resources/js/pages/Onboarding/steps/StepTonality.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { Button } from '@/components/ui/button';
+import { Head, Link, useForm } from '@inertiajs/vue3';
+
+const props = defineProps<{ tonality: string; tonalities: string[] }>();
+const emit = defineEmits<{ saved: [] }>();
+
+const LABEL: Record<string, string> = {
+    formal: 'Förmlich',
+    casual: 'Locker',
+    family: 'Familiär',
+};
+
+const form = useForm({ tonality: props.tonality });
+
+const submit = () =>
+    form.patch(route('onboarding.tonality.update'), {
+        preserveScroll: true,
+        onSuccess: () => emit('saved'),
+    });
+</script>
+
+<template>
+    <form class="grid gap-4" @submit.prevent="submit">
+        <Head title="Tonalität" />
+        <p class="text-sm text-muted-foreground">Wie sollen die KI-Antworten klingen? (optional)</p>
+        <label v-for="option in tonalities" :key="option" class="flex items-center gap-2">
+            <input v-model="form.tonality" type="radio" :value="option" :data-testid="`tonality-${option}`" />
+            <span>{{ LABEL[option] ?? option }}</span>
+        </label>
+        <div class="flex items-center gap-4">
+            <Button type="submit" :disabled="form.processing">Speichern</Button>
+            <Link :href="route('onboarding.wizard')" class="text-sm text-muted-foreground underline">Überspringen</Link>
+        </div>
+    </form>
+</template>

--- a/resources/js/types/index.ts
+++ b/resources/js/types/index.ts
@@ -35,6 +35,15 @@ export interface Restaurant {
     name: string;
     timezone: string;
     tonality: 'formal' | 'casual' | 'family';
+    onboarding_completed_at?: string | null;
+}
+
+export type OnboardingStep = 'restaurant' | 'hours' | 'tables' | 'tonality' | 'team';
+
+export interface OnboardingProgress {
+    coreComplete: boolean;
+    nextCoreStep: 'restaurant' | 'hours' | 'tables' | null;
+    steps: Record<OnboardingStep, boolean>;
 }
 
 export type UserRole = 'owner' | 'staff';


### PR DESCRIPTION
## Summary
- Full `Wizard.vue`: step rail with completion ticks, a 'live' banner once the core is complete, starts at the first incomplete core step, reloads `progress`/`restaurant`/`tables` after each save.
- Five step components on `OnboardingLayout`: `StepRestaurantInfo`, `StepOpeningHours` (add/remove blocks per day), `StepTables` (list + add), `StepTonality` (radio + skip), `StepTeam` (invite + skip). Each uses `useForm` posting to its `onboarding.*` route with inline `InputError`.
- Types: `OnboardingProgress`, `OnboardingStep`, `Restaurant.onboarding_completed_at`.
- Vitest for the opening-hours step (add/remove via exposed helpers).

## Test plan
- `npm run test` (117 passed incl. new step test), `npm run build`, `lint:check`, `format:check` clean.
- Backend `OnboardingWizardTest` still pins the page component + props.

Closes #406.