### PR TITLE
docs: rename PRD-016 Phase 1c to Phase 1b

### DIFF
--- a/docs/PRD-016-tenant-onboarding-and-ux.md
+++ b/docs/PRD-016-tenant-onboarding-and-ux.md
@@ -43,9 +43,9 @@ Zweitens: Die Oberfläche ist die funktionale V1-Foundation-UI ohne Gestaltungs-
 - Zentrale Design-Tokens als CSS-Variablen im bestehenden `@layer base`-Muster (Tailwind **v3.4**, shadcn/Reka-konform — siehe `resources/css/app.css`; **kein** v4-`@theme`): Palette (dunkle Topbar, Status-Farben), Spacing, Radius, Typo-Scale.
 - Anwenden auf: Onboarding-Wizard (Phase 1), Dashboard + öffentliche Reservierungs-/Bestätigungsseiten (Phase 2).
 
-**Phase 1c (eigene Welle): per-Restaurant-Konfiguration**
+**Phase 1b (eigene Welle): per-Restaurant-Konfiguration**
 - OpenAI-Key BYOK pro Restaurant (`restaurants.openai_api_key`, Encrypted Cast); Generator wählt den Key pro Restaurant, Fallback auf den globalen `.env`-Key.
-- E-Mail pro Restaurant: Die IMAP-Empfangs-Spalten (`imap_host/username/password`, Passwort `encrypted`) **existieren bereits** pro Restaurant — Phase 1c schaltet sie im Wizard frei und ergänzt den bislang fehlenden **SMTP-Versand** (neue Encrypted-Spalten). Bis dahin bleibt der Versand global (`.env`); die Wizard-Schritte zeigen „später/global einrichten".
+- E-Mail pro Restaurant: Die IMAP-Empfangs-Spalten (`imap_host/username/password`, Passwort `encrypted`) **existieren bereits** pro Restaurant — Phase 1b schaltet sie im Wizard frei und ergänzt den bislang fehlenden **SMTP-Versand** (neue Encrypted-Spalten). Bis dahin bleibt der Versand global (`.env`); die Wizard-Schritte zeigen „später/global einrichten".
 
 ### Out of Scope (Vision – dokumentiert, nicht gebaut)
 
@@ -67,9 +67,9 @@ Zweitens: Die Oberfläche ist die funktionale V1-Foundation-UI ohne Gestaltungs-
 | `invitations` | Tabelle | `id`, `restaurant_id` (fk), `email`, `role` (enum), `token` (gehasht), `expires_at`, `accepted_at` (nullable), `created_at` |
 | `restaurants.onboarding_completed_at` | datetime, nullable | „live", wenn gesetzt |
 | `users.password` | nullable | bis Einladung angenommen; Annahme setzt das Passwort |
-| `restaurants.openai_api_key` | string, encrypted, nullable | Phase 1c (BYOK) |
+| `restaurants.openai_api_key` | string, encrypted, nullable | Phase 1b (BYOK) |
 | `restaurants.imap_*` | **bereits vorhanden** | `imap_host/username/password` (Passwort `encrypted`) existieren schon pro Restaurant — im Wizard nur freischalten, nicht neu bauen |
-| `restaurants` SMTP-Versand-Config | encrypted, nullable | Phase 1c — neue Spalten oder `restaurant_mail_settings` (nur IMAP-Empfang ist da, Versand fehlt) |
+| `restaurants` SMTP-Versand-Config | encrypted, nullable | Phase 1b — neue Spalten oder `restaurant_mail_settings` (nur IMAP-Empfang ist da, Versand fehlt) |
 
 Jede Migration `up()` **und** `down()`; bestehende Migrationen werden nicht rückwirkend geändert.
 
@@ -103,7 +103,7 @@ Middleware (z. B. `EnsureOnboardingComplete`) auf den authentifizierten App-Rout
 ### Phasen
 
 - **Phase 1:** Tokens + Onboarding (Command, Invitation, Wizard Pflicht-Kern + Tonalität + Team) im C-Look.
-- **Phase 1c:** per-Restaurant BYOK + SMTP-Versand. **Eigenes Epic mit eigenen Akzeptanzkriterien** — pilot-optional, blockiert Phase 1/2 nicht (global bleibt nutzbar).
+- **Phase 1b:** per-Restaurant BYOK + SMTP-Versand. **Eigenes Epic mit eigenen Akzeptanzkriterien** — pilot-optional, blockiert Phase 1/2 nicht (global bleibt nutzbar).
 - **Phase 2:** Restyle Dashboard + öffentliche Reservierungs-/Bestätigungsseiten.
 
 ---
@@ -118,7 +118,7 @@ Middleware (z. B. `EnsureOnboardingComplete`) auf den authentifizierten App-Rout
 - [ ] Team-Einladung erzeugt Staff-Invitation über denselben Flow; Cross-Tenant unmöglich.
 - [ ] Migrationen vor/zurück lauffähig; keine bestehende Migration geändert.
 - [ ] Design-Tokens zentral (CSS-Variablen im `@layer base`-Muster, kein v4-`@theme`), alle 7 Status-Farben inkl. `cancelled`; Wizard + Dashboard + öffentliche Reservierungs-/Bestätigungsseiten in Richtung C; keine funktionale Regression.
-- [ ] Phase 1c: OpenAI-Key pro Restaurant wird vom Generator verwendet (Fallback global); SMTP-Versand-Config encrypted, nie im Klartext geloggt/ausgegeben.
+- [ ] Phase 1b: OpenAI-Key pro Restaurant wird vom Generator verwendet (Fallback global); SMTP-Versand-Config encrypted, nie im Klartext geloggt/ausgegeben.
 - [ ] `./vendor/bin/pint --test`, `npm run lint`, `npm run format:check`, `npm run build` ohne Findings; Ziggy bei neuen Routes regeneriert.
 
 ---
@@ -129,7 +129,7 @@ Middleware (z. B. `EnsureOnboardingComplete`) auf den authentifizierten App-Rout
 - **Invitation:** Annahme gültig/abgelaufen/doppelt; Token gehasht; Cross-Tenant abgewiesen.
 - **Wizard:** Pflicht-Schritt-Validierung + Persistenz; Gating-Redirect; `onboarding_completed_at`-Logik; Skip + Erinnerung.
 - **Team-Invite:** Owner darf, Staff nicht; fremdes Restaurant unmöglich.
-- **Phase 1c:** Generator nutzt per-Restaurant-Key (`OpenAI::fake`); kein Key-Leak in Logs/Responses; Mail-Secrets maskiert.
+- **Phase 1b:** Generator nutzt per-Restaurant-Key (`OpenAI::fake`); kein Key-Leak in Logs/Responses; Mail-Secrets maskiert.
 - **Frontend (Vitest):** Wizard-Schritt-Komponenten (Validierungsanzeige, Skip).
 - **Keine Regression:** bestehende Feature-/Vitest-Suiten grün.
 
@@ -137,7 +137,7 @@ Middleware (z. B. `EnsureOnboardingComplete`) auf den authentifizierten App-Rout
 
 ## Risiken & offene Fragen
 
-- **BYOK/E-Mail pro Restaurant** verschiebt globale `.env`-Config auf Tenant-Ebene — größter Aufwand; daher eigene Phase 1c, fürs Pilot optional/überspringbar (global bleibt nutzbar).
+- **BYOK/E-Mail pro Restaurant** verschiebt globale `.env`-Config auf Tenant-Ebene — größter Aufwand; daher eigene Phase 1b, fürs Pilot optional/überspringbar (global bleibt nutzbar).
 - **Wizard ↔ Settings-Duplizierung:** beide bearbeiten dieselben Felder — gemeinsame FormRequests/Komponenten nutzen.
 - **User ohne Passwort:** `password`-nullable berührt Auth-Annahmen (Login/Reset) — per Tests absichern.
 - **Design-Regression:** Token-Umstellung kann bestehende Screens optisch verschieben — Phase 2 schrittweise, mit visueller Kontrolle.


### PR DESCRIPTION
## Summary
Rename every `Phase 1c` reference in PRD-016 to `Phase 1b`. The PRD went `Phase 1 -> Phase 1c` with no 1a/1b defined — an orphaned label inherited from the original draft (#393), where the design-token and onboarding sub-phases were consolidated into 'Phase 1'. The remaining per-restaurant BYOK + SMTP wave is now `Phase 1b`, so the sequence reads 1 -> 1b -> 2 without a gap.

## Why
Flagged in review: a 'Phase 1c' with no 1b is confusing for the next planner. Pure label cleanup, no scope change.

## Test plan
- Docs-only; `grep` confirms no `1c` remains and 8 `Phase 1b` references are present.

Closes — no issue (cleanup).