### PR TITLE
PRD-016 Phase 1b #428: encrypted BYOK + SMTP columns on restaurants

### DIFF
--- a/app/Models/Restaurant.php
+++ b/app/Models/Restaurant.php
@@ -36,9 +36,16 @@ class Restaurant extends Model
         'opening_hours',
         'tonality',
         'onboarding_completed_at',
+        'openai_api_key',
         'imap_host',
         'imap_username',
         'imap_password',
+        'smtp_host',
+        'smtp_port',
+        'smtp_username',
+        'smtp_password',
+        'smtp_from_address',
+        'smtp_from_name',
         'send_mode',
         'auto_send_party_size_max',
         'auto_send_min_lead_time_minutes',
@@ -54,7 +61,9 @@ class Restaurant extends Model
      * @var list<string>
      */
     protected $hidden = [
+        'openai_api_key',
         'imap_password',
+        'smtp_password',
     ];
 
     /**
@@ -69,7 +78,10 @@ class Restaurant extends Model
             'opening_hours' => 'array',
             'tonality' => Tonality::class,
             'onboarding_completed_at' => 'datetime',
+            'openai_api_key' => 'encrypted',
             'imap_password' => 'encrypted',
+            'smtp_password' => 'encrypted',
+            'smtp_port' => 'integer',
             'send_mode' => SendMode::class,
             'auto_send_party_size_max' => 'integer',
             'auto_send_min_lead_time_minutes' => 'integer',

--- a/database/migrations/2026_05_25_000001_add_byok_and_smtp_to_restaurants.php
+++ b/database/migrations/2026_05_25_000001_add_byok_and_smtp_to_restaurants.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->text('openai_api_key')->nullable()->after('tonality');
+            $table->string('smtp_host')->nullable()->after('imap_password');
+            $table->unsignedInteger('smtp_port')->nullable()->after('smtp_host');
+            $table->string('smtp_username')->nullable()->after('smtp_port');
+            $table->text('smtp_password')->nullable()->after('smtp_username');
+            $table->string('smtp_from_address')->nullable()->after('smtp_password');
+            $table->string('smtp_from_name')->nullable()->after('smtp_from_address');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('restaurants', function (Blueprint $table) {
+            $table->dropColumn([
+                'openai_api_key',
+                'smtp_host',
+                'smtp_port',
+                'smtp_username',
+                'smtp_password',
+                'smtp_from_address',
+                'smtp_from_name',
+            ]);
+        });
+    }
+};

--- a/tests/Feature/Settings/RestaurantIntegrationColumnsTest.php
+++ b/tests/Feature/Settings/RestaurantIntegrationColumnsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Crypt;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+final class RestaurantIntegrationColumnsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_secret_columns_are_encrypted_at_rest_and_hidden(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'openai_api_key' => 'sk-secret-key',
+            'smtp_password' => 'smtp-secret',
+            'smtp_host' => 'smtp.bella.test',
+            'smtp_port' => 587,
+            'smtp_username' => 'mailer@bella.test',
+            'smtp_from_address' => 'hallo@bella.test',
+            'smtp_from_name' => 'Bella',
+        ]);
+
+        // Decrypts through the cast.
+        $this->assertSame('sk-secret-key', $restaurant->fresh()->openai_api_key);
+        $this->assertSame('smtp-secret', $restaurant->fresh()->smtp_password);
+        $this->assertSame(587, $restaurant->fresh()->smtp_port);
+
+        // Encrypted at rest.
+        $raw = DB::table('restaurants')->where('id', $restaurant->id)->first();
+        $this->assertNotSame('sk-secret-key', $raw->openai_api_key);
+        $this->assertSame('sk-secret-key', Crypt::decryptString($raw->openai_api_key));
+        $this->assertSame('smtp-secret', Crypt::decryptString($raw->smtp_password));
+
+        // Never serialized.
+        $array = $restaurant->toArray();
+        $this->assertArrayNotHasKey('openai_api_key', $array);
+        $this->assertArrayNotHasKey('smtp_password', $array);
+    }
+
+    public function test_secret_columns_default_to_null(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+
+        $this->assertNull($restaurant->openai_api_key);
+        $this->assertNull($restaurant->smtp_host);
+        $this->assertNull($restaurant->smtp_password);
+    }
+}


### PR DESCRIPTION
## Summary
One additive migration (up/down, no existing migration changed) adding `openai_api_key` + `smtp_host/port/username/password/from_address/from_name` to `restaurants`. Model: fillable + `encrypted` casts for `openai_api_key`/`smtp_password` (+ `smtp_port` integer) + `$hidden` so the secrets never serialize.

## Test plan
- `RestaurantIntegrationColumnsTest`: secrets encrypted at rest + decrypt via cast + hidden from toArray; columns default null.
- migrate + rollback clean; full suite 1063 passed; pint clean.

Closes #428.