### PR TITLE
PRD-016 Phase 1b #429: SecretMask UI masking helper

### DIFF
--- a/app/Support/SecretMask.php
+++ b/app/Support/SecretMask.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Support\Str;
+
+/**
+ * Renders a secret for the UI as four mask glyphs plus its last four
+ * characters, e.g. "••••3456". Never returns the secret itself. Secrets of
+ * four characters or fewer are fully masked so nothing leaks.
+ */
+final class SecretMask
+{
+    public static function tail4(?string $secret): ?string
+    {
+        if ($secret === null || $secret === '') {
+            return null;
+        }
+
+        if (Str::length($secret) <= 4) {
+            return '••••';
+        }
+
+        return '••••'.Str::substr($secret, -4);
+    }
+}

--- a/tests/Unit/Support/SecretMaskTest.php
+++ b/tests/Unit/Support/SecretMaskTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Support;
+
+use App\Support\SecretMask;
+use PHPUnit\Framework\TestCase;
+
+final class SecretMaskTest extends TestCase
+{
+    public function test_it_masks_all_but_the_last_four_characters(): void
+    {
+        $this->assertSame('••••3456', SecretMask::tail4('sk-0123456'));
+        $this->assertSame('••••cret', SecretMask::tail4('smtp-secret'));
+    }
+
+    public function test_short_or_empty_secrets_are_fully_masked_or_null(): void
+    {
+        $this->assertSame('••••', SecretMask::tail4('abc'));
+        $this->assertSame('••••', SecretMask::tail4('1234'));
+        $this->assertNull(SecretMask::tail4(null));
+        $this->assertNull(SecretMask::tail4(''));
+    }
+}


### PR DESCRIPTION
## Summary
`SecretMask::tail4(?string): ?string` — renders a secret as `••••`+last4, fully masked (`••••`) for <=4 chars, null for empty. Used by the Phase 1b settings pages so secrets never leave the server in clear.

## Test plan
- `SecretMaskTest`: long secrets show last 4; short/4-char fully masked; empty/null → null.
- pint clean.

Closes #429.