### PR TITLE
PRD-016 Phase 1b #430: RestaurantPolicy::manageIntegrations (owner-only)

### DIFF
--- a/app/Policies/RestaurantPolicy.php
+++ b/app/Policies/RestaurantPolicy.php
@@ -37,4 +37,14 @@ final class RestaurantPolicy
         return $user->restaurant_id === $restaurant->id
             && $user->role === UserRole::Owner;
     }
+
+    /**
+     * Per-restaurant integration secrets (OpenAI BYOK, SMTP, IMAP) are
+     * owner-only (PRD-016 Phase 1b).
+     */
+    public function manageIntegrations(User $user, Restaurant $restaurant): bool
+    {
+        return $user->restaurant_id === $restaurant->id
+            && $user->role === UserRole::Owner;
+    }
 }

--- a/tests/Feature/Settings/ManageIntegrationsPolicyTest.php
+++ b/tests/Feature/Settings/ManageIntegrationsPolicyTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Gate;
+use Tests\TestCase;
+
+final class ManageIntegrationsPolicyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_only_the_owner_of_the_restaurant_may_manage_integrations(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+        $otherOwner = User::factory()->owner()->forRestaurant(Restaurant::factory()->create())->create();
+
+        $this->assertTrue(Gate::forUser($owner)->allows('manageIntegrations', $restaurant));
+        $this->assertFalse(Gate::forUser($staff)->allows('manageIntegrations', $restaurant));
+        $this->assertFalse(Gate::forUser($otherOwner)->allows('manageIntegrations', $restaurant));
+    }
+}


### PR DESCRIPTION
## Summary
Owner-only `manageIntegrations` ability (mirrors `manageSendMode`); gates the BYOK/SMTP/IMAP settings pages.

## Test plan
- `ManageIntegrationsPolicyTest`: owner allowed; staff + foreign owner denied.
- pint clean.

Closes #430.