### PR TITLE
PRD-016 Phase 1b #431: OpenAiClientFactory (per-restaurant key + fallback)

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Services\AI\Contracts\ReplyGenerator;
+use App\Services\AI\OpenAiClientFactory;
 use App\Services\AI\OpenAiReplyGenerator;
 use App\Services\Email\Contracts\ImapMailboxFactory;
 use App\Services\Email\WebklexImapMailboxFactory;
@@ -23,6 +24,7 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->bind(ImapMailboxFactory::class, WebklexImapMailboxFactory::class);
         $this->app->bind(ExportGenerator::class, FormatRoutingExportGenerator::class);
+        $this->app->singleton(OpenAiClientFactory::class);
 
         // The generator needs two timeout regimes: the default 30 s client
         // for the async job (`generate`), and a short-budget client for the

--- a/app/Services/AI/OpenAiClientFactory.php
+++ b/app/Services/AI/OpenAiClientFactory.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\AI;
+
+use App\Models\Restaurant;
+use GuzzleHttp\Client as GuzzleClient;
+use OpenAI;
+use OpenAI\Contracts\ClientContract;
+use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
+
+/**
+ * Builds an OpenAI client for a given restaurant, using its own BYOK key when
+ * set and falling back to the global `.env` key otherwise. Mirrors the
+ * openai-php/laravel ServiceProvider build so org/project/base-uri stay
+ * honoured, and accepts an optional per-call timeout for the sync path.
+ */
+final class OpenAiClientFactory
+{
+    public function resolveKey(?Restaurant $restaurant): ?string
+    {
+        $perRestaurant = $restaurant?->openai_api_key;
+        if (is_string($perRestaurant) && $perRestaurant !== '') {
+            return $perRestaurant;
+        }
+
+        $global = config('openai.api_key');
+
+        return is_string($global) ? $global : null;
+    }
+
+    public function clientFor(?Restaurant $restaurant, ?int $timeout = null): ClientContract
+    {
+        $apiKey = $this->resolveKey($restaurant);
+        $organization = config('openai.organization');
+        $project = config('openai.project');
+        $baseUri = config('openai.base_uri');
+
+        if (! is_string($apiKey) || ($organization !== null && ! is_string($organization))) {
+            throw ApiKeyIsMissing::create();
+        }
+
+        $factory = OpenAI::factory()
+            ->withApiKey($apiKey)
+            ->withOrganization($organization)
+            ->withHttpClient(new GuzzleClient([
+                'timeout' => $timeout ?? config('openai.request_timeout', 30),
+            ]));
+
+        if (is_string($project)) {
+            $factory->withProject($project);
+        }
+
+        if (is_string($baseUri)) {
+            $factory->withBaseUri($baseUri);
+        }
+
+        return $factory->make();
+    }
+}

--- a/tests/Feature/AI/OpenAiClientFactoryTest.php
+++ b/tests/Feature/AI/OpenAiClientFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AI;
+
+use App\Models\Restaurant;
+use App\Services\AI\OpenAiClientFactory;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use OpenAI\Contracts\ClientContract;
+use Tests\TestCase;
+
+final class OpenAiClientFactoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_it_resolves_the_per_restaurant_key_with_global_fallback(): void
+    {
+        config(['openai.api_key' => 'sk-global']);
+        $factory = $this->app->make(OpenAiClientFactory::class);
+
+        $withKey = Restaurant::factory()->create(['openai_api_key' => 'sk-restaurant']);
+        $withoutKey = Restaurant::factory()->create(['openai_api_key' => null]);
+
+        $this->assertSame('sk-restaurant', $factory->resolveKey($withKey));
+        $this->assertSame('sk-global', $factory->resolveKey($withoutKey));
+        $this->assertSame('sk-global', $factory->resolveKey(null));
+    }
+
+    public function test_it_builds_a_usable_client(): void
+    {
+        config(['openai.api_key' => 'sk-global']);
+        $factory = $this->app->make(OpenAiClientFactory::class);
+
+        $this->assertInstanceOf(
+            ClientContract::class,
+            $factory->clientFor(Restaurant::factory()->create(['openai_api_key' => 'sk-restaurant'])),
+        );
+        $this->assertInstanceOf(ClientContract::class, $factory->clientFor(null, 5));
+    }
+}


### PR DESCRIPTION
## Summary
`OpenAiClientFactory::resolveKey(?Restaurant)` returns the restaurant's encrypted `openai_api_key` or the global `.env` key; `clientFor(?Restaurant, ?timeout)` builds the client (org/project/base-uri/timeout honoured like the openai-php/laravel provider). Singleton-bound. The generator is rewired onto it in #432.

## Test plan
- `OpenAiClientFactoryTest`: per-restaurant key chosen, global fallback for null/empty; builds a ClientContract (with + without timeout).
- Full suite 1068 passed; pint clean.

Closes #431.