### PR TITLE
PRD-016 Phase 1b #432: route reply generation through per-restaurant client

### DIFF
--- a/app/Http/Controllers/PublicReservationController.php
+++ b/app/Http/Controllers/PublicReservationController.php
@@ -121,7 +121,7 @@ final class PublicReservationController extends Controller
             // OpenAI client (the same late-resolution trick as
             // GenerateReservationReplyJob).
             $context = $this->contextBuilder->build($reservation);
-            $body = app(OpenAiReplyGenerator::class)->generateSync($context);
+            $body = app(OpenAiReplyGenerator::class)->generateSync($context, $restaurant, 5);
 
             $confirmed = DB::transaction(function () use ($reservation, $context, $body): bool {
                 // Serialize concurrent bookings for this restaurant's slot. The

--- a/app/Jobs/GenerateReservationReplyJob.php
+++ b/app/Jobs/GenerateReservationReplyJob.php
@@ -76,7 +76,7 @@ class GenerateReservationReplyJob implements ShouldQueue
             $generator = app(ReplyGenerator::class);
 
             $context = $builder->build($request);
-            $body = $generator->generate($context);
+            $body = $generator->generate($context, $request->restaurant);
 
             $reply = ReservationReply::create([
                 'reservation_request_id' => $request->id,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,14 +26,15 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(ExportGenerator::class, FormatRoutingExportGenerator::class);
         $this->app->singleton(OpenAiClientFactory::class);
 
-        // The generator needs two timeout regimes: the default 30 s client
-        // for the async job (`generate`), and a short-budget client for the
-        // PRD-014 sync-confirm path (`generateSync`). The factory builds the
-        // latter on demand with the requested timeout.
+        // Default client uses the global key (and is the BYOK fallback); the
+        // sync closure builds a timeout-bounded global client (PRD-014); the
+        // OpenAiClientFactory builds a per-restaurant client when a restaurant
+        // brought its own key (PRD-016 Phase 1b).
         $this->app->bind(OpenAiReplyGenerator::class, fn ($app): OpenAiReplyGenerator => new OpenAiReplyGenerator(
             $app->make(ClientContract::class),
             $app->make(LoggerInterface::class),
             fn (int $timeout): ClientContract => $this->buildTimeoutBoundOpenAiClient($timeout),
+            $app->make(OpenAiClientFactory::class),
         ));
         $this->app->bind(ReplyGenerator::class, OpenAiReplyGenerator::class);
     }

--- a/app/Services/AI/Contracts/ReplyGenerator.php
+++ b/app/Services/AI/Contracts/ReplyGenerator.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Services\AI\Contracts;
 
+use App\Models\Restaurant;
+
 /**
  * Producer of a German reply text from a deterministic Context-JSON.
  *
@@ -22,6 +24,8 @@ interface ReplyGenerator
     /**
      * @param  array<string, mixed>  $context  the JSON produced by
      *                                         ReservationContextBuilder::build()
+     * @param  Restaurant|null  $restaurant  source of the per-restaurant BYOK
+     *                                       key; null uses the global key
      */
-    public function generate(array $context): string;
+    public function generate(array $context, ?Restaurant $restaurant = null): string;
 }

--- a/app/Services/AI/OpenAiClientFactory.php
+++ b/app/Services/AI/OpenAiClientFactory.php
@@ -15,8 +15,11 @@ use OpenAI\Laravel\Exceptions\ApiKeyIsMissing;
  * set and falling back to the global `.env` key otherwise. Mirrors the
  * openai-php/laravel ServiceProvider build so org/project/base-uri stay
  * honoured, and accepts an optional per-call timeout for the sync path.
+ *
+ * Intentionally non-final so the generator's unit tests can mock `clientFor`
+ * to return an `OpenAI\Testing\ClientFake`.
  */
-final class OpenAiClientFactory
+class OpenAiClientFactory
 {
     public function resolveKey(?Restaurant $restaurant): ?string
     {

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -7,6 +7,7 @@ namespace App\Services\AI;
 use App\Exceptions\AI\OpenAiAuthenticationException;
 use App\Exceptions\AI\OpenAiRateLimitException;
 use App\Exceptions\AI\OpenAiTimeoutException;
+use App\Models\Restaurant;
 use App\Services\AI\Contracts\ReplyGenerator;
 use App\Support\OpenAiKeyHealth;
 use Closure;
@@ -48,27 +49,61 @@ final class OpenAiReplyGenerator implements ReplyGenerator
     private const float TEMPERATURE = 0.4;
 
     /**
-     * @param  (Closure(int): ClientContract)|null  $syncClientFactory
-     *                                                                  Builds a client whose HTTP timeout equals the sync hard-limit
-     *                                                                  (PRD-014). Bound in production so `generateSync` can run a
-     *                                                                  5 s-bounded call; left null in unit tests, where the injected
-     *                                                                  client (a fake) is used directly so `OpenAI::fake()` applies.
-     *                                                                  The async `generate` always uses the default 30 s `$client`.
+     * @param  ClientContract  $client  the default client, built with the
+     *                                  global `.env` key (and used as the BYOK
+     *                                  fallback / in tests).
+     * @param  (Closure(int): ClientContract)|null  $syncClientFactory  builds a
+     *                                                                  timeout-bounded global client for the
+     *                                                                  PRD-014 sync path; null in unit tests.
+     * @param  OpenAiClientFactory|null  $clientFactory  builds a client from a
+     *                                                   restaurant's own BYOK key (PRD-016 Phase
+     *                                                   1b); only consulted when the restaurant
+     *                                                   has its own key, else the default client
+     *                                                   (global key) applies.
      */
     public function __construct(
         private readonly ClientContract $client,
         private readonly LoggerInterface $logger,
         private readonly ?Closure $syncClientFactory = null,
+        private readonly ?OpenAiClientFactory $clientFactory = null,
     ) {}
+
+    /**
+     * The async client: the restaurant's BYOK client when it has its own key,
+     * otherwise the default global client.
+     */
+    private function asyncClientFor(?Restaurant $restaurant): ClientContract
+    {
+        if ($restaurant?->openai_api_key !== null && $this->clientFactory !== null) {
+            return $this->clientFactory->clientFor($restaurant);
+        }
+
+        return $this->client;
+    }
+
+    /**
+     * The sync client: the restaurant's timeout-bounded BYOK client when it has
+     * its own key, otherwise the timeout-bounded global client.
+     */
+    private function syncClientFor(?Restaurant $restaurant, int $timeout): ClientContract
+    {
+        if ($restaurant?->openai_api_key !== null && $this->clientFactory !== null) {
+            return $this->clientFactory->clientFor($restaurant, $timeout);
+        }
+
+        return $this->syncClientFactory !== null
+            ? ($this->syncClientFactory)($timeout)
+            : $this->client;
+    }
 
     /**
      * @param  array<string, mixed>  $context  the JSON produced by
      *                                         ReservationContextBuilder::build()
      */
-    public function generate(array $context): string
+    public function generate(array $context, ?Restaurant $restaurant = null): string
     {
         try {
-            $response = $this->client->chat()->create($this->chatCreatePayload($context));
+            $response = $this->asyncClientFor($restaurant)->chat()->create($this->chatCreatePayload($context));
 
             $content = trim((string) ($response->choices[0]->message->content ?? ''));
 
@@ -133,13 +168,10 @@ final class OpenAiReplyGenerator implements ReplyGenerator
      * @param  array<string, mixed>  $context  the JSON produced by
      *                                         ReservationContextBuilder::build()
      */
-    public function generateSync(array $context, int $timeout = 5): string
+    public function generateSync(array $context, ?Restaurant $restaurant = null, int $timeout = 5): string
     {
-        $client = $this->syncClientFactory !== null
-            ? ($this->syncClientFactory)($timeout)
-            : $this->client;
-
         try {
+            $client = $this->syncClientFor($restaurant, $timeout);
             $response = $client->chat()->create($this->chatCreatePayload($context));
 
             $content = trim((string) ($response->choices[0]->message->content ?? ''));

--- a/tests/Feature/AI/ByokGenerationTest.php
+++ b/tests/Feature/AI/ByokGenerationTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AI;
+
+use App\Models\Restaurant;
+use App\Services\AI\OpenAiClientFactory;
+use App\Services\AI\OpenAiReplyGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use OpenAI\Responses\Chat\CreateResponse;
+use OpenAI\Testing\ClientFake;
+use Psr\Log\NullLogger;
+use Tests\TestCase;
+
+final class ByokGenerationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_restaurant_with_its_own_key_uses_the_factory_client(): void
+    {
+        $restaurant = Restaurant::factory()->create(['openai_api_key' => 'sk-restaurant']);
+
+        $globalFake = new ClientFake([
+            CreateResponse::fake(['choices' => [['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'GLOBAL'], 'finish_reason' => 'stop']]]),
+        ]);
+        $restaurantFake = new ClientFake([
+            CreateResponse::fake(['choices' => [['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'BYOK'], 'finish_reason' => 'stop']]]),
+        ]);
+
+        $factory = $this->createMock(OpenAiClientFactory::class);
+        $factory->expects($this->once())
+            ->method('clientFor')
+            ->with($this->callback(fn (?Restaurant $r): bool => $r?->is($restaurant) === true))
+            ->willReturn($restaurantFake);
+
+        $generator = new OpenAiReplyGenerator($globalFake, new NullLogger, null, $factory);
+
+        $this->assertSame('BYOK', $generator->generate($this->context(), $restaurant));
+    }
+
+    public function test_a_restaurant_without_its_own_key_uses_the_default_client(): void
+    {
+        $restaurant = Restaurant::factory()->create(['openai_api_key' => null]);
+
+        $globalFake = new ClientFake([
+            CreateResponse::fake(['choices' => [['index' => 0, 'message' => ['role' => 'assistant', 'content' => 'GLOBAL'], 'finish_reason' => 'stop']]]),
+        ]);
+
+        $factory = $this->createMock(OpenAiClientFactory::class);
+        $factory->expects($this->never())->method('clientFor');
+
+        $generator = new OpenAiReplyGenerator($globalFake, new NullLogger, null, $factory);
+
+        $this->assertSame('GLOBAL', $generator->generate($this->context(), $restaurant));
+    }
+
+    /** @return array<string, mixed> */
+    private function context(): array
+    {
+        return [
+            'restaurant' => ['name' => 'Bella', 'tonality' => 'formal'],
+            'request' => ['guest_name' => 'Anna', 'party_size' => 2],
+            'availability' => ['is_available' => true],
+        ];
+    }
+}

--- a/tests/Feature/AutoSend/AuditTrailTest.php
+++ b/tests/Feature/AutoSend/AuditTrailTest.php
@@ -193,7 +193,7 @@ class AuditTrailTest extends TestCase
         {
             public function __construct(private readonly string $body) {}
 
-            public function generate(array $context): string
+            public function generate(array $context, ?Restaurant $restaurant = null): string
             {
                 return $this->body;
             }

--- a/tests/Feature/Jobs/GenerateReservationReplyJobErrorMatrixTest.php
+++ b/tests/Feature/Jobs/GenerateReservationReplyJobErrorMatrixTest.php
@@ -50,7 +50,7 @@ class GenerateReservationReplyJobErrorMatrixTest extends TestCase
         {
             public function __construct(private readonly \Throwable $error) {}
 
-            public function generate(array $context): string
+            public function generate(array $context, ?Restaurant $restaurant = null): string
             {
                 throw $this->error;
             }
@@ -161,7 +161,7 @@ class GenerateReservationReplyJobErrorMatrixTest extends TestCase
         $request = $this->makeRequest();
         $this->app->bind(ReplyGenerator::class, fn () => new class implements ReplyGenerator
         {
-            public function generate(array $context): string
+            public function generate(array $context, ?Restaurant $restaurant = null): string
             {
                 return 'Generierter Antworttext.';
             }

--- a/tests/Feature/Jobs/GenerateReservationReplyJobTest.php
+++ b/tests/Feature/Jobs/GenerateReservationReplyJobTest.php
@@ -42,7 +42,7 @@ class GenerateReservationReplyJobTest extends TestCase
         {
             public function __construct(private readonly string|RuntimeException $bodyOrError) {}
 
-            public function generate(array $context): string
+            public function generate(array $context, ?Restaurant $restaurant = null): string
             {
                 if ($this->bodyOrError instanceof RuntimeException) {
                     throw $this->bodyOrError;

--- a/tests/Feature/Jobs/GenerateReservationReplySnapshotTest.php
+++ b/tests/Feature/Jobs/GenerateReservationReplySnapshotTest.php
@@ -55,7 +55,7 @@ class GenerateReservationReplySnapshotTest extends TestCase
         {
             public function __construct(private readonly string|RuntimeException $bodyOrError) {}
 
-            public function generate(array $context): string
+            public function generate(array $context, ?Restaurant $restaurant = null): string
             {
                 if ($this->bodyOrError instanceof RuntimeException) {
                     throw $this->bodyOrError;

--- a/tests/Feature/ReservationReplyFlowTest.php
+++ b/tests/Feature/ReservationReplyFlowTest.php
@@ -215,7 +215,7 @@ class ReservationReplyFlowTest extends TestCase
         {
             public function __construct(private readonly \Throwable $error) {}
 
-            public function generate(array $context): string
+            public function generate(array $context, ?Restaurant $restaurant = null): string
             {
                 throw $this->error;
             }


### PR DESCRIPTION
## Summary
`ReplyGenerator::generate` and `OpenAiReplyGenerator::generate/generateSync` take an optional `?Restaurant`. When the restaurant has its own `openai_api_key`, the client is built via `OpenAiClientFactory` (BYOK); otherwise the existing global default client / sync-timeout closure is used — **fully backward compatible** (the factory is an optional 4th constructor arg, only consulted for BYOK restaurants).

Call sites: `GenerateReservationReplyJob` passes `$request->restaurant`; `PublicReservationController` sync path passes `$restaurant`. `OpenAiClientFactory` made non-final so the generator's tests can mock `clientFor`. Interface-stub `generate` signatures updated across tests.

## Design note
Chose a hybrid (keep the injected global client as fallback + add the factory) over a factory-only constructor to avoid destabilising the ~20 existing generator test constructions; the global/no-BYOK behaviour is byte-for-byte unchanged.

## Test plan
- New `ByokGenerationTest`: restaurant with own key → factory client used; without → default client, factory never called.
- Full suite 1070 passed; pint clean.

Closes #432.