### PR TITLE
PRD-016 Phase 1b #433: per-restaurant OpenAI key health

### DIFF
--- a/app/Events/OpenAiAuthenticationFailed.php
+++ b/app/Events/OpenAiAuthenticationFailed.php
@@ -14,4 +14,10 @@ use Illuminate\Foundation\Events\Dispatchable;
 final class OpenAiAuthenticationFailed
 {
     use Dispatchable;
+
+    /**
+     * @param  int|null  $restaurantId  the restaurant whose key was rejected,
+     *                                  or null for the global key.
+     */
+    public function __construct(public readonly ?int $restaurantId = null) {}
 }

--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -62,11 +62,12 @@ final class DashboardController extends Controller
                 : ReservationRequestResource::collection($waitlistBanner->eligibleNow($restaurantId))->resolve($request),
             'selectedRequest' => fn () => $this->resolveSelected($selectedId, $request),
             'threadMessages' => fn () => $this->resolveThreadMessages($selectedId, $request),
-            // Owner-only banner. The flag is global (V1.0 has one OpenAI key
-            // app-wide); dismissing-by-user is intentionally NOT supported
-            // (issue #76) so a stale alert can't outlive a still-broken key.
+            // Owner-only banner. Scoped to this restaurant's key (PRD-016 Phase
+            // 1b BYOK); a rejected restaurant key surfaces only to its owner.
+            // Dismissing-by-user is intentionally NOT supported (issue #76) so a
+            // stale alert can't outlive a still-broken key.
             'openaiKeyRejectedAt' => $request->user()?->role === UserRole::Owner
-                ? OpenAiKeyHealth::rejectedAt()
+                ? OpenAiKeyHealth::rejectedAt($restaurantId)
                 : null,
             // PRD-007 mode banner. Surfaces the active send-mode at the
             // top of the dashboard whenever it deviates from the V1.0

--- a/app/Jobs/GenerateReservationReplyJob.php
+++ b/app/Jobs/GenerateReservationReplyJob.php
@@ -100,7 +100,7 @@ class GenerateReservationReplyJob implements ShouldQueue
             // 401 → admin notification, no retry. Always fall straight
             // through to the fallback path so the dashboard still has
             // something to show.
-            OpenAiAuthenticationFailed::dispatch();
+            OpenAiAuthenticationFailed::dispatch($request->restaurant_id);
 
             $this->storeFallbackDraft($request, $context, $logger, '401 authentication failed');
         } catch (Throwable $e) {

--- a/app/Listeners/RecordOpenAiKeyRejected.php
+++ b/app/Listeners/RecordOpenAiKeyRejected.php
@@ -17,6 +17,6 @@ final class RecordOpenAiKeyRejected
 {
     public function handle(OpenAiAuthenticationFailed $event): void
     {
-        OpenAiKeyHealth::flagAsRejected();
+        OpenAiKeyHealth::flagAsRejected($event->restaurantId);
     }
 }

--- a/app/Services/AI/OpenAiReplyGenerator.php
+++ b/app/Services/AI/OpenAiReplyGenerator.php
@@ -110,7 +110,7 @@ final class OpenAiReplyGenerator implements ReplyGenerator
             // Reaching this point means the call authenticated successfully —
             // auto-clear the admin "OpenAI key check" banner (#76) so the
             // dashboard doesn't strand stale alerts after a key rotation.
-            OpenAiKeyHealth::clear();
+            OpenAiKeyHealth::clear($restaurant?->id);
 
             return $content !== '' ? $content : self::FALLBACK_TEXT;
         } catch (ErrorException $e) {
@@ -182,7 +182,7 @@ final class OpenAiReplyGenerator implements ReplyGenerator
 
             // Successful authenticated call — clear the admin "OpenAI key
             // check" banner (#76), mirroring `generate`.
-            OpenAiKeyHealth::clear();
+            OpenAiKeyHealth::clear($restaurant?->id);
 
             return $content;
         } catch (ErrorException $e) {

--- a/app/Support/OpenAiKeyHealth.php
+++ b/app/Support/OpenAiKeyHealth.php
@@ -35,20 +35,29 @@ final class OpenAiKeyHealth
 
     private const int RETENTION_SECONDS = 7 * 24 * 60 * 60;
 
-    public static function flagAsRejected(): void
+    public static function flagAsRejected(?int $restaurantId = null): void
     {
-        Cache::put(self::CACHE_KEY, now()->toIso8601String(), self::RETENTION_SECONDS);
+        Cache::put(self::cacheKey($restaurantId), now()->toIso8601String(), self::RETENTION_SECONDS);
     }
 
-    public static function clear(): void
+    public static function clear(?int $restaurantId = null): void
     {
-        Cache::forget(self::CACHE_KEY);
+        Cache::forget(self::cacheKey($restaurantId));
     }
 
-    public static function rejectedAt(): ?string
+    public static function rejectedAt(?int $restaurantId = null): ?string
     {
-        $value = Cache::get(self::CACHE_KEY);
+        $value = Cache::get(self::cacheKey($restaurantId));
 
         return is_string($value) ? $value : null;
+    }
+
+    /**
+     * Per-restaurant scope (PRD-016 Phase 1b BYOK): a rejected restaurant key
+     * flags only that restaurant; the global key keeps the `global` scope.
+     */
+    private static function cacheKey(?int $restaurantId): string
+    {
+        return self::CACHE_KEY.'.'.($restaurantId ?? 'global');
     }
 }

--- a/tests/Feature/AI/PerRestaurantKeyHealthTest.php
+++ b/tests/Feature/AI/PerRestaurantKeyHealthTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\AI;
+
+use App\Events\OpenAiAuthenticationFailed;
+use App\Listeners\RecordOpenAiKeyRejected;
+use App\Support\OpenAiKeyHealth;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PerRestaurantKeyHealthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_health_is_scoped_per_restaurant(): void
+    {
+        OpenAiKeyHealth::flagAsRejected(7);
+
+        $this->assertNotNull(OpenAiKeyHealth::rejectedAt(7));
+        $this->assertNull(OpenAiKeyHealth::rejectedAt(8));
+        $this->assertNull(OpenAiKeyHealth::rejectedAt()); // global key unaffected
+
+        OpenAiKeyHealth::clear(7);
+        $this->assertNull(OpenAiKeyHealth::rejectedAt(7));
+    }
+
+    public function test_the_listener_flags_the_event_restaurant(): void
+    {
+        (new RecordOpenAiKeyRejected)->handle(new OpenAiAuthenticationFailed(42));
+
+        $this->assertNotNull(OpenAiKeyHealth::rejectedAt(42));
+        $this->assertNull(OpenAiKeyHealth::rejectedAt(43));
+    }
+}

--- a/tests/Feature/OpenAi401AdminNotificationTest.php
+++ b/tests/Feature/OpenAi401AdminNotificationTest.php
@@ -45,10 +45,10 @@ class OpenAi401AdminNotificationTest extends TestCase
 
     public function test_dashboard_surfaces_the_banner_for_owner_users(): void
     {
-        OpenAiKeyHealth::flagAsRejected();
-
         $restaurant = Restaurant::factory()->create();
         $owner = User::factory()->create(['restaurant_id' => $restaurant->id, 'role' => UserRole::Owner]);
+
+        OpenAiKeyHealth::flagAsRejected($restaurant->id);
 
         $this->actingAs($owner)
             ->get(route('dashboard'))


### PR DESCRIPTION
## Summary
`OpenAiKeyHealth::{flagAsRejected,clear,rejectedAt}` take an optional `?int $restaurantId` (cache key per restaurant; `null` → global). The 401 path threads the restaurant id: `OpenAiAuthenticationFailed` carries it, the listener flags it, `GenerateReservationReplyJob` dispatches with `$request->restaurant_id`, the generator clears per restaurant on success, and the dashboard banner reads the owner's restaurant scope. A rejected per-restaurant BYOK key flags only that owner; the global key keeps global health.

## Test plan
- `PerRestaurantKeyHealthTest`: scoping + listener.
- Adapted the owner-banner test to flag the restaurant scope (intentional behaviour change).
- Full suite 1072 passed; pint clean.

Closes #433.