### PR TITLE
PRD-016 Phase 1b #434: BYOK (OpenAI key) settings page

### DIFF
--- a/app/Http/Controllers/Settings/AiKeySettingsController.php
+++ b/app/Http/Controllers/Settings/AiKeySettingsController.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\AiKeySettingsRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Support\SecretMask;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Owner-only per-restaurant OpenAI BYOK key (PRD-016 Phase 1b). The key is
+ * never returned to the browser — only a masked tail and a "configured" flag.
+ */
+final class AiKeySettingsController extends Controller
+{
+    public function edit(): Response
+    {
+        $restaurant = $this->ownedRestaurant();
+
+        return Inertia::render('settings/AiKey', [
+            'configured' => $restaurant->openai_api_key !== null,
+            'masked' => SecretMask::tail4($restaurant->openai_api_key),
+        ]);
+    }
+
+    public function update(AiKeySettingsRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+        $key = $request->validated()['openai_api_key'] ?? null;
+
+        // Empty submission leaves the stored key untouched.
+        if (is_string($key) && $key !== '') {
+            $restaurant->update(['openai_api_key' => $key]);
+        }
+
+        return back()->with('success', 'OpenAI-Schlüssel gespeichert.');
+    }
+
+    private function ownedRestaurant(): Restaurant
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $restaurant = $user->restaurant;
+
+        if ($restaurant === null) {
+            abort(403);
+        }
+
+        Gate::authorize('manageIntegrations', $restaurant);
+
+        return $restaurant;
+    }
+}

--- a/app/Http/Requests/Settings/AiKeySettingsRequest.php
+++ b/app/Http/Requests/Settings/AiKeySettingsRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the per-restaurant OpenAI key. Authorization happens in the
+ * controller via the `manageIntegrations` policy. An empty value means
+ * "leave the stored key unchanged".
+ */
+class AiKeySettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'openai_api_key' => ['nullable', 'string', 'max:255', 'starts_with:sk-'],
+        ];
+    }
+}

--- a/resources/js/pages/settings/AiKey.vue
+++ b/resources/js/pages/settings/AiKey.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3';
+
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+import { type BreadcrumbItem } from '@/types';
+
+interface Props {
+    configured: boolean;
+    masked: string | null;
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'OpenAI-Schlüssel', href: '/settings/ai-key' }];
+
+const form = useForm({
+    openai_api_key: '',
+});
+
+const submit = () => {
+    form.patch(route('settings.ai-key.update'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset('openai_api_key'),
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="OpenAI-Schlüssel" />
+
+        <SettingsLayout>
+            <div class="flex flex-col space-y-6">
+                <HeadingSmall
+                    title="OpenAI-Schlüssel"
+                    description="Eigener OpenAI-API-Schlüssel für dieses Restaurant. Ohne eigenen Schlüssel wird der globale Schlüssel verwendet."
+                />
+
+                <form class="space-y-6" @submit.prevent="submit">
+                    <div class="grid gap-2">
+                        <Label for="openai_api_key">API-Schlüssel</Label>
+                        <Input
+                            id="openai_api_key"
+                            v-model="form.openai_api_key"
+                            type="password"
+                            autocomplete="off"
+                            :placeholder="configured ? `Hinterlegt (${masked}) — leer lassen, um zu behalten` : 'sk-…'"
+                        />
+                        <InputError :message="form.errors.openai_api_key" />
+                    </div>
+
+                    <Button type="submit" :disabled="form.processing">Speichern</Button>
+                </form>
+            </div>
+        </SettingsLayout>
+    </AppLayout>
+</template>

--- a/resources/js/pages/settings/AiKey.vue
+++ b/resources/js/pages/settings/AiKey.vue
@@ -15,7 +15,7 @@ interface Props {
     masked: string | null;
 }
 
-const props = defineProps<Props>();
+defineProps<Props>();
 
 const breadcrumbs: BreadcrumbItem[] = [{ title: 'OpenAI-Schlüssel', href: '/settings/ai-key' }];
 

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -136,6 +136,8 @@ declare module 'ziggy-js' {
     "settings.send-mode.update": [],
     "settings.notifications.edit": [],
     "settings.notifications.update": [],
+    "settings.ai-key.edit": [],
+    "settings.ai-key.update": [],
     "register": [],
     "login": [],
     "password.request": [],

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Settings\AiKeySettingsController;
 use App\Http\Controllers\Settings\NotificationSettingsController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
@@ -30,4 +31,9 @@ Route::middleware('auth')->group(function () {
         ->name('settings.notifications.edit');
     Route::put('settings/notifications', [NotificationSettingsController::class, 'update'])
         ->name('settings.notifications.update');
+
+    Route::get('settings/ai-key', [AiKeySettingsController::class, 'edit'])
+        ->name('settings.ai-key.edit');
+    Route::patch('settings/ai-key', [AiKeySettingsController::class, 'update'])
+        ->name('settings.ai-key.update');
 });

--- a/tests/Feature/Settings/AiKeySettingsTest.php
+++ b/tests/Feature/Settings/AiKeySettingsTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+final class AiKeySettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_sees_masked_key_and_can_update_it(): void
+    {
+        $restaurant = Restaurant::factory()->create(['openai_api_key' => 'sk-old-1234']);
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->get(route('settings.ai-key.edit'))
+            ->assertOk()
+            ->assertInertia(fn (AssertableInertia $p) => $p
+                ->component('settings/AiKey')
+                ->where('configured', true)
+                ->where('masked', '••••1234')
+                ->missing('openai_api_key'));
+
+        $this->actingAs($owner)->patch(route('settings.ai-key.update'), ['openai_api_key' => 'sk-new-5678'])
+            ->assertRedirect();
+
+        $this->assertSame('sk-new-5678', $restaurant->fresh()->openai_api_key);
+    }
+
+    public function test_empty_submission_keeps_the_existing_key(): void
+    {
+        $restaurant = Restaurant::factory()->create(['openai_api_key' => 'sk-keep-9999']);
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->patch(route('settings.ai-key.update'), ['openai_api_key' => ''])->assertRedirect();
+
+        $this->assertSame('sk-keep-9999', $restaurant->fresh()->openai_api_key);
+    }
+
+    public function test_invalid_key_is_rejected(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)
+            ->from(route('settings.ai-key.edit'))
+            ->patch(route('settings.ai-key.update'), ['openai_api_key' => 'not-a-key'])
+            ->assertSessionHasErrors('openai_api_key');
+    }
+
+    public function test_staff_cannot_access(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($staff)->get(route('settings.ai-key.edit'))->assertForbidden();
+        $this->actingAs($staff)->patch(route('settings.ai-key.update'), ['openai_api_key' => 'sk-x-1234'])->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
Owner-only `settings/ai-key` page (`AiKeySettingsController` + `AiKeySettingsRequest` + `AiKey.vue`, gated by `manageIntegrations`). Read returns only a masked tail + `configured` flag (never the key); empty submission keeps the stored key; the key must `starts_with:sk-`. Follows the SendMode settings pattern (no shared-nav entry, consistent with other owner-only settings). Ziggy types regenerated.

## Test plan
- `AiKeySettingsTest`: masked read + update; empty keeps existing; invalid rejected; staff forbidden (GET + PATCH).
- Full suite green; pint/build/lint/format clean.

Closes #434.