### PR TITLE
PRD-016 Phase 1b #435: per-restaurant SMTP send (runtime mailer + From)

### DIFF
--- a/app/Jobs/SendReservationReplyJob.php
+++ b/app/Jobs/SendReservationReplyJob.php
@@ -8,6 +8,7 @@ use App\Enums\MessageDirection;
 use App\Enums\ReservationReplyStatus;
 use App\Enums\ReservationStatus;
 use App\Mail\ReservationReplyMail;
+use App\Mail\Support\RestaurantMailer;
 use App\Models\ReservationMessage;
 use App\Models\ReservationReply;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -75,11 +76,22 @@ final class SendReservationReplyJob implements ShouldQueue
         }
 
         try {
+            $restaurant = $reservationRequest->restaurant;
+            $mailerSupport = app(RestaurantMailer::class);
+            $from = $mailerSupport->from($restaurant);
+
             $mail = new ReservationReplyMail($reply);
+            $mail->from($from['address'], $from['name']);
 
-            Mail::to($email)->send($mail);
+            // Per-restaurant SMTP when configured, else the default .env mailer.
+            $mailerName = $mailerSupport->resolve($restaurant);
+            if ($mailerName !== null) {
+                Mail::mailer($mailerName)->to($email)->send($mail);
+            } else {
+                Mail::to($email)->send($mail);
+            }
 
-            $fromAddress = (string) (config('mail.from.address') ?: 'noreply@localhost');
+            $fromAddress = $from['address'] !== '' ? $from['address'] : 'noreply@localhost';
             $subject = (string) $mail->envelope()->subject;
 
             ReservationMessage::create([

--- a/app/Mail/Support/RestaurantMailer.php
+++ b/app/Mail/Support/RestaurantMailer.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Mail\Support;
+
+use App\Models\Restaurant;
+
+/**
+ * Registers a runtime SMTP mailer for a restaurant that has its own SMTP
+ * config (PRD-016 Phase 1b) and returns its name. Returns null when the
+ * restaurant has no SMTP configured, so callers fall back to the default
+ * `.env` mailer. The mailer config is added in-memory (config()) for the
+ * current process only; it is never written to a config file.
+ */
+final class RestaurantMailer
+{
+    /**
+     * @return string|null the runtime mailer name, or null to use the default
+     */
+    public function resolve(Restaurant $restaurant): ?string
+    {
+        if ($restaurant->smtp_host === null || $restaurant->smtp_host === '') {
+            return null;
+        }
+
+        $name = 'restaurant-'.$restaurant->id;
+
+        config([
+            "mail.mailers.{$name}" => [
+                'transport' => 'smtp',
+                'host' => $restaurant->smtp_host,
+                'port' => $restaurant->smtp_port ?? 587,
+                'username' => $restaurant->smtp_username,
+                'password' => $restaurant->smtp_password,
+                'encryption' => 'tls',
+                'timeout' => null,
+            ],
+        ]);
+
+        return $name;
+    }
+
+    /**
+     * The From address/name for the restaurant: its own when configured,
+     * otherwise the global `mail.from`.
+     *
+     * @return array{address: string, name: string}
+     */
+    public function from(Restaurant $restaurant): array
+    {
+        return [
+            'address' => $restaurant->smtp_from_address ?? (string) config('mail.from.address'),
+            'name' => $restaurant->smtp_from_name ?? (string) config('mail.from.name'),
+        ];
+    }
+}

--- a/tests/Feature/Mail/PerRestaurantSmtpTest.php
+++ b/tests/Feature/Mail/PerRestaurantSmtpTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Mail;
+
+use App\Enums\ReservationReplyStatus;
+use App\Jobs\SendReservationReplyJob;
+use App\Mail\ReservationReplyMail;
+use App\Mail\Support\RestaurantMailer;
+use App\Models\ReservationReply;
+use App\Models\ReservationRequest;
+use App\Models\Restaurant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+final class PerRestaurantSmtpTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_a_reply_for_a_configured_restaurant_sends_via_its_mailer(): void
+    {
+        Mail::fake();
+
+        $restaurant = Restaurant::factory()->create([
+            'smtp_host' => 'smtp.bella.test',
+            'smtp_port' => 587,
+            'smtp_username' => 'mailer@bella.test',
+            'smtp_password' => 'pw',
+            'smtp_from_address' => 'hallo@bella.test',
+            'smtp_from_name' => 'Bella',
+        ]);
+        $request = ReservationRequest::factory()->forRestaurant($restaurant)->create(['guest_email' => 'guest@example.test']);
+        $reply = ReservationReply::factory()->create([
+            'reservation_request_id' => $request->id,
+            'status' => ReservationReplyStatus::Approved,
+            'body' => 'Bestätigt.',
+        ]);
+
+        (new SendReservationReplyJob($reply->id))->handle();
+
+        Mail::assertSent(ReservationReplyMail::class, fn (ReservationReplyMail $mail): bool => $mail->hasTo('guest@example.test'));
+    }
+
+    public function test_a_configured_restaurant_gets_its_own_mailer_and_from(): void
+    {
+        $restaurant = Restaurant::factory()->create([
+            'smtp_host' => 'smtp.bella.test',
+            'smtp_port' => 2525,
+            'smtp_username' => 'mailer@bella.test',
+            'smtp_password' => 'pw',
+            'smtp_from_address' => 'hallo@bella.test',
+            'smtp_from_name' => 'Bella',
+        ]);
+
+        $support = app(RestaurantMailer::class);
+        $name = $support->resolve($restaurant);
+
+        $this->assertSame('restaurant-'.$restaurant->id, $name);
+        $this->assertSame('smtp.bella.test', config("mail.mailers.{$name}.host"));
+        $this->assertSame(2525, config("mail.mailers.{$name}.port"));
+        $this->assertSame('mailer@bella.test', config("mail.mailers.{$name}.username"));
+        $this->assertSame(['address' => 'hallo@bella.test', 'name' => 'Bella'], $support->from($restaurant));
+    }
+
+    public function test_an_unconfigured_restaurant_uses_the_default_mailer_and_global_from(): void
+    {
+        config(['mail.from.address' => 'global@app.test', 'mail.from.name' => 'App']);
+        $restaurant = Restaurant::factory()->create(['smtp_host' => null]);
+
+        $support = app(RestaurantMailer::class);
+
+        $this->assertNull($support->resolve($restaurant));
+        $this->assertSame(['address' => 'global@app.test', 'name' => 'App'], $support->from($restaurant));
+    }
+}


### PR DESCRIPTION
## Summary
`RestaurantMailer::resolve($restaurant)` registers an in-memory `mail.mailers.restaurant-{id}` SMTP config and returns its name (null when unconfigured); `from($restaurant)` returns the restaurant's From or the global `mail.from`. `SendReservationReplyJob` sends via the per-restaurant mailer when configured, else the existing `Mail::to()` default path (keeping all existing mail flows/mocks unchanged). The recorded outbound message From reflects the restaurant.

## Test plan
- `PerRestaurantSmtpTest`: resolve + From (configured + unconfigured); a reply for a configured restaurant sends via its mailer (Mail::fake).
- Full suite 1078 passed; pint clean.

Closes #435.