### PR TITLE
PRD-016 Phase 1b #436: SMTP settings page

### DIFF
--- a/app/Http/Controllers/Settings/SmtpSettingsController.php
+++ b/app/Http/Controllers/Settings/SmtpSettingsController.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\SmtpSettingsRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Support\SecretMask;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Owner-only per-restaurant SMTP send config (PRD-016 Phase 1b). The password
+ * is never returned to the browser — only a masked tail.
+ */
+final class SmtpSettingsController extends Controller
+{
+    public function edit(): Response
+    {
+        $restaurant = $this->ownedRestaurant();
+
+        return Inertia::render('settings/Smtp', [
+            'smtp' => [
+                'host' => $restaurant->smtp_host,
+                'port' => $restaurant->smtp_port,
+                'username' => $restaurant->smtp_username,
+                'from_address' => $restaurant->smtp_from_address,
+                'from_name' => $restaurant->smtp_from_name,
+                'password_masked' => SecretMask::tail4($restaurant->smtp_password),
+            ],
+        ]);
+    }
+
+    public function update(SmtpSettingsRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+        $validated = $request->validated();
+
+        $payload = collect($validated)->except('smtp_password')->all();
+
+        // Empty password leaves the stored one untouched.
+        if (($validated['smtp_password'] ?? '') !== '') {
+            $payload['smtp_password'] = $validated['smtp_password'];
+        }
+
+        $restaurant->update($payload);
+
+        return back()->with('success', 'SMTP-Einstellungen gespeichert.');
+    }
+
+    private function ownedRestaurant(): Restaurant
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $restaurant = $user->restaurant;
+
+        if ($restaurant === null) {
+            abort(403);
+        }
+
+        Gate::authorize('manageIntegrations', $restaurant);
+
+        return $restaurant;
+    }
+}

--- a/app/Http/Requests/Settings/SmtpSettingsRequest.php
+++ b/app/Http/Requests/Settings/SmtpSettingsRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the per-restaurant SMTP send config. An empty password means
+ * "leave the stored password unchanged".
+ */
+class SmtpSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'smtp_host' => ['required', 'string', 'max:255'],
+            'smtp_port' => ['required', 'integer', 'between:1,65535'],
+            'smtp_username' => ['required', 'string', 'max:255'],
+            'smtp_password' => ['nullable', 'string', 'max:255'],
+            'smtp_from_address' => ['required', 'email', 'max:255'],
+            'smtp_from_name' => ['required', 'string', 'max:255'],
+        ];
+    }
+}

--- a/resources/js/pages/settings/Smtp.vue
+++ b/resources/js/pages/settings/Smtp.vue
@@ -1,0 +1,99 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3';
+
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+import { type BreadcrumbItem } from '@/types';
+
+interface Props {
+    smtp: {
+        host: string | null;
+        port: number | null;
+        username: string | null;
+        from_address: string | null;
+        from_name: string | null;
+        password_masked: string | null;
+    };
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'SMTP-Versand', href: '/settings/smtp' }];
+
+const form = useForm({
+    smtp_host: props.smtp.host ?? '',
+    smtp_port: props.smtp.port ?? 587,
+    smtp_username: props.smtp.username ?? '',
+    smtp_password: '',
+    smtp_from_address: props.smtp.from_address ?? '',
+    smtp_from_name: props.smtp.from_name ?? '',
+});
+
+const submit = () => {
+    form.patch(route('settings.smtp.update'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset('smtp_password'),
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="SMTP-Versand" />
+
+        <SettingsLayout>
+            <div class="flex flex-col space-y-6">
+                <HeadingSmall
+                    title="SMTP-Versand"
+                    description="Eigener SMTP-Server für ausgehende Gäste-Mails. Ohne eigene Konfiguration wird der globale Versand verwendet."
+                />
+
+                <form class="space-y-6" @submit.prevent="submit">
+                    <div class="grid gap-2">
+                        <Label for="smtp_host">Host</Label>
+                        <Input id="smtp_host" v-model="form.smtp_host" required />
+                        <InputError :message="form.errors.smtp_host" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="smtp_port">Port</Label>
+                        <Input id="smtp_port" v-model="form.smtp_port" type="number" min="1" max="65535" required />
+                        <InputError :message="form.errors.smtp_port" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="smtp_username">Benutzername</Label>
+                        <Input id="smtp_username" v-model="form.smtp_username" required autocomplete="off" />
+                        <InputError :message="form.errors.smtp_username" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="smtp_password">Passwort</Label>
+                        <Input
+                            id="smtp_password"
+                            v-model="form.smtp_password"
+                            type="password"
+                            autocomplete="off"
+                            :placeholder="smtp.password_masked ? `Hinterlegt (${smtp.password_masked}) — leer lassen, um zu behalten` : 'Passwort'"
+                        />
+                        <InputError :message="form.errors.smtp_password" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="smtp_from_address">Absender-Adresse</Label>
+                        <Input id="smtp_from_address" v-model="form.smtp_from_address" type="email" required />
+                        <InputError :message="form.errors.smtp_from_address" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="smtp_from_name">Absender-Name</Label>
+                        <Input id="smtp_from_name" v-model="form.smtp_from_name" required />
+                        <InputError :message="form.errors.smtp_from_name" />
+                    </div>
+
+                    <Button type="submit" :disabled="form.processing">Speichern</Button>
+                </form>
+            </div>
+        </SettingsLayout>
+    </AppLayout>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -138,6 +138,8 @@ declare module 'ziggy-js' {
     "settings.notifications.update": [],
     "settings.ai-key.edit": [],
     "settings.ai-key.update": [],
+    "settings.smtp.edit": [],
+    "settings.smtp.update": [],
     "register": [],
     "login": [],
     "password.request": [],

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\Settings\NotificationSettingsController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
 use App\Http\Controllers\Settings\SendModeSettingsController;
+use App\Http\Controllers\Settings\SmtpSettingsController;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -36,4 +37,9 @@ Route::middleware('auth')->group(function () {
         ->name('settings.ai-key.edit');
     Route::patch('settings/ai-key', [AiKeySettingsController::class, 'update'])
         ->name('settings.ai-key.update');
+
+    Route::get('settings/smtp', [SmtpSettingsController::class, 'edit'])
+        ->name('settings.smtp.edit');
+    Route::patch('settings/smtp', [SmtpSettingsController::class, 'update'])
+        ->name('settings.smtp.update');
 });

--- a/tests/Feature/Settings/SmtpSettingsTest.php
+++ b/tests/Feature/Settings/SmtpSettingsTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+final class SmtpSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function validPayload(array $overrides = []): array
+    {
+        return [
+            'smtp_host' => 'smtp.bella.test',
+            'smtp_port' => 587,
+            'smtp_username' => 'mailer@bella.test',
+            'smtp_password' => 'smtp-pass-9999',
+            'smtp_from_address' => 'hallo@bella.test',
+            'smtp_from_name' => 'Bella',
+            ...$overrides,
+        ];
+    }
+
+    public function test_owner_can_save_smtp_config_and_password_is_masked_on_read(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->patch(route('settings.smtp.update'), $this->validPayload())->assertRedirect();
+
+        $restaurant->refresh();
+        $this->assertSame('smtp.bella.test', $restaurant->smtp_host);
+        $this->assertSame('smtp-pass-9999', $restaurant->smtp_password);
+        $this->assertSame('hallo@bella.test', $restaurant->smtp_from_address);
+
+        $this->actingAs($owner)->get(route('settings.smtp.edit'))
+            ->assertInertia(fn (AssertableInertia $p) => $p
+                ->component('settings/Smtp')
+                ->where('smtp.host', 'smtp.bella.test')
+                ->where('smtp.password_masked', '••••9999')
+                ->missing('smtp.password'));
+    }
+
+    public function test_empty_password_keeps_the_existing_one(): void
+    {
+        $restaurant = Restaurant::factory()->create(['smtp_host' => 'h', 'smtp_password' => 'keep-1234']);
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)
+            ->patch(route('settings.smtp.update'), $this->validPayload(['smtp_host' => 'h2', 'smtp_password' => '']))
+            ->assertRedirect();
+
+        $restaurant->refresh();
+        $this->assertSame('h2', $restaurant->smtp_host);
+        $this->assertSame('keep-1234', $restaurant->smtp_password);
+    }
+
+    public function test_validation_rejects_a_bad_from_address(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)
+            ->from(route('settings.smtp.edit'))
+            ->patch(route('settings.smtp.update'), $this->validPayload(['smtp_from_address' => 'not-an-email']))
+            ->assertSessionHasErrors('smtp_from_address');
+    }
+
+    public function test_staff_cannot_access(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($staff)->get(route('settings.smtp.edit'))->assertForbidden();
+        $this->actingAs($staff)->patch(route('settings.smtp.update'), $this->validPayload())->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
Owner-only `settings/smtp` page (`SmtpSettingsController` + `SmtpSettingsRequest` + `Smtp.vue`, gated by `manageIntegrations`). Edits host/port/username/password/from-address/from-name; the password is masked on read (never returned) and an empty submission keeps the stored password. Ziggy types regenerated.

## Test plan
- `SmtpSettingsTest`: save + masked read; empty password keeps existing; bad from-address rejected; staff forbidden (GET + PATCH).
- Full suite green; pint/build/lint/format clean.

Closes #436.