### PR TITLE
PRD-016 Phase 1b #437: IMAP receive settings page

### DIFF
--- a/app/Http/Controllers/Settings/ImapSettingsController.php
+++ b/app/Http/Controllers/Settings/ImapSettingsController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Settings\ImapSettingsRequest;
+use App\Models\Restaurant;
+use App\Models\User;
+use App\Support\SecretMask;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Owner-only per-restaurant IMAP receive config (PRD-016 Phase 1b). The
+ * columns already exist; this surfaces them in the UI. The password is never
+ * returned to the browser — only a masked tail.
+ */
+final class ImapSettingsController extends Controller
+{
+    public function edit(): Response
+    {
+        $restaurant = $this->ownedRestaurant();
+
+        return Inertia::render('settings/Imap', [
+            'imap' => [
+                'host' => $restaurant->imap_host,
+                'username' => $restaurant->imap_username,
+                'password_masked' => SecretMask::tail4($restaurant->imap_password),
+            ],
+        ]);
+    }
+
+    public function update(ImapSettingsRequest $request): RedirectResponse
+    {
+        $restaurant = $this->ownedRestaurant();
+        $validated = $request->validated();
+
+        $payload = collect($validated)->except('imap_password')->all();
+
+        // Empty password leaves the stored one untouched.
+        if (($validated['imap_password'] ?? '') !== '') {
+            $payload['imap_password'] = $validated['imap_password'];
+        }
+
+        $restaurant->update($payload);
+
+        return back()->with('success', 'IMAP-Einstellungen gespeichert.');
+    }
+
+    private function ownedRestaurant(): Restaurant
+    {
+        /** @var User $user */
+        $user = Auth::user();
+        $restaurant = $user->restaurant;
+
+        if ($restaurant === null) {
+            abort(403);
+        }
+
+        Gate::authorize('manageIntegrations', $restaurant);
+
+        return $restaurant;
+    }
+}

--- a/app/Http/Requests/Settings/ImapSettingsRequest.php
+++ b/app/Http/Requests/Settings/ImapSettingsRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Settings;
+
+use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validates the per-restaurant IMAP receive config. An empty password means
+ * "leave the stored password unchanged".
+ */
+class ImapSettingsRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return $this->user() !== null;
+    }
+
+    /**
+     * @return array<string, array<int, ValidationRule|string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'imap_host' => ['required', 'string', 'max:255'],
+            'imap_username' => ['required', 'string', 'max:255'],
+            'imap_password' => ['nullable', 'string', 'max:255'],
+        ];
+    }
+}

--- a/resources/js/pages/settings/Imap.vue
+++ b/resources/js/pages/settings/Imap.vue
@@ -1,0 +1,75 @@
+<script setup lang="ts">
+import { Head, useForm } from '@inertiajs/vue3';
+
+import HeadingSmall from '@/components/HeadingSmall.vue';
+import InputError from '@/components/InputError.vue';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import AppLayout from '@/layouts/AppLayout.vue';
+import SettingsLayout from '@/layouts/settings/Layout.vue';
+import { type BreadcrumbItem } from '@/types';
+
+interface Props {
+    imap: {
+        host: string | null;
+        username: string | null;
+        password_masked: string | null;
+    };
+}
+
+const props = defineProps<Props>();
+
+const breadcrumbs: BreadcrumbItem[] = [{ title: 'IMAP-Empfang', href: '/settings/imap' }];
+
+const form = useForm({
+    imap_host: props.imap.host ?? '',
+    imap_username: props.imap.username ?? '',
+    imap_password: '',
+});
+
+const submit = () => {
+    form.patch(route('settings.imap.update'), {
+        preserveScroll: true,
+        onSuccess: () => form.reset('imap_password'),
+    });
+};
+</script>
+
+<template>
+    <AppLayout :breadcrumbs="breadcrumbs">
+        <Head title="IMAP-Empfang" />
+
+        <SettingsLayout>
+            <div class="flex flex-col space-y-6">
+                <HeadingSmall title="IMAP-Empfang" description="Eigenes IMAP-Postfach, aus dem Reservierungsanfragen abgeholt werden." />
+
+                <form class="space-y-6" @submit.prevent="submit">
+                    <div class="grid gap-2">
+                        <Label for="imap_host">Host</Label>
+                        <Input id="imap_host" v-model="form.imap_host" required />
+                        <InputError :message="form.errors.imap_host" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="imap_username">Benutzername</Label>
+                        <Input id="imap_username" v-model="form.imap_username" required autocomplete="off" />
+                        <InputError :message="form.errors.imap_username" />
+                    </div>
+                    <div class="grid gap-2">
+                        <Label for="imap_password">Passwort</Label>
+                        <Input
+                            id="imap_password"
+                            v-model="form.imap_password"
+                            type="password"
+                            autocomplete="off"
+                            :placeholder="imap.password_masked ? `Hinterlegt (${imap.password_masked}) — leer lassen, um zu behalten` : 'Passwort'"
+                        />
+                        <InputError :message="form.errors.imap_password" />
+                    </div>
+
+                    <Button type="submit" :disabled="form.processing">Speichern</Button>
+                </form>
+            </div>
+        </SettingsLayout>
+    </AppLayout>
+</template>

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -140,6 +140,8 @@ declare module 'ziggy-js' {
     "settings.ai-key.update": [],
     "settings.smtp.edit": [],
     "settings.smtp.update": [],
+    "settings.imap.edit": [],
+    "settings.imap.update": [],
     "register": [],
     "login": [],
     "password.request": [],

--- a/routes/settings.php
+++ b/routes/settings.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Settings\AiKeySettingsController;
+use App\Http\Controllers\Settings\ImapSettingsController;
 use App\Http\Controllers\Settings\NotificationSettingsController;
 use App\Http\Controllers\Settings\PasswordController;
 use App\Http\Controllers\Settings\ProfileController;
@@ -42,4 +43,9 @@ Route::middleware('auth')->group(function () {
         ->name('settings.smtp.edit');
     Route::patch('settings/smtp', [SmtpSettingsController::class, 'update'])
         ->name('settings.smtp.update');
+
+    Route::get('settings/imap', [ImapSettingsController::class, 'edit'])
+        ->name('settings.imap.edit');
+    Route::patch('settings/imap', [ImapSettingsController::class, 'update'])
+        ->name('settings.imap.update');
 });

--- a/tests/Feature/Settings/ImapSettingsTest.php
+++ b/tests/Feature/Settings/ImapSettingsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Settings;
+
+use App\Models\Restaurant;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Inertia\Testing\AssertableInertia;
+use Tests\TestCase;
+
+final class ImapSettingsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_owner_can_configure_imap_and_password_is_masked(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->patch(route('settings.imap.update'), [
+            'imap_host' => 'imap.bella.test',
+            'imap_username' => 'inbox@bella.test',
+            'imap_password' => 'imap-pass-4321',
+        ])->assertRedirect();
+
+        $restaurant->refresh();
+        $this->assertSame('imap.bella.test', $restaurant->imap_host);
+        $this->assertSame('imap-pass-4321', $restaurant->imap_password);
+
+        $this->actingAs($owner)->get(route('settings.imap.edit'))
+            ->assertInertia(fn (AssertableInertia $p) => $p
+                ->component('settings/Imap')
+                ->where('imap.host', 'imap.bella.test')
+                ->where('imap.password_masked', '••••4321')
+                ->missing('imap.password'));
+    }
+
+    public function test_empty_password_keeps_the_existing_one(): void
+    {
+        $restaurant = Restaurant::factory()->create(['imap_host' => 'h', 'imap_password' => 'keep-7777']);
+        $owner = User::factory()->owner()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($owner)->patch(route('settings.imap.update'), [
+            'imap_host' => 'h2', 'imap_username' => 'u', 'imap_password' => '',
+        ])->assertRedirect();
+
+        $restaurant->refresh();
+        $this->assertSame('h2', $restaurant->imap_host);
+        $this->assertSame('keep-7777', $restaurant->imap_password);
+    }
+
+    public function test_staff_cannot_access(): void
+    {
+        $restaurant = Restaurant::factory()->create();
+        $staff = User::factory()->forRestaurant($restaurant)->create();
+
+        $this->actingAs($staff)->get(route('settings.imap.edit'))->assertForbidden();
+        $this->actingAs($staff)->patch(route('settings.imap.update'), [
+            'imap_host' => 'h', 'imap_username' => 'u', 'imap_password' => 'p',
+        ])->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
Owner-only `settings/imap` page (`ImapSettingsController` + `ImapSettingsRequest` + `Imap.vue`, gated by `manageIntegrations`) to configure the already-existing `imap_*` columns from the UI (previously seeder/tinker only). Password masked on read; empty submission keeps the stored password. `FetchReservationEmailsJob`/`WebklexImapMailboxFactory` unchanged. Ziggy types regenerated.

## Test plan
- `ImapSettingsTest`: configure + masked read; empty password keeps existing; staff forbidden (GET + PATCH).
- Full suite 1086 passed; pint/build/lint/format clean.

Closes #437.