### PR TITLE
PRD-016 Phase 2 #451: shared StatusBadge component

### DIFF
--- a/resources/js/components/StatusBadge.test.ts
+++ b/resources/js/components/StatusBadge.test.ts
@@ -1,0 +1,19 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import StatusBadge from './StatusBadge.vue';
+
+describe('StatusBadge', () => {
+    it('renders the token class and German label for a status', () => {
+        const wrapper = mount(StatusBadge, { props: { status: 'confirmed' } });
+
+        expect(wrapper.text()).toBe('Bestätigt');
+        expect(wrapper.classes().join(' ')).toContain('text-status-confirmed');
+    });
+
+    it('renders cancelled (the 7th status) too', () => {
+        const wrapper = mount(StatusBadge, { props: { status: 'cancelled' } });
+
+        expect(wrapper.text()).toBe('Storniert');
+        expect(wrapper.classes().join(' ')).toContain('status-cancelled');
+    });
+});

--- a/resources/js/components/StatusBadge.vue
+++ b/resources/js/components/StatusBadge.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { statusBadgeClass, statusLabel, type ReservationStatus } from '@/lib/reservationStatus';
+
+const props = defineProps<{ status: ReservationStatus }>();
+</script>
+
+<template>
+    <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium" :class="statusBadgeClass(props.status)">
+        {{ statusLabel(props.status) }}
+    </span>
+</template>


### PR DESCRIPTION
## Summary
Reusable `StatusBadge.vue` consuming `reservationStatus.ts` (token class + German label) — a status pill for the dashboard (#452) and public pages (#455).

## Test plan
- `StatusBadge.test.ts` (Vitest, local — CI does not run Vitest): renders token class + label for confirmed + cancelled.
- lint/format/build clean.

Closes #451.