### PR TITLE
PRD-016 Phase 2 #453: dashboard onboarding-reminder cards

### DIFF
--- a/resources/js/components/OnboardingReminders.test.ts
+++ b/resources/js/components/OnboardingReminders.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import OnboardingReminders from './OnboardingReminders.vue';
+
+// Ziggy's route() is a template global property; provide it via mocks so the
+// `:href="route(...)"` binding resolves (Link is stubbed to a plain anchor).
+const mountOptions = {
+    global: {
+        mocks: { route: () => '/onboarding' },
+        stubs: { Link: { template: '<a><slot /></a>' } },
+    },
+};
+
+describe('OnboardingReminders', () => {
+    it('renders a card per pending optional step', () => {
+        const wrapper = mount(OnboardingReminders, { props: { reminders: ['team', 'tonality'] }, ...mountOptions });
+
+        expect(wrapper.findAll('[data-testid="onboarding-reminder"]')).toHaveLength(2);
+        expect(wrapper.text()).toContain('Team einladen');
+    });
+
+    it('renders nothing when there are no reminders', () => {
+        const wrapper = mount(OnboardingReminders, { props: { reminders: [] }, ...mountOptions });
+
+        expect(wrapper.findAll('[data-testid="onboarding-reminder"]')).toHaveLength(0);
+    });
+});

--- a/resources/js/components/OnboardingReminders.vue
+++ b/resources/js/components/OnboardingReminders.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { Link } from '@inertiajs/vue3';
+
+type OptionalStep = 'tonality' | 'team';
+
+defineProps<{ reminders: OptionalStep[] }>();
+
+const COPY: Record<OptionalStep, { title: string; body: string }> = {
+    tonality: { title: 'Tonalität festlegen', body: 'Bestimmen Sie, wie die KI-Antworten klingen.' },
+    team: { title: 'Team einladen', body: 'Laden Sie Mitarbeitende zu Ihrem Restaurant ein.' },
+};
+</script>
+
+<template>
+    <div v-if="reminders.length > 0" class="grid gap-3 sm:grid-cols-2">
+        <Link
+            v-for="step in reminders"
+            :key="step"
+            data-testid="onboarding-reminder"
+            :href="route('onboarding.wizard')"
+            class="rounded-lg border border-border bg-card p-4 text-sm transition hover:border-primary"
+        >
+            <p class="font-medium">{{ COPY[step].title }}</p>
+            <p class="text-muted-foreground">{{ COPY[step].body }}</p>
+        </Link>
+    </div>
+</template>

--- a/resources/js/pages/Dashboard.vue
+++ b/resources/js/pages/Dashboard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import DashboardExportDropdown from '@/components/DashboardExportDropdown.vue';
 import InputError from '@/components/InputError.vue';
+import OnboardingReminders from '@/components/OnboardingReminders.vue';
 import ReservationThreadHistory from '@/components/ReservationThreadHistory.vue';
 import StatusBadge from '@/components/StatusBadge.vue';
 import WaitlistBanner from '@/components/WaitlistBanner.vue';
@@ -47,6 +48,7 @@ interface DashboardProps {
     waitlistBanner: ReservationRequestRow[];
     openaiKeyRejectedAt?: string | null;
     sendMode?: 'manual' | 'shadow' | 'auto' | null;
+    onboardingReminders?: ('tonality' | 'team')[];
 }
 
 const props = defineProps<DashboardProps>();
@@ -582,6 +584,8 @@ useReservationDiffTrigger(dashboardRowIds, dashboardFilters, notifications);
                     </div>
                 </div>
             </header>
+
+            <OnboardingReminders :reminders="props.onboardingReminders ?? []" />
 
             <WaitlistBanner :banner="props.waitlistBanner" :timezone="restaurantTimezone" @open="openReservation" />
 


### PR DESCRIPTION
## Summary
`OnboardingReminders.vue` renders a card per pending optional onboarding step (tonality/team), linking to the wizard. The Dashboard declares the `onboardingReminders` prop (already supplied by `DashboardController` since #405) and renders the component above the waitlist banner. Cards disappear once the step is addressed (prop empties).

## Test plan
- Vitest (local): renders N cards for N reminders, nothing for empty; route() provided via `global.mocks`, Link stubbed.
- Full vitest 121, lint/format/build clean; `DashboardOnboardingRemindersTest` (backend) still green.
- Visual: a live restaurant without staff shows the "Team einladen" card (screenshot review).

Closes #453.