### PR TITLE
PRD-016 Phase 2 #454: dark app-shell topbar

### DIFF
--- a/resources/js/components/AppSidebarHeader.test.ts
+++ b/resources/js/components/AppSidebarHeader.test.ts
@@ -1,0 +1,23 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AppSidebarHeader from './AppSidebarHeader.vue';
+
+const stubs = {
+    SidebarTrigger: true,
+    Breadcrumb: true,
+    BreadcrumbItem: true,
+    BreadcrumbLink: true,
+    BreadcrumbList: true,
+    BreadcrumbPage: true,
+    BreadcrumbSeparator: true,
+};
+
+describe('AppSidebarHeader', () => {
+    it('uses the dark direction-C topbar tokens', () => {
+        const wrapper = mount(AppSidebarHeader, { props: { breadcrumbs: [] }, global: { stubs } });
+
+        const header = wrapper.find('header');
+        expect(header.classes()).toContain('bg-topbar');
+        expect(header.classes()).toContain('text-topbar-foreground');
+    });
+});

--- a/resources/js/components/AppSidebarHeader.vue
+++ b/resources/js/components/AppSidebarHeader.vue
@@ -10,7 +10,7 @@ defineProps<{
 
 <template>
     <header
-        class="flex h-16 shrink-0 items-center gap-2 border-b border-sidebar-border/70 px-6 transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 md:px-4"
+        class="flex h-16 shrink-0 items-center gap-2 border-b border-topbar/40 bg-topbar px-6 text-topbar-foreground transition-[width,height] ease-linear group-has-[[data-collapsible=icon]]/sidebar-wrapper:h-12 md:px-4"
     >
         <div class="flex items-center gap-2">
             <SidebarTrigger class="-ml-1" />


### PR DESCRIPTION
## Summary
`AppSidebarHeader` gets the direction-C dark topbar (`bg-topbar` / `text-topbar-foreground` + topbar border) for the authenticated dashboard chrome, matching OnboardingLayout/PublicLayout intent.

## Test plan
- `AppSidebarHeader.test.ts` (Vitest, local): header carries bg-topbar + text-topbar-foreground.
- Full vitest 122; lint/format/build clean.
- **Visual review (you):** dark header bar, breadcrumb + sidebar-trigger contrast on dark.

Closes #454.