### PR TITLE
fix: visible save feedback on onboarding tonality + team steps

### DIFF
--- a/resources/js/pages/Onboarding/steps/StepTeam.vue
+++ b/resources/js/pages/Onboarding/steps/StepTeam.vue
@@ -3,6 +3,7 @@ import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { TransitionRoot } from '@headlessui/vue';
 import { Link, useForm } from '@inertiajs/vue3';
 
 const emit = defineEmits<{ saved: [] }>();
@@ -30,6 +31,15 @@ const submit = () =>
         <div class="flex items-center gap-4">
             <Button type="submit" :disabled="form.processing">Einladen</Button>
             <Link :href="route('onboarding.wizard')" class="text-sm text-muted-foreground underline">Überspringen</Link>
+            <TransitionRoot
+                :show="form.recentlySuccessful"
+                enter="transition ease-in-out"
+                enter-from="opacity-0"
+                leave="transition ease-in-out"
+                leave-to="opacity-0"
+            >
+                <p class="text-sm text-muted-foreground">Einladung verschickt.</p>
+            </TransitionRoot>
         </div>
     </form>
 </template>

--- a/resources/js/pages/Onboarding/steps/StepTonality.vue
+++ b/resources/js/pages/Onboarding/steps/StepTonality.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
+import InputError from '@/components/InputError.vue';
 import { Button } from '@/components/ui/button';
+import { TransitionRoot } from '@headlessui/vue';
 import { Head, Link, useForm } from '@inertiajs/vue3';
 
 const props = defineProps<{ tonality: string; tonalities: string[] }>();
@@ -28,9 +30,19 @@ const submit = () =>
             <input v-model="form.tonality" type="radio" :value="option" :data-testid="`tonality-${option}`" />
             <span>{{ LABEL[option] ?? option }}</span>
         </label>
+        <InputError :message="form.errors.tonality" />
         <div class="flex items-center gap-4">
             <Button type="submit" :disabled="form.processing">Speichern</Button>
             <Link :href="route('onboarding.wizard')" class="text-sm text-muted-foreground underline">Überspringen</Link>
+            <TransitionRoot
+                :show="form.recentlySuccessful"
+                enter="transition ease-in-out"
+                enter-from="opacity-0"
+                leave="transition ease-in-out"
+                leave-to="opacity-0"
+            >
+                <p class="text-sm text-muted-foreground">Gespeichert.</p>
+            </TransitionRoot>
         </div>
     </form>
 </template>


### PR DESCRIPTION
## Summary
The wizard's optional steps (Tonalität, Team) had no UI feedback after a successful save — unlike the required steps where data visibly appears. Effect: clicking Speichern on Tonalität looks like a no-op to the user (reported during Phase 2 visual testing).

Adds the established `form.recentlySuccessful` + `TransitionRoot` indicator from `settings/Profile.vue` and an `InputError` for the form-level validation message, so:
- successful save → "Gespeichert." / "Einladung verschickt." appears briefly.
- 422 validation error → message surfaces inline.
- 5xx / network error → still console-only (could add an onError toast later if needed).

No backend change; no test logic change (the existing wizard feature tests assert the redirect/state, which is unaffected). No tracked issue — surfaced organically during visual review.

## Test plan
- Vitest 122 + lint/format/build clean; `OnboardingWizardStoreTest` (backend) still asserts tonality + team store paths.
- Visual re-test: pick a tonality → Speichern → "Gespeichert." appears briefly.
