### PR TITLE
fix: onboarding wizard auto-advances to next step after save

### DIFF
--- a/resources/js/pages/Onboarding/Wizard.vue
+++ b/resources/js/pages/Onboarding/Wizard.vue
@@ -37,8 +37,24 @@ const active = ref<OnboardingStep>(props.progress.nextCoreStep ?? 'tonality');
 
 const goTo = (step: OnboardingStep) => (active.value = step);
 
-// Re-fetch derived progress + restaurant/tables after each step save.
-const onSaved = () => router.reload({ only: ['progress', 'restaurant', 'tables'] });
+// Steps where saving is a single "done with this step" action: auto-advance to
+// the next step in ORDER. Tische / Team stay because the user may add several
+// (a new table, more invitees) and would not want each save to navigate away.
+const STAYS_ON_SAVE: Set<OnboardingStep> = new Set(['tables', 'team']);
+
+// Re-fetch derived progress + restaurant/tables after each step save, and
+// advance to the next step where it makes sense.
+const onSaved = () => {
+    router.reload({ only: ['progress', 'restaurant', 'tables'] });
+
+    if (!STAYS_ON_SAVE.has(active.value)) {
+        const index = ORDER.findIndex((step) => step.key === active.value);
+        const next = ORDER[index + 1]?.key;
+        if (next) {
+            active.value = next;
+        }
+    }
+};
 </script>
 
 <template>


### PR DESCRIPTION
## Summary
The wizard's `onSaved` re-fetched progress but stayed on the same step — so saving Tonalität showed "Gespeichert." but didn't progress to Team, against wizard expectation. Now `onSaved` advances `active` to the next step in `ORDER` after a save.

Exceptions: **Tische** and **Team** stay (`STAYS_ON_SAVE`) because the user typically adds multiple tables / invites multiple people and shouldn't be navigated away each time.

Order/effect:
- Stammdaten → save → Öffnungszeiten
- Öffnungszeiten → save → Tische
- Tische → add a table → **stays** (add more) — user moves on via the rail when done
- Tonalität → save → **Team** ← the missing transition the user reported
- Team → invite → **stays** (invite more)

The step rail keeps full manual control; this is convenience, not a forced flow.

## Test plan
- Vitest 122 + lint/format/build clean; backend `OnboardingWizardStoreTest` unchanged (assertions are about state + redirect, not the JS step pointer).
- Visual re-test: in the wizard, save Tonalität → the page should switch to Team automatically.
