### PR TITLE
fix: onboarding wizard exit link to dashboard

### DIFF
--- a/resources/js/pages/Onboarding/Wizard.vue
+++ b/resources/js/pages/Onboarding/Wizard.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import OnboardingLayout from '@/layouts/OnboardingLayout.vue';
 import type { OnboardingProgress, OnboardingStep } from '@/types';
-import { Head, router } from '@inertiajs/vue3';
+import { Head, Link, router } from '@inertiajs/vue3';
 import { ref } from 'vue';
 import StepOpeningHours from './steps/StepOpeningHours.vue';
 import StepRestaurantInfo from './steps/StepRestaurantInfo.vue';
@@ -74,9 +74,13 @@ const onSaved = () => {
             </button>
         </nav>
 
-        <p v-if="progress.coreComplete" class="mb-4 text-sm font-medium text-status-confirmed">
-            Pflichtangaben vollständig — Ihr Restaurant ist live.
-        </p>
+        <div
+            v-if="progress.coreComplete"
+            class="mb-4 flex flex-wrap items-center justify-between gap-3 rounded-md border border-status-confirmed/40 bg-status-confirmed/10 px-3 py-2"
+        >
+            <p class="text-sm font-medium text-status-confirmed">Pflichtangaben vollständig — Ihr Restaurant ist live.</p>
+            <Link :href="route('dashboard')" class="text-sm font-medium underline">Zum Dashboard →</Link>
+        </div>
 
         <StepRestaurantInfo v-if="active === 'restaurant'" :restaurant="restaurant" @saved="onSaved" />
         <StepOpeningHours v-else-if="active === 'hours'" :opening-hours="restaurant.opening_hours" @saved="onSaved" />


### PR DESCRIPTION
## Summary
The wizard had no visible exit. Once the Pflicht-Kern was complete (restaurant "live"), the banner just said so — no link to leave for the dashboard. With auto-advance now landing the owner on Team (no next step) and an inviter "Überspringen" that loops back to the wizard, the user was effectively stuck.

The live banner now carries a "Zum Dashboard →" link, visible exactly when the restaurant is live (so the gate won't bounce them back). Style: a soft status-confirmed band so it actually reads as an actionable affordance rather than a passive note.

Edge case kept intentional: before the core is complete the banner doesn't show — there's no exit because the gate would just redirect the owner back to the wizard. That's the desired UX.

## Test plan
- Vitest 122 + lint/format/build clean; no backend change.
- Visual: finish the core (e.g. add a table), confirm the green "live" banner now shows "Zum Dashboard →" on the right; clicking goes to /dashboard.
