### PR TITLE
fix: AppLogo reads brand from config('app.name')

### DIFF
--- a/resources/js/components/AppLogo.vue
+++ b/resources/js/components/AppLogo.vue
@@ -1,11 +1,19 @@
 <script setup lang="ts">
 import AppLogoIcon from '@/components/AppLogoIcon.vue';
+import type { SharedData } from '@/types';
+import { usePage } from '@inertiajs/vue3';
+import { computed } from 'vue';
 
 interface Props {
     class?: string;
 }
 
 defineProps<Props>();
+
+// Pulled from config('app.name') via Inertia shared props (HandleInertiaRequests).
+// Rebrand by setting APP_NAME in .env — no need to touch this file.
+const page = usePage<SharedData>();
+const appName = computed(() => page.props.name);
 </script>
 
 <template>
@@ -13,6 +21,6 @@ defineProps<Props>();
         <AppLogoIcon class="size-5 fill-current text-white dark:text-black" />
     </div>
     <div class="ml-1 grid flex-1 text-left text-sm">
-        <span class="mb-0.5 truncate font-semibold leading-none">Laravel Starter Kit</span>
+        <span class="mb-0.5 truncate font-semibold leading-none">{{ appName }}</span>
     </div>
 </template>


### PR DESCRIPTION
## Summary
`AppLogo.vue` hardcoded "Laravel Starter Kit" (Breeze default) — visible in the authenticated sidebar. Replace with `config('app.name')` pulled from the existing Inertia-shared `name` prop (already provided by `HandleInertiaRequests::share()`). The brand now lives in `APP_NAME` (currently `reservation-agent`); rebrand later via `.env`, no Vue change needed.

## Test plan
- Vitest 122 + lint/format/build clean.
- Visual: sidebar shows the configured app name instead of "Laravel Starter Kit".

> Note: if the visible "reservation-agent" reads too technical, set `APP_NAME="Your Brand"` in `.env` — it propagates here, to mail From-name and to other shared-name surfaces.
